### PR TITLE
docs: add PatternFly 6 dark-themed GitHub Pages site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,9 +23,9 @@ jobs:
     name: Build docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
@@ -35,7 +35,7 @@ jobs:
       - name: Build docs
         run: python3 scripts/ogo-docs.py
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: public/
 
@@ -47,5 +47,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
         id: deployment

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: pip install markdown tomli pygments
+        run: pip install markdown==3.7 tomli==2.2.1 pygments==2.19.1
 
       - name: Build docs
         run: python3 scripts/ogo-docs.py

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,51 @@
+name: Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'scripts/ogo-docs.py'
+      - 'docs.toml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install markdown tomli pygments
+
+      - name: Build docs
+        run: python3 scripts/ogo-docs.py
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: public/
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ index.Dockerfile*
 *.key
 kubeconfig
 .claude/
+public/

--- a/Makefile
+++ b/Makefile
@@ -348,3 +348,15 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) image-push IMG=$(CATALOG_IMG)
+
+.PHONY: docs
+docs: ## Build the docs site into public/
+	python3 scripts/ogo-docs.py
+
+.PHONY: docs-serve
+docs-serve: ## Build and serve the docs site locally on port 8000
+	python3 scripts/ogo-docs.py serve
+
+.PHONY: docs-lint
+docs-lint: ## Lint docs frontmatter, nav, and links
+	python3 scripts/ogo-docs.py lint

--- a/docs.toml
+++ b/docs.toml
@@ -1,0 +1,49 @@
+[project]
+site_name = "OGO"
+site_url = "https://aknochow.github.io/ogo/"
+docs_dir = "docs"
+site_dir = "public"
+
+[project.theme]
+name = "patternfly-6-dark"
+
+# Navigation
+[[project.nav]]
+"Overview" = [
+  { "Introduction" = "index.md" },
+]
+
+[[project.nav]]
+"Concepts" = [
+  { "Overview" = "concepts/index.md" },
+  { "Why OpenShift" = "concepts/why-openshift.md" },
+  { "Gateway" = "concepts/gateway.md" },
+  { "Sandbox" = "concepts/sandbox.md" },
+  { "Authentication" = "concepts/authentication.md" },
+  { "Provider" = "concepts/provider.md" },
+  { "Policy" = "concepts/policy.md" },
+]
+
+[[project.nav]]
+"Guides" = [
+  { "Overview" = "guides/index.md" },
+  { "Quickstart" = "guides/quickstart.md" },
+  { "Envoy Gateway" = "guides/envoy-gateway.md" },
+  { "OpenShift SSO" = "guides/openshift-sso.md" },
+]
+
+[[project.nav]]
+"Reference" = [
+  { "Overview" = "reference/index.md" },
+  { "OpenShellGateway" = "reference/openshellgateway.md" },
+  { "OpenShellProvider" = "reference/openshellprovider.md" },
+  { "OpenShellPolicy" = "reference/openshellpolicy.md" },
+]
+
+[[project.nav]]
+"Examples" = [
+  { "Overview" = "examples/index.md" },
+  { "Claude Code + Anthropic" = "examples/claude-code.md" },
+  { "Claude Code + Vertex AI" = "examples/vertex-ai.md" },
+  { "Developer Policy" = "examples/developer-policy.md" },
+]

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="18" fill="#0f1524"/>
+  <!-- Gateway arch -->
+  <path d="M16 80 L16 44 A34 34 0 0 1 84 44 L84 80"
+        fill="none" stroke="#00b9e4" stroke-width="10"
+        stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Left pillar base -->
+  <rect x="10" y="76" width="14" height="10" rx="3" fill="#00b9e4"/>
+  <!-- Right pillar base -->
+  <rect x="76" y="76" width="14" height="10" rx="3" fill="#00b9e4"/>
+</svg>

--- a/docs/stylesheets/patternfly-base.css
+++ b/docs/stylesheets/patternfly-base.css
@@ -1,0 +1,9408 @@
+:where(html,
+body,
+p,
+ol,
+ul,
+li,
+dl,
+dt,
+dd,
+blockquote,
+figure,
+fieldset,
+legend,
+textarea,
+pre,
+iframe,
+hr,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6) {
+  padding: 0;
+  margin: 0;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  scrollbar-color: var(--pf-t--global--border--color--default) transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: var(--pf-t--global--border--color--default);
+  border-radius: var(--pf-t--global--spacer--xs);
+}
+
+*::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+
+*::-webkit-scrollbar {
+  max-width: var(--pf-t--global--spacer--sm);
+  max-height: var(--pf-t--global--spacer--sm);
+}
+
+:where(html) {
+  background-image: var(--pf-t--global--background--image--default);
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-position: center;
+  background-size: cover;
+}
+
+:where(html,
+body) {
+  height: 100%;
+}
+
+:where(body) {
+  font-family: var(--pf-t--global--font--family--body);
+  font-size: var(--pf-t--global--font--size--body--default);
+  font-weight: var(--pf-t--global--font--weight--body--default);
+  line-height: var(--pf-t--global--font--line-height--body);
+  color: var(--pf-t--global--text--color--regular);
+}
+
+:where(h1,
+h2,
+h3,
+h4,
+h5,
+h6) {
+  font-size: 100%;
+  font-weight: var(--pf-t--global--font--weight--body--default);
+}
+
+:where(ul) {
+  list-style: none;
+}
+
+:where(button,
+input,
+optgroup,
+select,
+textarea) {
+  margin: 0;
+  font-family: inherit;
+  font-size: 100%;
+  line-height: var(--pf-t--global--font--line-height--body);
+  color: var(--pf-t--global--text--color--regular);
+}
+
+:where(img,
+embed,
+iframe,
+object,
+audio,
+video) {
+  max-width: 100%;
+  height: auto;
+}
+
+:where(iframe) {
+  border: 0;
+}
+
+:where(table) {
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+:where(td,
+th) {
+  padding: 0;
+  text-align: start;
+}
+
+:where(code,
+pre) {
+  font-family: var(--pf-t--global--font--family--mono);
+}
+
+:where(a) {
+  color: var(--pf-t--global--text--color--link--default);
+  text-decoration-line: var(--pf-t--global--text-decoration--link--line--default);
+  text-decoration-style: var(--pf-t--global--text-decoration--link--style--default);
+  text-decoration-color: var(--pf-t--global--text-decoration--color--default);
+  text-underline-offset: max(var(--pf-t--global--text-decoration--offset--default), 0.28em);
+  transition: ease text-underline-offset 0.3s;
+}
+
+:where(a:hover, a:focus) {
+  color: var(--pf-t--global--text--color--link--hover);
+  text-decoration-line: var(--pf-t--global--text-decoration--link--line--hover);
+  text-decoration-style: var(--pf-t--global--text-decoration--link--style--hover);
+  text-decoration-color: var(--pf-t--global--text-decoration--color--hover);
+  text-underline-offset: max(var(--pf-t--global--text-decoration--offset--hover), 0.33em);
+}
+
+:where(a,
+button) {
+  cursor: pointer;
+}
+
+:where(:root) {
+  color-scheme: light;
+}
+
+:where(.pf-v6-theme-dark) {
+  color-scheme: dark;
+}
+
+.pf-v6-screen-reader {
+  position: fixed;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+.pf-v6-screen-reader.pf-m-full-size {
+  width: 100%;
+  height: 100%;
+}
+.pf-v6-screen-reader.pf-m-absolute {
+  position: absolute;
+}
+
+.pf-v6-m-tabular-nums {
+  font-variant-numeric: tabular-nums;
+}
+
+.pf-v6-m-legacy-font {
+  --pf-t--global--font--family--body: var(--pf-t--global--font--family--body--legacy);
+  --pf-t--global--font--family--heading: var(--pf-t--global--font--family--heading--legacy);
+  --pf-t--global--font--family--mono: var(--pf-t--global--font--family--mono--legacy);
+  --pf-t--global--font--weight--body: var(--pf-t--global--font--weight--body--legacy);
+  --pf-t--global--font--weight--body--bold: var(--pf-t--global--font--weight--body--bold--legacy);
+  --pf-t--global--font--weight--heading: var(--pf-t--global--font--weight--heading--legacy);
+  --pf-t--global--font--weight--heading--bold: var(--pf-t--global--font--weight--heading--bold--legacy);
+}
+
+.pf-v6-m-dir-rtl {
+  --pf-v6-global--inverse--multiplier: -1;
+  direction: rtl;
+}
+
+.pf-v6-m-dir-ltr {
+  --pf-v6-global--inverse--multiplier: 1;
+  direction: ltr;
+}
+
+:where(.pf-v6-m-dir-rtl, [dir=rtl]) .pf-v6-m-mirror-inline-rtl {
+  scale: -1 1;
+}
+
+.pf-v6-m-no-motion {
+  --pf-t--global--delay--400: 1ms !important;
+  --pf-t--global--delay--300: 1ms !important;
+  --pf-t--global--delay--200: 1ms !important;
+  --pf-t--global--delay--100: 1ms !important;
+  --pf-t--global--duration--600: 1ms !important;
+  --pf-t--global--duration--500: 1ms !important;
+  --pf-t--global--duration--400: 1ms !important;
+  --pf-t--global--duration--300: 1ms !important;
+  --pf-t--global--duration--200: 1ms !important;
+  --pf-t--global--duration--100: 1ms !important;
+  --pf-t--global--duration--50: 1ms !important;
+  --pf-v6-global--thinking-active--Animation--Duration: 0 !important;
+}
+
+.pf-v6-m-ai-indicator {
+  position: relative;
+}
+.pf-v6-m-ai-indicator::before {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  content: "";
+  background: linear-gradient(to right, #f56e6e 0%, #876fd4 65%, #5e40be 100%) border-box;
+  border: var(--pf-t--global--border--width--extra-strong) solid transparent;
+  border-radius: inherit;
+  mask: linear-gradient(#000 0 0) padding-box, linear-gradient(#000 0 0);
+  mask-composite: exclude;
+}
+
+@property --pf-v6-global--thinking--BoxShadow--Spread {
+  syntax: "<length>";
+  initial-value: 0;
+  inherits: false;
+}
+.pf-v6-m-thinking {
+  box-shadow: 0 0 var(--pf-v6-global--thinking--BoxShadow--Spread) var(--pf-v6-global--thinking--BoxShadow--Color--End-End), 0 0 var(--pf-v6-global--thinking--BoxShadow--Spread) var(--pf-v6-global--thinking--BoxShadow--Color--Start-End), 0 0 var(--pf-v6-global--thinking--BoxShadow--Spread) var(--pf-v6-global--thinking--BoxShadow--Color--End-Start), 0 0 var(--pf-v6-global--thinking--BoxShadow--Spread) var(--pf-v6-global--thinking--BoxShadow--Color--Start-Start);
+  animation: pf-v6-global-thinking var(--pf-v6-global--thinking-active--Animation--Duration) infinite ease-in-out;
+}
+.pf-v6-m-thinking.pf-m-inset {
+  box-shadow: inset 0 0 var(--pf-v6-global--thinking--BoxShadow--Spread) var(--pf-v6-global--thinking--BoxShadow--Color--End-End), inset 0 0 var(--pf-v6-global--thinking--BoxShadow--Spread) var(--pf-v6-global--thinking--BoxShadow--Color--Start-End), inset 0 0 var(--pf-v6-global--thinking--BoxShadow--Spread) var(--pf-v6-global--thinking--BoxShadow--Color--End-Start), inset 0 0 var(--pf-v6-global--thinking--BoxShadow--Spread) var(--pf-v6-global--thinking--BoxShadow--Color--Start-Start);
+}
+
+@keyframes pf-v6-global-thinking {
+  50% {
+    --pf-v6-global--thinking--BoxShadow--Spread: var(--pf-v6-global--thinking-active--BoxShadow--Spread);
+  }
+}
+:root {
+  --pf-v6-global--danger-jiggle--AnimationDuration--Transform: var(--pf-t--global--motion--duration--fade--default);
+  --pf-v6-global--danger-jiggle--AnimationTimingFunction--Transform: var(--pf-t--global--motion--timing-function--default);
+  --pf-v6-global--thinking--BoxShadow--Spread: 0px;
+  --pf-v6-global--thinking--BoxShadow--Color--Start-Start: oklch(45.9% 0.187 3.815deg);
+  --pf-v6-global--thinking--BoxShadow--Color--Start-End: oklch(50% 0.134 242.749deg);
+  --pf-v6-global--thinking--BoxShadow--Color--End-Start: oklch(45.9% 0.187 3.815deg);
+  --pf-v6-global--thinking--BoxShadow--Color--End-End: oklch(43.2% 0.232 292.759deg);
+  --pf-v6-global--thinking-active--BoxShadow--Spread: 15px;
+  --pf-v6-global--thinking-active--Animation--Duration: 0;
+}
+@media screen and (prefers-reduced-motion: no-preference) {
+  :root {
+    --pf-v6-global--thinking-active--Animation--Duration: 2s;
+  }
+}
+:root {
+  container-type: inline-size;
+  container-name: pf-v6-contain-viewport pf-v6-contain-table;
+}
+
+@property --pf-v6-global--danger-jiggle--TranslateX {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0;
+}
+@keyframes pf-v6-global-danger-jiggle-motion {
+  33% {
+    --pf-v6-global--danger-jiggle--TranslateX: -2px;
+  }
+  66% {
+    --pf-v6-global--danger-jiggle--TranslateX: 3px;
+  }
+}
+@keyframes pf-v6-global-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes pf-v6-global-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+@font-face {
+  font-family: "Red Hat Text";
+  font-style: normal;
+  font-weight: 400 500;
+  src: url("./assets/fonts/RedHatText/RedHatTextVF.woff2") format("woff2-variations");
+  font-display: fallback;
+}
+@font-face {
+  font-family: "Red Hat Text";
+  font-style: italic;
+  font-weight: 400 500;
+  src: url("./assets/fonts/RedHatText/RedHatTextVF-Italic.woff2") format("woff2-variations");
+  font-display: fallback;
+}
+@font-face {
+  font-family: "Red Hat Display";
+  font-style: normal;
+  font-weight: 400 700;
+  src: url("./assets/fonts/RedHatDisplay/RedHatDisplayVF.woff2") format("woff2-variations");
+  font-display: fallback;
+}
+@font-face {
+  font-family: "Red Hat Display";
+  font-style: italic;
+  font-weight: 400 700;
+  src: url("./assets/fonts/RedHatDisplay/RedHatDisplayVF-Italic.woff2") format("woff2-variations");
+  font-display: fallback;
+}
+@font-face {
+  font-family: "Red Hat Mono";
+  font-style: normal;
+  font-weight: 400;
+  src: url("./assets/fonts/RedHatMono/RedHatMonoVF.woff2") format("woff2-variations");
+  font-display: fallback;
+}
+@font-face {
+  font-family: "Red Hat Mono";
+  font-style: italic;
+  font-weight: 400;
+  src: url("./assets/fonts/RedHatMono/RedHatMonoVF-Italic.woff2") format("woff2-variations");
+  font-display: fallback;
+}
+.fa-lg {
+  font-size: 1.3333333333em;
+  line-height: 0.75em;
+  vertical-align: -0.0667em;
+}
+
+.fa-xs {
+  font-size: 0.75em;
+}
+
+.fa-sm {
+  font-size: 0.875em;
+}
+
+.fa-1x {
+  font-size: 1em;
+}
+
+.fa-2x {
+  font-size: 2em;
+}
+
+.fa-3x {
+  font-size: 3em;
+}
+
+.fa-4x {
+  font-size: 4em;
+}
+
+.fa-5x {
+  font-size: 5em;
+}
+
+.fa-6x {
+  font-size: 6em;
+}
+
+.fa-7x {
+  font-size: 7em;
+}
+
+.fa-8x {
+  font-size: 8em;
+}
+
+.fa-9x {
+  font-size: 9em;
+}
+
+.fa-10x {
+  font-size: 10em;
+}
+
+.fa-fw {
+  text-align: center;
+  width: 1.25em;
+}
+
+.fa-ul {
+  list-style-type: none;
+  margin-left: 2.5em;
+  padding-left: 0;
+}
+.fa-ul > li {
+  position: relative;
+}
+
+.fa-li {
+  left: -2em;
+  position: absolute;
+  text-align: center;
+  width: 2em;
+  line-height: inherit;
+}
+
+.fa-border {
+  border: solid 0.08em #eee;
+  border-radius: 0.1em;
+  padding: 0.2em 0.25em 0.15em;
+}
+
+.fa-pull-left {
+  float: left;
+}
+
+.fa-pull-right {
+  float: right;
+}
+
+.fa.fa-pull-left,
+.fas.fa-pull-left,
+.far.fa-pull-left,
+.fal.fa-pull-left,
+.fab.fa-pull-left {
+  margin-right: 0.3em;
+}
+.fa.fa-pull-right,
+.fas.fa-pull-right,
+.far.fa-pull-right,
+.fal.fa-pull-right,
+.fab.fa-pull-right {
+  margin-left: 0.3em;
+}
+
+.fa-spin {
+  animation: fa-spin 2s infinite linear;
+}
+
+.fa-pulse {
+  animation: fa-spin 1s infinite steps(8);
+}
+
+@keyframes fa-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+.fa-rotate-90 {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";
+  transform: rotate(90deg);
+}
+
+.fa-rotate-180 {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2)";
+  transform: rotate(180deg);
+}
+
+.fa-rotate-270 {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=3)";
+  transform: rotate(270deg);
+}
+
+.fa-flip-horizontal {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1)";
+  transform: scale(-1, 1);
+}
+
+.fa-flip-vertical {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)";
+  transform: scale(1, -1);
+}
+
+.fa-flip-horizontal.fa-flip-vertical {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)";
+  transform: scale(-1, -1);
+}
+
+:root .fa-rotate-90,
+:root .fa-rotate-180,
+:root .fa-rotate-270,
+:root .fa-flip-horizontal,
+:root .fa-flip-vertical {
+  filter: none;
+}
+
+.fa-stack {
+  display: inline-block;
+  height: 2em;
+  line-height: 2em;
+  position: relative;
+  vertical-align: middle;
+  width: 0.625em;
+}
+
+.fa-stack-1x,
+.fa-stack-2x {
+  left: 0;
+  position: absolute;
+  text-align: center;
+  width: 100%;
+}
+
+.fa-stack-1x {
+  line-height: inherit;
+}
+
+.fa-stack-2x {
+  font-size: 2em;
+}
+
+.fa-inverse {
+  color: #fff;
+}
+
+.sr-only {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.sr-only-focusable:active, .sr-only-focusable:focus {
+  clip: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  position: static;
+  width: auto;
+}
+
+@font-face {
+  font-family: "Font Awesome 5 Free";
+  font-style: normal;
+  font-weight: 900;
+  src: url("./assets/fonts/webfonts/fa-solid-900.woff2") format("woff2");
+}
+.fa,
+.fas {
+  font-family: "Font Awesome 5 Free";
+  font-weight: 900;
+}
+
+.fa-500px:before {
+  content: "\f26e";
+}
+
+.fa-accessible-icon:before {
+  content: "\f368";
+}
+
+.fa-accusoft:before {
+  content: "\f369";
+}
+
+.fa-acquisitions-incorporated:before {
+  content: "\f6af";
+}
+
+.fa-ad:before {
+  content: "\f641";
+}
+
+.fa-address-book:before {
+  content: "\f2b9";
+}
+
+.fa-address-card:before {
+  content: "\f2bb";
+}
+
+.fa-adjust:before {
+  content: "\f042";
+}
+
+.fa-adn:before {
+  content: "\f170";
+}
+
+.fa-adobe:before {
+  content: "\f778";
+}
+
+.fa-adversal:before {
+  content: "\f36a";
+}
+
+.fa-affiliatetheme:before {
+  content: "\f36b";
+}
+
+.fa-air-freshener:before {
+  content: "\f5d0";
+}
+
+.fa-algolia:before {
+  content: "\f36c";
+}
+
+.fa-align-center:before {
+  content: "\f037";
+}
+
+.fa-align-justify:before {
+  content: "\f039";
+}
+
+.fa-align-left:before {
+  content: "\f036";
+}
+
+.fa-align-right:before {
+  content: "\f038";
+}
+
+.fa-alipay:before {
+  content: "\f642";
+}
+
+.fa-allergies:before {
+  content: "\f461";
+}
+
+.fa-amazon:before {
+  content: "\f270";
+}
+
+.fa-amazon-pay:before {
+  content: "\f42c";
+}
+
+.fa-ambulance:before {
+  content: "\f0f9";
+}
+
+.fa-american-sign-language-interpreting:before {
+  content: "\f2a3";
+}
+
+.fa-amilia:before {
+  content: "\f36d";
+}
+
+.fa-anchor:before {
+  content: "\f13d";
+}
+
+.fa-android:before {
+  content: "\f17b";
+}
+
+.fa-angellist:before {
+  content: "\f209";
+}
+
+.fa-angle-double-down:before {
+  content: "\f103";
+}
+
+.fa-angle-double-left:before {
+  content: "\f100";
+}
+
+.fa-angle-double-right:before {
+  content: "\f101";
+}
+
+.fa-angle-double-up:before {
+  content: "\f102";
+}
+
+.fa-angle-down:before {
+  content: "\f107";
+}
+
+.fa-angle-left:before {
+  content: "\f104";
+}
+
+.fa-angle-right:before {
+  content: "\f105";
+}
+
+.fa-angle-up:before {
+  content: "\f106";
+}
+
+.fa-angry:before {
+  content: "\f556";
+}
+
+.fa-angrycreative:before {
+  content: "\f36e";
+}
+
+.fa-angular:before {
+  content: "\f420";
+}
+
+.fa-ankh:before {
+  content: "\f644";
+}
+
+.fa-app-store:before {
+  content: "\f36f";
+}
+
+.fa-app-store-ios:before {
+  content: "\f370";
+}
+
+.fa-apper:before {
+  content: "\f371";
+}
+
+.fa-apple:before {
+  content: "\f179";
+}
+
+.fa-apple-alt:before {
+  content: "\f5d1";
+}
+
+.fa-apple-pay:before {
+  content: "\f415";
+}
+
+.fa-archive:before {
+  content: "\f187";
+}
+
+.fa-archway:before {
+  content: "\f557";
+}
+
+.fa-arrow-alt-circle-down:before {
+  content: "\f358";
+}
+
+.fa-arrow-alt-circle-left:before {
+  content: "\f359";
+}
+
+.fa-arrow-alt-circle-right:before {
+  content: "\f35a";
+}
+
+.fa-arrow-alt-circle-up:before {
+  content: "\f35b";
+}
+
+.fa-arrow-circle-down:before {
+  content: "\f0ab";
+}
+
+.fa-arrow-circle-left:before {
+  content: "\f0a8";
+}
+
+.fa-arrow-circle-right:before {
+  content: "\f0a9";
+}
+
+.fa-arrow-circle-up:before {
+  content: "\f0aa";
+}
+
+.fa-arrow-down:before {
+  content: "\f063";
+}
+
+.fa-arrow-left:before {
+  content: "\f060";
+}
+
+.fa-arrow-right:before {
+  content: "\f061";
+}
+
+.fa-arrow-up:before {
+  content: "\f062";
+}
+
+.fa-arrows-alt:before {
+  content: "\f0b2";
+}
+
+.fa-arrows-alt-h:before {
+  content: "\f337";
+}
+
+.fa-arrows-alt-v:before {
+  content: "\f338";
+}
+
+.fa-artstation:before {
+  content: "\f77a";
+}
+
+.fa-assistive-listening-systems:before {
+  content: "\f2a2";
+}
+
+.fa-asterisk:before {
+  content: "\f069";
+}
+
+.fa-asymmetrik:before {
+  content: "\f372";
+}
+
+.fa-at:before {
+  content: "\f1fa";
+}
+
+.fa-atlas:before {
+  content: "\f558";
+}
+
+.fa-atlassian:before {
+  content: "\f77b";
+}
+
+.fa-atom:before {
+  content: "\f5d2";
+}
+
+.fa-audible:before {
+  content: "\f373";
+}
+
+.fa-audio-description:before {
+  content: "\f29e";
+}
+
+.fa-autoprefixer:before {
+  content: "\f41c";
+}
+
+.fa-avianex:before {
+  content: "\f374";
+}
+
+.fa-aviato:before {
+  content: "\f421";
+}
+
+.fa-award:before {
+  content: "\f559";
+}
+
+.fa-aws:before {
+  content: "\f375";
+}
+
+.fa-baby:before {
+  content: "\f77c";
+}
+
+.fa-baby-carriage:before {
+  content: "\f77d";
+}
+
+.fa-backspace:before {
+  content: "\f55a";
+}
+
+.fa-backward:before {
+  content: "\f04a";
+}
+
+.fa-balance-scale:before {
+  content: "\f24e";
+}
+
+.fa-ban:before {
+  content: "\f05e";
+}
+
+.fa-band-aid:before {
+  content: "\f462";
+}
+
+.fa-bandcamp:before {
+  content: "\f2d5";
+}
+
+.fa-barcode:before {
+  content: "\f02a";
+}
+
+.fa-bars:before {
+  content: "\f0c9";
+}
+
+.fa-baseball-ball:before {
+  content: "\f433";
+}
+
+.fa-basketball-ball:before {
+  content: "\f434";
+}
+
+.fa-bath:before {
+  content: "\f2cd";
+}
+
+.fa-battery-empty:before {
+  content: "\f244";
+}
+
+.fa-battery-full:before {
+  content: "\f240";
+}
+
+.fa-battery-half:before {
+  content: "\f242";
+}
+
+.fa-battery-quarter:before {
+  content: "\f243";
+}
+
+.fa-battery-three-quarters:before {
+  content: "\f241";
+}
+
+.fa-bed:before {
+  content: "\f236";
+}
+
+.fa-beer:before {
+  content: "\f0fc";
+}
+
+.fa-behance:before {
+  content: "\f1b4";
+}
+
+.fa-behance-square:before {
+  content: "\f1b5";
+}
+
+.fa-bell:before {
+  content: "\f0f3";
+}
+
+.fa-bell-slash:before {
+  content: "\f1f6";
+}
+
+.fa-bezier-curve:before {
+  content: "\f55b";
+}
+
+.fa-bible:before {
+  content: "\f647";
+}
+
+.fa-bicycle:before {
+  content: "\f206";
+}
+
+.fa-bimobject:before {
+  content: "\f378";
+}
+
+.fa-binoculars:before {
+  content: "\f1e5";
+}
+
+.fa-biohazard:before {
+  content: "\f780";
+}
+
+.fa-birthday-cake:before {
+  content: "\f1fd";
+}
+
+.fa-bitbucket:before {
+  content: "\f171";
+}
+
+.fa-bitcoin:before {
+  content: "\f379";
+}
+
+.fa-bity:before {
+  content: "\f37a";
+}
+
+.fa-black-tie:before {
+  content: "\f27e";
+}
+
+.fa-blackberry:before {
+  content: "\f37b";
+}
+
+.fa-blender:before {
+  content: "\f517";
+}
+
+.fa-blender-phone:before {
+  content: "\f6b6";
+}
+
+.fa-blind:before {
+  content: "\f29d";
+}
+
+.fa-blog:before {
+  content: "\f781";
+}
+
+.fa-blogger:before {
+  content: "\f37c";
+}
+
+.fa-blogger-b:before {
+  content: "\f37d";
+}
+
+.fa-bluetooth:before {
+  content: "\f293";
+}
+
+.fa-bluetooth-b:before {
+  content: "\f294";
+}
+
+.fa-bold:before {
+  content: "\f032";
+}
+
+.fa-bolt:before {
+  content: "\f0e7";
+}
+
+.fa-bomb:before {
+  content: "\f1e2";
+}
+
+.fa-bone:before {
+  content: "\f5d7";
+}
+
+.fa-bong:before {
+  content: "\f55c";
+}
+
+.fa-book:before {
+  content: "\f02d";
+}
+
+.fa-book-dead:before {
+  content: "\f6b7";
+}
+
+.fa-book-open:before {
+  content: "\f518";
+}
+
+.fa-book-reader:before {
+  content: "\f5da";
+}
+
+.fa-bookmark:before {
+  content: "\f02e";
+}
+
+.fa-bowling-ball:before {
+  content: "\f436";
+}
+
+.fa-box:before {
+  content: "\f466";
+}
+
+.fa-box-open:before {
+  content: "\f49e";
+}
+
+.fa-boxes:before {
+  content: "\f468";
+}
+
+.fa-braille:before {
+  content: "\f2a1";
+}
+
+.fa-brain:before {
+  content: "\f5dc";
+}
+
+.fa-briefcase:before {
+  content: "\f0b1";
+}
+
+.fa-briefcase-medical:before {
+  content: "\f469";
+}
+
+.fa-broadcast-tower:before {
+  content: "\f519";
+}
+
+.fa-broom:before {
+  content: "\f51a";
+}
+
+.fa-brush:before {
+  content: "\f55d";
+}
+
+.fa-btc:before {
+  content: "\f15a";
+}
+
+.fa-bug:before {
+  content: "\f188";
+}
+
+.fa-building:before {
+  content: "\f1ad";
+}
+
+.fa-bullhorn:before {
+  content: "\f0a1";
+}
+
+.fa-bullseye:before {
+  content: "\f140";
+}
+
+.fa-burn:before {
+  content: "\f46a";
+}
+
+.fa-buromobelexperte:before {
+  content: "\f37f";
+}
+
+.fa-bus:before {
+  content: "\f207";
+}
+
+.fa-bus-alt:before {
+  content: "\f55e";
+}
+
+.fa-business-time:before {
+  content: "\f64a";
+}
+
+.fa-buysellads:before {
+  content: "\f20d";
+}
+
+.fa-calculator:before {
+  content: "\f1ec";
+}
+
+.fa-calendar:before {
+  content: "\f133";
+}
+
+.fa-calendar-alt:before {
+  content: "\f073";
+}
+
+.fa-calendar-check:before {
+  content: "\f274";
+}
+
+.fa-calendar-day:before {
+  content: "\f783";
+}
+
+.fa-calendar-minus:before {
+  content: "\f272";
+}
+
+.fa-calendar-plus:before {
+  content: "\f271";
+}
+
+.fa-calendar-times:before {
+  content: "\f273";
+}
+
+.fa-calendar-week:before {
+  content: "\f784";
+}
+
+.fa-camera:before {
+  content: "\f030";
+}
+
+.fa-camera-retro:before {
+  content: "\f083";
+}
+
+.fa-campground:before {
+  content: "\f6bb";
+}
+
+.fa-canadian-maple-leaf:before {
+  content: "\f785";
+}
+
+.fa-candy-cane:before {
+  content: "\f786";
+}
+
+.fa-cannabis:before {
+  content: "\f55f";
+}
+
+.fa-capsules:before {
+  content: "\f46b";
+}
+
+.fa-car:before {
+  content: "\f1b9";
+}
+
+.fa-car-alt:before {
+  content: "\f5de";
+}
+
+.fa-car-battery:before {
+  content: "\f5df";
+}
+
+.fa-car-crash:before {
+  content: "\f5e1";
+}
+
+.fa-car-side:before {
+  content: "\f5e4";
+}
+
+.fa-caret-down:before {
+  content: "\f0d7";
+}
+
+.fa-caret-left:before {
+  content: "\f0d9";
+}
+
+.fa-caret-right:before {
+  content: "\f0da";
+}
+
+.fa-caret-square-down:before {
+  content: "\f150";
+}
+
+.fa-caret-square-left:before {
+  content: "\f191";
+}
+
+.fa-caret-square-right:before {
+  content: "\f152";
+}
+
+.fa-caret-square-up:before {
+  content: "\f151";
+}
+
+.fa-caret-up:before {
+  content: "\f0d8";
+}
+
+.fa-carrot:before {
+  content: "\f787";
+}
+
+.fa-cart-arrow-down:before {
+  content: "\f218";
+}
+
+.fa-cart-plus:before {
+  content: "\f217";
+}
+
+.fa-cash-register:before {
+  content: "\f788";
+}
+
+.fa-cat:before {
+  content: "\f6be";
+}
+
+.fa-cc-amazon-pay:before {
+  content: "\f42d";
+}
+
+.fa-cc-amex:before {
+  content: "\f1f3";
+}
+
+.fa-cc-apple-pay:before {
+  content: "\f416";
+}
+
+.fa-cc-diners-club:before {
+  content: "\f24c";
+}
+
+.fa-cc-discover:before {
+  content: "\f1f2";
+}
+
+.fa-cc-jcb:before {
+  content: "\f24b";
+}
+
+.fa-cc-mastercard:before {
+  content: "\f1f1";
+}
+
+.fa-cc-paypal:before {
+  content: "\f1f4";
+}
+
+.fa-cc-stripe:before {
+  content: "\f1f5";
+}
+
+.fa-cc-visa:before {
+  content: "\f1f0";
+}
+
+.fa-centercode:before {
+  content: "\f380";
+}
+
+.fa-centos:before {
+  content: "\f789";
+}
+
+.fa-certificate:before {
+  content: "\f0a3";
+}
+
+.fa-chair:before {
+  content: "\f6c0";
+}
+
+.fa-chalkboard:before {
+  content: "\f51b";
+}
+
+.fa-chalkboard-teacher:before {
+  content: "\f51c";
+}
+
+.fa-charging-station:before {
+  content: "\f5e7";
+}
+
+.fa-chart-area:before {
+  content: "\f1fe";
+}
+
+.fa-chart-bar:before {
+  content: "\f080";
+}
+
+.fa-chart-line:before {
+  content: "\f201";
+}
+
+.fa-chart-pie:before {
+  content: "\f200";
+}
+
+.fa-check:before {
+  content: "\f00c";
+}
+
+.fa-check-circle:before {
+  content: "\f058";
+}
+
+.fa-check-double:before {
+  content: "\f560";
+}
+
+.fa-check-square:before {
+  content: "\f14a";
+}
+
+.fa-chess:before {
+  content: "\f439";
+}
+
+.fa-chess-bishop:before {
+  content: "\f43a";
+}
+
+.fa-chess-board:before {
+  content: "\f43c";
+}
+
+.fa-chess-king:before {
+  content: "\f43f";
+}
+
+.fa-chess-knight:before {
+  content: "\f441";
+}
+
+.fa-chess-pawn:before {
+  content: "\f443";
+}
+
+.fa-chess-queen:before {
+  content: "\f445";
+}
+
+.fa-chess-rook:before {
+  content: "\f447";
+}
+
+.fa-chevron-circle-down:before {
+  content: "\f13a";
+}
+
+.fa-chevron-circle-left:before {
+  content: "\f137";
+}
+
+.fa-chevron-circle-right:before {
+  content: "\f138";
+}
+
+.fa-chevron-circle-up:before {
+  content: "\f139";
+}
+
+.fa-chevron-down:before {
+  content: "\f078";
+}
+
+.fa-chevron-left:before {
+  content: "\f053";
+}
+
+.fa-chevron-right:before {
+  content: "\f054";
+}
+
+.fa-chevron-up:before {
+  content: "\f077";
+}
+
+.fa-child:before {
+  content: "\f1ae";
+}
+
+.fa-chrome:before {
+  content: "\f268";
+}
+
+.fa-church:before {
+  content: "\f51d";
+}
+
+.fa-circle:before {
+  content: "\f111";
+}
+
+.fa-circle-notch:before {
+  content: "\f1ce";
+}
+
+.fa-city:before {
+  content: "\f64f";
+}
+
+.fa-clipboard:before {
+  content: "\f328";
+}
+
+.fa-clipboard-check:before {
+  content: "\f46c";
+}
+
+.fa-clipboard-list:before {
+  content: "\f46d";
+}
+
+.fa-clock:before {
+  content: "\f017";
+}
+
+.fa-clone:before {
+  content: "\f24d";
+}
+
+.fa-closed-captioning:before {
+  content: "\f20a";
+}
+
+.fa-cloud:before {
+  content: "\f0c2";
+}
+
+.fa-cloud-download-alt:before {
+  content: "\f381";
+}
+
+.fa-cloud-meatball:before {
+  content: "\f73b";
+}
+
+.fa-cloud-moon:before {
+  content: "\f6c3";
+}
+
+.fa-cloud-moon-rain:before {
+  content: "\f73c";
+}
+
+.fa-cloud-rain:before {
+  content: "\f73d";
+}
+
+.fa-cloud-showers-heavy:before {
+  content: "\f740";
+}
+
+.fa-cloud-sun:before {
+  content: "\f6c4";
+}
+
+.fa-cloud-sun-rain:before {
+  content: "\f743";
+}
+
+.fa-cloud-upload-alt:before {
+  content: "\f382";
+}
+
+.fa-cloudscale:before {
+  content: "\f383";
+}
+
+.fa-cloudsmith:before {
+  content: "\f384";
+}
+
+.fa-cloudversify:before {
+  content: "\f385";
+}
+
+.fa-cocktail:before {
+  content: "\f561";
+}
+
+.fa-code:before {
+  content: "\f121";
+}
+
+.fa-code-branch:before {
+  content: "\f126";
+}
+
+.fa-codepen:before {
+  content: "\f1cb";
+}
+
+.fa-codiepie:before {
+  content: "\f284";
+}
+
+.fa-coffee:before {
+  content: "\f0f4";
+}
+
+.fa-cog:before {
+  content: "\f013";
+}
+
+.fa-cogs:before {
+  content: "\f085";
+}
+
+.fa-coins:before {
+  content: "\f51e";
+}
+
+.fa-columns:before {
+  content: "\f0db";
+}
+
+.fa-comment:before {
+  content: "\f075";
+}
+
+.fa-comment-alt:before {
+  content: "\f27a";
+}
+
+.fa-comment-dollar:before {
+  content: "\f651";
+}
+
+.fa-comment-dots:before {
+  content: "\f4ad";
+}
+
+.fa-comment-slash:before {
+  content: "\f4b3";
+}
+
+.fa-comments:before {
+  content: "\f086";
+}
+
+.fa-comments-dollar:before {
+  content: "\f653";
+}
+
+.fa-compact-disc:before {
+  content: "\f51f";
+}
+
+.fa-compass:before {
+  content: "\f14e";
+}
+
+.fa-compress:before {
+  content: "\f066";
+}
+
+.fa-compress-arrows-alt:before {
+  content: "\f78c";
+}
+
+.fa-concierge-bell:before {
+  content: "\f562";
+}
+
+.fa-confluence:before {
+  content: "\f78d";
+}
+
+.fa-connectdevelop:before {
+  content: "\f20e";
+}
+
+.fa-contao:before {
+  content: "\f26d";
+}
+
+.fa-cookie:before {
+  content: "\f563";
+}
+
+.fa-cookie-bite:before {
+  content: "\f564";
+}
+
+.fa-copy:before {
+  content: "\f0c5";
+}
+
+.fa-copyright:before {
+  content: "\f1f9";
+}
+
+.fa-couch:before {
+  content: "\f4b8";
+}
+
+.fa-cpanel:before {
+  content: "\f388";
+}
+
+.fa-creative-commons:before {
+  content: "\f25e";
+}
+
+.fa-creative-commons-by:before {
+  content: "\f4e7";
+}
+
+.fa-creative-commons-nc:before {
+  content: "\f4e8";
+}
+
+.fa-creative-commons-nc-eu:before {
+  content: "\f4e9";
+}
+
+.fa-creative-commons-nc-jp:before {
+  content: "\f4ea";
+}
+
+.fa-creative-commons-nd:before {
+  content: "\f4eb";
+}
+
+.fa-creative-commons-pd:before {
+  content: "\f4ec";
+}
+
+.fa-creative-commons-pd-alt:before {
+  content: "\f4ed";
+}
+
+.fa-creative-commons-remix:before {
+  content: "\f4ee";
+}
+
+.fa-creative-commons-sa:before {
+  content: "\f4ef";
+}
+
+.fa-creative-commons-sampling:before {
+  content: "\f4f0";
+}
+
+.fa-creative-commons-sampling-plus:before {
+  content: "\f4f1";
+}
+
+.fa-creative-commons-share:before {
+  content: "\f4f2";
+}
+
+.fa-creative-commons-zero:before {
+  content: "\f4f3";
+}
+
+.fa-credit-card:before {
+  content: "\f09d";
+}
+
+.fa-critical-role:before {
+  content: "\f6c9";
+}
+
+.fa-crop:before {
+  content: "\f125";
+}
+
+.fa-crop-alt:before {
+  content: "\f565";
+}
+
+.fa-cross:before {
+  content: "\f654";
+}
+
+.fa-crosshairs:before {
+  content: "\f05b";
+}
+
+.fa-crow:before {
+  content: "\f520";
+}
+
+.fa-crown:before {
+  content: "\f521";
+}
+
+.fa-css3:before {
+  content: "\f13c";
+}
+
+.fa-css3-alt:before {
+  content: "\f38b";
+}
+
+.fa-cube:before {
+  content: "\f1b2";
+}
+
+.fa-cubes:before {
+  content: "\f1b3";
+}
+
+.fa-cut:before {
+  content: "\f0c4";
+}
+
+.fa-cuttlefish:before {
+  content: "\f38c";
+}
+
+.fa-d-and-d:before {
+  content: "\f38d";
+}
+
+.fa-d-and-d-beyond:before {
+  content: "\f6ca";
+}
+
+.fa-dashcube:before {
+  content: "\f210";
+}
+
+.fa-database:before {
+  content: "\f1c0";
+}
+
+.fa-deaf:before {
+  content: "\f2a4";
+}
+
+.fa-delicious:before {
+  content: "\f1a5";
+}
+
+.fa-democrat:before {
+  content: "\f747";
+}
+
+.fa-deploydog:before {
+  content: "\f38e";
+}
+
+.fa-deskpro:before {
+  content: "\f38f";
+}
+
+.fa-desktop:before {
+  content: "\f108";
+}
+
+.fa-dev:before {
+  content: "\f6cc";
+}
+
+.fa-deviantart:before {
+  content: "\f1bd";
+}
+
+.fa-dharmachakra:before {
+  content: "\f655";
+}
+
+.fa-dhl:before {
+  content: "\f790";
+}
+
+.fa-diagnoses:before {
+  content: "\f470";
+}
+
+.fa-diaspora:before {
+  content: "\f791";
+}
+
+.fa-dice:before {
+  content: "\f522";
+}
+
+.fa-dice-d20:before {
+  content: "\f6cf";
+}
+
+.fa-dice-d6:before {
+  content: "\f6d1";
+}
+
+.fa-dice-five:before {
+  content: "\f523";
+}
+
+.fa-dice-four:before {
+  content: "\f524";
+}
+
+.fa-dice-one:before {
+  content: "\f525";
+}
+
+.fa-dice-six:before {
+  content: "\f526";
+}
+
+.fa-dice-three:before {
+  content: "\f527";
+}
+
+.fa-dice-two:before {
+  content: "\f528";
+}
+
+.fa-digg:before {
+  content: "\f1a6";
+}
+
+.fa-digital-ocean:before {
+  content: "\f391";
+}
+
+.fa-digital-tachograph:before {
+  content: "\f566";
+}
+
+.fa-directions:before {
+  content: "\f5eb";
+}
+
+.fa-discord:before {
+  content: "\f392";
+}
+
+.fa-discourse:before {
+  content: "\f393";
+}
+
+.fa-divide:before {
+  content: "\f529";
+}
+
+.fa-dizzy:before {
+  content: "\f567";
+}
+
+.fa-dna:before {
+  content: "\f471";
+}
+
+.fa-dochub:before {
+  content: "\f394";
+}
+
+.fa-docker:before {
+  content: "\f395";
+}
+
+.fa-dog:before {
+  content: "\f6d3";
+}
+
+.fa-dollar-sign:before {
+  content: "\f155";
+}
+
+.fa-dolly:before {
+  content: "\f472";
+}
+
+.fa-dolly-flatbed:before {
+  content: "\f474";
+}
+
+.fa-donate:before {
+  content: "\f4b9";
+}
+
+.fa-door-closed:before {
+  content: "\f52a";
+}
+
+.fa-door-open:before {
+  content: "\f52b";
+}
+
+.fa-dot-circle:before {
+  content: "\f192";
+}
+
+.fa-dove:before {
+  content: "\f4ba";
+}
+
+.fa-download:before {
+  content: "\f019";
+}
+
+.fa-draft2digital:before {
+  content: "\f396";
+}
+
+.fa-drafting-compass:before {
+  content: "\f568";
+}
+
+.fa-dragon:before {
+  content: "\f6d5";
+}
+
+.fa-draw-polygon:before {
+  content: "\f5ee";
+}
+
+.fa-dribbble:before {
+  content: "\f17d";
+}
+
+.fa-dribbble-square:before {
+  content: "\f397";
+}
+
+.fa-dropbox:before {
+  content: "\f16b";
+}
+
+.fa-drum:before {
+  content: "\f569";
+}
+
+.fa-drum-steelpan:before {
+  content: "\f56a";
+}
+
+.fa-drumstick-bite:before {
+  content: "\f6d7";
+}
+
+.fa-drupal:before {
+  content: "\f1a9";
+}
+
+.fa-dumbbell:before {
+  content: "\f44b";
+}
+
+.fa-dumpster:before {
+  content: "\f793";
+}
+
+.fa-dumpster-fire:before {
+  content: "\f794";
+}
+
+.fa-dungeon:before {
+  content: "\f6d9";
+}
+
+.fa-dyalog:before {
+  content: "\f399";
+}
+
+.fa-earlybirds:before {
+  content: "\f39a";
+}
+
+.fa-ebay:before {
+  content: "\f4f4";
+}
+
+.fa-edge:before {
+  content: "\f282";
+}
+
+.fa-edit:before {
+  content: "\f044";
+}
+
+.fa-eject:before {
+  content: "\f052";
+}
+
+.fa-elementor:before {
+  content: "\f430";
+}
+
+.fa-ellipsis-h:before {
+  content: "\f141";
+}
+
+.fa-ellipsis-v:before {
+  content: "\f142";
+}
+
+.fa-ello:before {
+  content: "\f5f1";
+}
+
+.fa-ember:before {
+  content: "\f423";
+}
+
+.fa-empire:before {
+  content: "\f1d1";
+}
+
+.fa-envelope:before {
+  content: "\f0e0";
+}
+
+.fa-envelope-open:before {
+  content: "\f2b6";
+}
+
+.fa-envelope-open-text:before {
+  content: "\f658";
+}
+
+.fa-envelope-square:before {
+  content: "\f199";
+}
+
+.fa-envira:before {
+  content: "\f299";
+}
+
+.fa-equals:before {
+  content: "\f52c";
+}
+
+.fa-eraser:before {
+  content: "\f12d";
+}
+
+.fa-erlang:before {
+  content: "\f39d";
+}
+
+.fa-ethereum:before {
+  content: "\f42e";
+}
+
+.fa-ethernet:before {
+  content: "\f796";
+}
+
+.fa-etsy:before {
+  content: "\f2d7";
+}
+
+.fa-euro-sign:before {
+  content: "\f153";
+}
+
+.fa-exchange-alt:before {
+  content: "\f362";
+}
+
+.fa-exclamation:before {
+  content: "\f12a";
+}
+
+.fa-exclamation-circle:before {
+  content: "\f06a";
+}
+
+.fa-exclamation-triangle:before {
+  content: "\f071";
+}
+
+.fa-expand:before {
+  content: "\f065";
+}
+
+.fa-expand-arrows-alt:before {
+  content: "\f31e";
+}
+
+.fa-expeditedssl:before {
+  content: "\f23e";
+}
+
+.fa-external-link-alt:before {
+  content: "\f35d";
+}
+
+.fa-external-link-square-alt:before {
+  content: "\f360";
+}
+
+.fa-eye:before {
+  content: "\f06e";
+}
+
+.fa-eye-dropper:before {
+  content: "\f1fb";
+}
+
+.fa-eye-slash:before {
+  content: "\f070";
+}
+
+.fa-facebook:before {
+  content: "\f09a";
+}
+
+.fa-facebook-f:before {
+  content: "\f39e";
+}
+
+.fa-facebook-messenger:before {
+  content: "\f39f";
+}
+
+.fa-facebook-square:before {
+  content: "\f082";
+}
+
+.fa-fantasy-flight-games:before {
+  content: "\f6dc";
+}
+
+.fa-fast-backward:before {
+  content: "\f049";
+}
+
+.fa-fast-forward:before {
+  content: "\f050";
+}
+
+.fa-fax:before {
+  content: "\f1ac";
+}
+
+.fa-feather:before {
+  content: "\f52d";
+}
+
+.fa-feather-alt:before {
+  content: "\f56b";
+}
+
+.fa-fedex:before {
+  content: "\f797";
+}
+
+.fa-fedora:before {
+  content: "\f798";
+}
+
+.fa-female:before {
+  content: "\f182";
+}
+
+.fa-fighter-jet:before {
+  content: "\f0fb";
+}
+
+.fa-figma:before {
+  content: "\f799";
+}
+
+.fa-file:before {
+  content: "\f15b";
+}
+
+.fa-file-alt:before {
+  content: "\f15c";
+}
+
+.fa-file-archive:before {
+  content: "\f1c6";
+}
+
+.fa-file-audio:before {
+  content: "\f1c7";
+}
+
+.fa-file-code:before {
+  content: "\f1c9";
+}
+
+.fa-file-contract:before {
+  content: "\f56c";
+}
+
+.fa-file-csv:before {
+  content: "\f6dd";
+}
+
+.fa-file-download:before {
+  content: "\f56d";
+}
+
+.fa-file-excel:before {
+  content: "\f1c3";
+}
+
+.fa-file-export:before {
+  content: "\f56e";
+}
+
+.fa-file-image:before {
+  content: "\f1c5";
+}
+
+.fa-file-import:before {
+  content: "\f56f";
+}
+
+.fa-file-invoice:before {
+  content: "\f570";
+}
+
+.fa-file-invoice-dollar:before {
+  content: "\f571";
+}
+
+.fa-file-medical:before {
+  content: "\f477";
+}
+
+.fa-file-medical-alt:before {
+  content: "\f478";
+}
+
+.fa-file-pdf:before {
+  content: "\f1c1";
+}
+
+.fa-file-powerpoint:before {
+  content: "\f1c4";
+}
+
+.fa-file-prescription:before {
+  content: "\f572";
+}
+
+.fa-file-signature:before {
+  content: "\f573";
+}
+
+.fa-file-upload:before {
+  content: "\f574";
+}
+
+.fa-file-video:before {
+  content: "\f1c8";
+}
+
+.fa-file-word:before {
+  content: "\f1c2";
+}
+
+.fa-fill:before {
+  content: "\f575";
+}
+
+.fa-fill-drip:before {
+  content: "\f576";
+}
+
+.fa-film:before {
+  content: "\f008";
+}
+
+.fa-filter:before {
+  content: "\f0b0";
+}
+
+.fa-fingerprint:before {
+  content: "\f577";
+}
+
+.fa-fire:before {
+  content: "\f06d";
+}
+
+.fa-fire-alt:before {
+  content: "\f7e4";
+}
+
+.fa-fire-extinguisher:before {
+  content: "\f134";
+}
+
+.fa-firefox:before {
+  content: "\f269";
+}
+
+.fa-first-aid:before {
+  content: "\f479";
+}
+
+.fa-first-order:before {
+  content: "\f2b0";
+}
+
+.fa-first-order-alt:before {
+  content: "\f50a";
+}
+
+.fa-firstdraft:before {
+  content: "\f3a1";
+}
+
+.fa-fish:before {
+  content: "\f578";
+}
+
+.fa-fist-raised:before {
+  content: "\f6de";
+}
+
+.fa-flag:before {
+  content: "\f024";
+}
+
+.fa-flag-checkered:before {
+  content: "\f11e";
+}
+
+.fa-flag-usa:before {
+  content: "\f74d";
+}
+
+.fa-flask:before {
+  content: "\f0c3";
+}
+
+.fa-flickr:before {
+  content: "\f16e";
+}
+
+.fa-flipboard:before {
+  content: "\f44d";
+}
+
+.fa-flushed:before {
+  content: "\f579";
+}
+
+.fa-fly:before {
+  content: "\f417";
+}
+
+.fa-folder:before {
+  content: "\f07b";
+}
+
+.fa-folder-minus:before {
+  content: "\f65d";
+}
+
+.fa-folder-open:before {
+  content: "\f07c";
+}
+
+.fa-folder-plus:before {
+  content: "\f65e";
+}
+
+.fa-font:before {
+  content: "\f031";
+}
+
+.fa-font-awesome:before {
+  content: "\f2b4";
+}
+
+.fa-font-awesome-alt:before {
+  content: "\f35c";
+}
+
+.fa-font-awesome-flag:before {
+  content: "\f425";
+}
+
+.fa-font-awesome-logo-full:before {
+  content: "\f4e6";
+}
+
+.fa-fonticons:before {
+  content: "\f280";
+}
+
+.fa-fonticons-fi:before {
+  content: "\f3a2";
+}
+
+.fa-football-ball:before {
+  content: "\f44e";
+}
+
+.fa-fort-awesome:before {
+  content: "\f286";
+}
+
+.fa-fort-awesome-alt:before {
+  content: "\f3a3";
+}
+
+.fa-forumbee:before {
+  content: "\f211";
+}
+
+.fa-forward:before {
+  content: "\f04e";
+}
+
+.fa-foursquare:before {
+  content: "\f180";
+}
+
+.fa-free-code-camp:before {
+  content: "\f2c5";
+}
+
+.fa-freebsd:before {
+  content: "\f3a4";
+}
+
+.fa-frog:before {
+  content: "\f52e";
+}
+
+.fa-frown:before {
+  content: "\f119";
+}
+
+.fa-frown-open:before {
+  content: "\f57a";
+}
+
+.fa-fulcrum:before {
+  content: "\f50b";
+}
+
+.fa-funnel-dollar:before {
+  content: "\f662";
+}
+
+.fa-futbol:before {
+  content: "\f1e3";
+}
+
+.fa-galactic-republic:before {
+  content: "\f50c";
+}
+
+.fa-galactic-senate:before {
+  content: "\f50d";
+}
+
+.fa-gamepad:before {
+  content: "\f11b";
+}
+
+.fa-gas-pump:before {
+  content: "\f52f";
+}
+
+.fa-gavel:before {
+  content: "\f0e3";
+}
+
+.fa-gem:before {
+  content: "\f3a5";
+}
+
+.fa-genderless:before {
+  content: "\f22d";
+}
+
+.fa-get-pocket:before {
+  content: "\f265";
+}
+
+.fa-gg:before {
+  content: "\f260";
+}
+
+.fa-gg-circle:before {
+  content: "\f261";
+}
+
+.fa-ghost:before {
+  content: "\f6e2";
+}
+
+.fa-gift:before {
+  content: "\f06b";
+}
+
+.fa-gifts:before {
+  content: "\f79c";
+}
+
+.fa-git:before {
+  content: "\f1d3";
+}
+
+.fa-git-square:before {
+  content: "\f1d2";
+}
+
+.fa-github:before {
+  content: "\f09b";
+}
+
+.fa-github-alt:before {
+  content: "\f113";
+}
+
+.fa-github-square:before {
+  content: "\f092";
+}
+
+.fa-gitkraken:before {
+  content: "\f3a6";
+}
+
+.fa-gitlab:before {
+  content: "\f296";
+}
+
+.fa-gitter:before {
+  content: "\f426";
+}
+
+.fa-glass-cheers:before {
+  content: "\f79f";
+}
+
+.fa-glass-martini:before {
+  content: "\f000";
+}
+
+.fa-glass-martini-alt:before {
+  content: "\f57b";
+}
+
+.fa-glass-whiskey:before {
+  content: "\f7a0";
+}
+
+.fa-glasses:before {
+  content: "\f530";
+}
+
+.fa-glide:before {
+  content: "\f2a5";
+}
+
+.fa-glide-g:before {
+  content: "\f2a6";
+}
+
+.fa-globe:before {
+  content: "\f0ac";
+}
+
+.fa-globe-africa:before {
+  content: "\f57c";
+}
+
+.fa-globe-americas:before {
+  content: "\f57d";
+}
+
+.fa-globe-asia:before {
+  content: "\f57e";
+}
+
+.fa-globe-europe:before {
+  content: "\f7a2";
+}
+
+.fa-gofore:before {
+  content: "\f3a7";
+}
+
+.fa-golf-ball:before {
+  content: "\f450";
+}
+
+.fa-goodreads:before {
+  content: "\f3a8";
+}
+
+.fa-goodreads-g:before {
+  content: "\f3a9";
+}
+
+.fa-google:before {
+  content: "\f1a0";
+}
+
+.fa-google-drive:before {
+  content: "\f3aa";
+}
+
+.fa-google-play:before {
+  content: "\f3ab";
+}
+
+.fa-google-plus:before {
+  content: "\f2b3";
+}
+
+.fa-google-plus-g:before {
+  content: "\f0d5";
+}
+
+.fa-google-plus-square:before {
+  content: "\f0d4";
+}
+
+.fa-google-wallet:before {
+  content: "\f1ee";
+}
+
+.fa-gopuram:before {
+  content: "\f664";
+}
+
+.fa-graduation-cap:before {
+  content: "\f19d";
+}
+
+.fa-gratipay:before {
+  content: "\f184";
+}
+
+.fa-grav:before {
+  content: "\f2d6";
+}
+
+.fa-greater-than:before {
+  content: "\f531";
+}
+
+.fa-greater-than-equal:before {
+  content: "\f532";
+}
+
+.fa-grimace:before {
+  content: "\f57f";
+}
+
+.fa-grin:before {
+  content: "\f580";
+}
+
+.fa-grin-alt:before {
+  content: "\f581";
+}
+
+.fa-grin-beam:before {
+  content: "\f582";
+}
+
+.fa-grin-beam-sweat:before {
+  content: "\f583";
+}
+
+.fa-grin-hearts:before {
+  content: "\f584";
+}
+
+.fa-grin-squint:before {
+  content: "\f585";
+}
+
+.fa-grin-squint-tears:before {
+  content: "\f586";
+}
+
+.fa-grin-stars:before {
+  content: "\f587";
+}
+
+.fa-grin-tears:before {
+  content: "\f588";
+}
+
+.fa-grin-tongue:before {
+  content: "\f589";
+}
+
+.fa-grin-tongue-squint:before {
+  content: "\f58a";
+}
+
+.fa-grin-tongue-wink:before {
+  content: "\f58b";
+}
+
+.fa-grin-wink:before {
+  content: "\f58c";
+}
+
+.fa-grip-horizontal:before {
+  content: "\f58d";
+}
+
+.fa-grip-lines:before {
+  content: "\f7a4";
+}
+
+.fa-grip-lines-vertical:before {
+  content: "\f7a5";
+}
+
+.fa-grip-vertical:before {
+  content: "\f58e";
+}
+
+.fa-gripfire:before {
+  content: "\f3ac";
+}
+
+.fa-grunt:before {
+  content: "\f3ad";
+}
+
+.fa-guitar:before {
+  content: "\f7a6";
+}
+
+.fa-gulp:before {
+  content: "\f3ae";
+}
+
+.fa-h-square:before {
+  content: "\f0fd";
+}
+
+.fa-hacker-news:before {
+  content: "\f1d4";
+}
+
+.fa-hacker-news-square:before {
+  content: "\f3af";
+}
+
+.fa-hackerrank:before {
+  content: "\f5f7";
+}
+
+.fa-hammer:before {
+  content: "\f6e3";
+}
+
+.fa-hamsa:before {
+  content: "\f665";
+}
+
+.fa-hand-holding:before {
+  content: "\f4bd";
+}
+
+.fa-hand-holding-heart:before {
+  content: "\f4be";
+}
+
+.fa-hand-holding-usd:before {
+  content: "\f4c0";
+}
+
+.fa-hand-lizard:before {
+  content: "\f258";
+}
+
+.fa-hand-paper:before {
+  content: "\f256";
+}
+
+.fa-hand-peace:before {
+  content: "\f25b";
+}
+
+.fa-hand-point-down:before {
+  content: "\f0a7";
+}
+
+.fa-hand-point-left:before {
+  content: "\f0a5";
+}
+
+.fa-hand-point-right:before {
+  content: "\f0a4";
+}
+
+.fa-hand-point-up:before {
+  content: "\f0a6";
+}
+
+.fa-hand-pointer:before {
+  content: "\f25a";
+}
+
+.fa-hand-rock:before {
+  content: "\f255";
+}
+
+.fa-hand-scissors:before {
+  content: "\f257";
+}
+
+.fa-hand-spock:before {
+  content: "\f259";
+}
+
+.fa-hands:before {
+  content: "\f4c2";
+}
+
+.fa-hands-helping:before {
+  content: "\f4c4";
+}
+
+.fa-handshake:before {
+  content: "\f2b5";
+}
+
+.fa-hanukiah:before {
+  content: "\f6e6";
+}
+
+.fa-hashtag:before {
+  content: "\f292";
+}
+
+.fa-hat-wizard:before {
+  content: "\f6e8";
+}
+
+.fa-haykal:before {
+  content: "\f666";
+}
+
+.fa-hdd:before {
+  content: "\f0a0";
+}
+
+.fa-heading:before {
+  content: "\f1dc";
+}
+
+.fa-headphones:before {
+  content: "\f025";
+}
+
+.fa-headphones-alt:before {
+  content: "\f58f";
+}
+
+.fa-headset:before {
+  content: "\f590";
+}
+
+.fa-heart:before {
+  content: "\f004";
+}
+
+.fa-heart-broken:before {
+  content: "\f7a9";
+}
+
+.fa-heartbeat:before {
+  content: "\f21e";
+}
+
+.fa-helicopter:before {
+  content: "\f533";
+}
+
+.fa-highlighter:before {
+  content: "\f591";
+}
+
+.fa-hiking:before {
+  content: "\f6ec";
+}
+
+.fa-hippo:before {
+  content: "\f6ed";
+}
+
+.fa-hips:before {
+  content: "\f452";
+}
+
+.fa-hire-a-helper:before {
+  content: "\f3b0";
+}
+
+.fa-history:before {
+  content: "\f1da";
+}
+
+.fa-hockey-puck:before {
+  content: "\f453";
+}
+
+.fa-holly-berry:before {
+  content: "\f7aa";
+}
+
+.fa-home:before {
+  content: "\f015";
+}
+
+.fa-hooli:before {
+  content: "\f427";
+}
+
+.fa-hornbill:before {
+  content: "\f592";
+}
+
+.fa-horse:before {
+  content: "\f6f0";
+}
+
+.fa-horse-head:before {
+  content: "\f7ab";
+}
+
+.fa-hospital:before {
+  content: "\f0f8";
+}
+
+.fa-hospital-alt:before {
+  content: "\f47d";
+}
+
+.fa-hospital-symbol:before {
+  content: "\f47e";
+}
+
+.fa-hot-tub:before {
+  content: "\f593";
+}
+
+.fa-hotel:before {
+  content: "\f594";
+}
+
+.fa-hotjar:before {
+  content: "\f3b1";
+}
+
+.fa-hourglass:before {
+  content: "\f254";
+}
+
+.fa-hourglass-end:before {
+  content: "\f253";
+}
+
+.fa-hourglass-half:before {
+  content: "\f252";
+}
+
+.fa-hourglass-start:before {
+  content: "\f251";
+}
+
+.fa-house-damage:before {
+  content: "\f6f1";
+}
+
+.fa-houzz:before {
+  content: "\f27c";
+}
+
+.fa-hryvnia:before {
+  content: "\f6f2";
+}
+
+.fa-html5:before {
+  content: "\f13b";
+}
+
+.fa-hubspot:before {
+  content: "\f3b2";
+}
+
+.fa-i-cursor:before {
+  content: "\f246";
+}
+
+.fa-icicles:before {
+  content: "\f7ad";
+}
+
+.fa-id-badge:before {
+  content: "\f2c1";
+}
+
+.fa-id-card:before {
+  content: "\f2c2";
+}
+
+.fa-id-card-alt:before {
+  content: "\f47f";
+}
+
+.fa-igloo:before {
+  content: "\f7ae";
+}
+
+.fa-image:before {
+  content: "\f03e";
+}
+
+.fa-images:before {
+  content: "\f302";
+}
+
+.fa-imdb:before {
+  content: "\f2d8";
+}
+
+.fa-inbox:before {
+  content: "\f01c";
+}
+
+.fa-indent:before {
+  content: "\f03c";
+}
+
+.fa-industry:before {
+  content: "\f275";
+}
+
+.fa-infinity:before {
+  content: "\f534";
+}
+
+.fa-info:before {
+  content: "\f129";
+}
+
+.fa-info-circle:before {
+  content: "\f05a";
+}
+
+.fa-instagram:before {
+  content: "\f16d";
+}
+
+.fa-intercom:before {
+  content: "\f7af";
+}
+
+.fa-internet-explorer:before {
+  content: "\f26b";
+}
+
+.fa-invision:before {
+  content: "\f7b0";
+}
+
+.fa-ioxhost:before {
+  content: "\f208";
+}
+
+.fa-italic:before {
+  content: "\f033";
+}
+
+.fa-itunes:before {
+  content: "\f3b4";
+}
+
+.fa-itunes-note:before {
+  content: "\f3b5";
+}
+
+.fa-java:before {
+  content: "\f4e4";
+}
+
+.fa-jedi:before {
+  content: "\f669";
+}
+
+.fa-jedi-order:before {
+  content: "\f50e";
+}
+
+.fa-jenkins:before {
+  content: "\f3b6";
+}
+
+.fa-jira:before {
+  content: "\f7b1";
+}
+
+.fa-joget:before {
+  content: "\f3b7";
+}
+
+.fa-joint:before {
+  content: "\f595";
+}
+
+.fa-joomla:before {
+  content: "\f1aa";
+}
+
+.fa-journal-whills:before {
+  content: "\f66a";
+}
+
+.fa-js:before {
+  content: "\f3b8";
+}
+
+.fa-js-square:before {
+  content: "\f3b9";
+}
+
+.fa-jsfiddle:before {
+  content: "\f1cc";
+}
+
+.fa-kaaba:before {
+  content: "\f66b";
+}
+
+.fa-kaggle:before {
+  content: "\f5fa";
+}
+
+.fa-key:before {
+  content: "\f084";
+}
+
+.fa-keybase:before {
+  content: "\f4f5";
+}
+
+.fa-keyboard:before {
+  content: "\f11c";
+}
+
+.fa-keycdn:before {
+  content: "\f3ba";
+}
+
+.fa-khanda:before {
+  content: "\f66d";
+}
+
+.fa-kickstarter:before {
+  content: "\f3bb";
+}
+
+.fa-kickstarter-k:before {
+  content: "\f3bc";
+}
+
+.fa-kiss:before {
+  content: "\f596";
+}
+
+.fa-kiss-beam:before {
+  content: "\f597";
+}
+
+.fa-kiss-wink-heart:before {
+  content: "\f598";
+}
+
+.fa-kiwi-bird:before {
+  content: "\f535";
+}
+
+.fa-korvue:before {
+  content: "\f42f";
+}
+
+.fa-landmark:before {
+  content: "\f66f";
+}
+
+.fa-language:before {
+  content: "\f1ab";
+}
+
+.fa-laptop:before {
+  content: "\f109";
+}
+
+.fa-laptop-code:before {
+  content: "\f5fc";
+}
+
+.fa-laravel:before {
+  content: "\f3bd";
+}
+
+.fa-lastfm:before {
+  content: "\f202";
+}
+
+.fa-lastfm-square:before {
+  content: "\f203";
+}
+
+.fa-laugh:before {
+  content: "\f599";
+}
+
+.fa-laugh-beam:before {
+  content: "\f59a";
+}
+
+.fa-laugh-squint:before {
+  content: "\f59b";
+}
+
+.fa-laugh-wink:before {
+  content: "\f59c";
+}
+
+.fa-layer-group:before {
+  content: "\f5fd";
+}
+
+.fa-leaf:before {
+  content: "\f06c";
+}
+
+.fa-leanpub:before {
+  content: "\f212";
+}
+
+.fa-lemon:before {
+  content: "\f094";
+}
+
+.fa-less:before {
+  content: "\f41d";
+}
+
+.fa-less-than:before {
+  content: "\f536";
+}
+
+.fa-less-than-equal:before {
+  content: "\f537";
+}
+
+.fa-level-down-alt:before {
+  content: "\f3be";
+}
+
+.fa-level-up-alt:before {
+  content: "\f3bf";
+}
+
+.fa-life-ring:before {
+  content: "\f1cd";
+}
+
+.fa-lightbulb:before {
+  content: "\f0eb";
+}
+
+.fa-line:before {
+  content: "\f3c0";
+}
+
+.fa-link:before {
+  content: "\f0c1";
+}
+
+.fa-linkedin:before {
+  content: "\f08c";
+}
+
+.fa-linkedin-in:before {
+  content: "\f0e1";
+}
+
+.fa-linode:before {
+  content: "\f2b8";
+}
+
+.fa-linux:before {
+  content: "\f17c";
+}
+
+.fa-lira-sign:before {
+  content: "\f195";
+}
+
+.fa-list:before {
+  content: "\f03a";
+}
+
+.fa-list-alt:before {
+  content: "\f022";
+}
+
+.fa-list-ol:before {
+  content: "\f0cb";
+}
+
+.fa-list-ul:before {
+  content: "\f0ca";
+}
+
+.fa-location-arrow:before {
+  content: "\f124";
+}
+
+.fa-lock:before {
+  content: "\f023";
+}
+
+.fa-lock-open:before {
+  content: "\f3c1";
+}
+
+.fa-long-arrow-alt-down:before {
+  content: "\f309";
+}
+
+.fa-long-arrow-alt-left:before {
+  content: "\f30a";
+}
+
+.fa-long-arrow-alt-right:before {
+  content: "\f30b";
+}
+
+.fa-long-arrow-alt-up:before {
+  content: "\f30c";
+}
+
+.fa-low-vision:before {
+  content: "\f2a8";
+}
+
+.fa-luggage-cart:before {
+  content: "\f59d";
+}
+
+.fa-lyft:before {
+  content: "\f3c3";
+}
+
+.fa-magento:before {
+  content: "\f3c4";
+}
+
+.fa-magic:before {
+  content: "\f0d0";
+}
+
+.fa-magnet:before {
+  content: "\f076";
+}
+
+.fa-mail-bulk:before {
+  content: "\f674";
+}
+
+.fa-mailchimp:before {
+  content: "\f59e";
+}
+
+.fa-male:before {
+  content: "\f183";
+}
+
+.fa-mandalorian:before {
+  content: "\f50f";
+}
+
+.fa-map:before {
+  content: "\f279";
+}
+
+.fa-map-marked:before {
+  content: "\f59f";
+}
+
+.fa-map-marked-alt:before {
+  content: "\f5a0";
+}
+
+.fa-map-marker:before {
+  content: "\f041";
+}
+
+.fa-map-marker-alt:before {
+  content: "\f3c5";
+}
+
+.fa-map-pin:before {
+  content: "\f276";
+}
+
+.fa-map-signs:before {
+  content: "\f277";
+}
+
+.fa-markdown:before {
+  content: "\f60f";
+}
+
+.fa-marker:before {
+  content: "\f5a1";
+}
+
+.fa-mars:before {
+  content: "\f222";
+}
+
+.fa-mars-double:before {
+  content: "\f227";
+}
+
+.fa-mars-stroke:before {
+  content: "\f229";
+}
+
+.fa-mars-stroke-h:before {
+  content: "\f22b";
+}
+
+.fa-mars-stroke-v:before {
+  content: "\f22a";
+}
+
+.fa-mask:before {
+  content: "\f6fa";
+}
+
+.fa-mastodon:before {
+  content: "\f4f6";
+}
+
+.fa-maxcdn:before {
+  content: "\f136";
+}
+
+.fa-medal:before {
+  content: "\f5a2";
+}
+
+.fa-medapps:before {
+  content: "\f3c6";
+}
+
+.fa-medium:before {
+  content: "\f23a";
+}
+
+.fa-medium-m:before {
+  content: "\f3c7";
+}
+
+.fa-medkit:before {
+  content: "\f0fa";
+}
+
+.fa-medrt:before {
+  content: "\f3c8";
+}
+
+.fa-meetup:before {
+  content: "\f2e0";
+}
+
+.fa-megaport:before {
+  content: "\f5a3";
+}
+
+.fa-meh:before {
+  content: "\f11a";
+}
+
+.fa-meh-blank:before {
+  content: "\f5a4";
+}
+
+.fa-meh-rolling-eyes:before {
+  content: "\f5a5";
+}
+
+.fa-memory:before {
+  content: "\f538";
+}
+
+.fa-mendeley:before {
+  content: "\f7b3";
+}
+
+.fa-menorah:before {
+  content: "\f676";
+}
+
+.fa-mercury:before {
+  content: "\f223";
+}
+
+.fa-meteor:before {
+  content: "\f753";
+}
+
+.fa-microchip:before {
+  content: "\f2db";
+}
+
+.fa-microphone:before {
+  content: "\f130";
+}
+
+.fa-microphone-alt:before {
+  content: "\f3c9";
+}
+
+.fa-microphone-alt-slash:before {
+  content: "\f539";
+}
+
+.fa-microphone-slash:before {
+  content: "\f131";
+}
+
+.fa-microscope:before {
+  content: "\f610";
+}
+
+.fa-microsoft:before {
+  content: "\f3ca";
+}
+
+.fa-minus:before {
+  content: "\f068";
+}
+
+.fa-minus-circle:before {
+  content: "\f056";
+}
+
+.fa-minus-square:before {
+  content: "\f146";
+}
+
+.fa-mitten:before {
+  content: "\f7b5";
+}
+
+.fa-mix:before {
+  content: "\f3cb";
+}
+
+.fa-mixcloud:before {
+  content: "\f289";
+}
+
+.fa-mizuni:before {
+  content: "\f3cc";
+}
+
+.fa-mobile:before {
+  content: "\f10b";
+}
+
+.fa-mobile-alt:before {
+  content: "\f3cd";
+}
+
+.fa-modx:before {
+  content: "\f285";
+}
+
+.fa-monero:before {
+  content: "\f3d0";
+}
+
+.fa-money-bill:before {
+  content: "\f0d6";
+}
+
+.fa-money-bill-alt:before {
+  content: "\f3d1";
+}
+
+.fa-money-bill-wave:before {
+  content: "\f53a";
+}
+
+.fa-money-bill-wave-alt:before {
+  content: "\f53b";
+}
+
+.fa-money-check:before {
+  content: "\f53c";
+}
+
+.fa-money-check-alt:before {
+  content: "\f53d";
+}
+
+.fa-monument:before {
+  content: "\f5a6";
+}
+
+.fa-moon:before {
+  content: "\f186";
+}
+
+.fa-mortar-pestle:before {
+  content: "\f5a7";
+}
+
+.fa-mosque:before {
+  content: "\f678";
+}
+
+.fa-motorcycle:before {
+  content: "\f21c";
+}
+
+.fa-mountain:before {
+  content: "\f6fc";
+}
+
+.fa-mouse-pointer:before {
+  content: "\f245";
+}
+
+.fa-mug-hot:before {
+  content: "\f7b6";
+}
+
+.fa-music:before {
+  content: "\f001";
+}
+
+.fa-napster:before {
+  content: "\f3d2";
+}
+
+.fa-neos:before {
+  content: "\f612";
+}
+
+.fa-network-wired:before {
+  content: "\f6ff";
+}
+
+.fa-neuter:before {
+  content: "\f22c";
+}
+
+.fa-newspaper:before {
+  content: "\f1ea";
+}
+
+.fa-nimblr:before {
+  content: "\f5a8";
+}
+
+.fa-nintendo-switch:before {
+  content: "\f418";
+}
+
+.fa-node:before {
+  content: "\f419";
+}
+
+.fa-node-js:before {
+  content: "\f3d3";
+}
+
+.fa-not-equal:before {
+  content: "\f53e";
+}
+
+.fa-notes-medical:before {
+  content: "\f481";
+}
+
+.fa-npm:before {
+  content: "\f3d4";
+}
+
+.fa-ns8:before {
+  content: "\f3d5";
+}
+
+.fa-nutritionix:before {
+  content: "\f3d6";
+}
+
+.fa-object-group:before {
+  content: "\f247";
+}
+
+.fa-object-ungroup:before {
+  content: "\f248";
+}
+
+.fa-odnoklassniki:before {
+  content: "\f263";
+}
+
+.fa-odnoklassniki-square:before {
+  content: "\f264";
+}
+
+.fa-oil-can:before {
+  content: "\f613";
+}
+
+.fa-old-republic:before {
+  content: "\f510";
+}
+
+.fa-om:before {
+  content: "\f679";
+}
+
+.fa-opencart:before {
+  content: "\f23d";
+}
+
+.fa-openid:before {
+  content: "\f19b";
+}
+
+.fa-opera:before {
+  content: "\f26a";
+}
+
+.fa-optin-monster:before {
+  content: "\f23c";
+}
+
+.fa-osi:before {
+  content: "\f41a";
+}
+
+.fa-otter:before {
+  content: "\f700";
+}
+
+.fa-outdent:before {
+  content: "\f03b";
+}
+
+.fa-page4:before {
+  content: "\f3d7";
+}
+
+.fa-pagelines:before {
+  content: "\f18c";
+}
+
+.fa-paint-brush:before {
+  content: "\f1fc";
+}
+
+.fa-paint-roller:before {
+  content: "\f5aa";
+}
+
+.fa-palette:before {
+  content: "\f53f";
+}
+
+.fa-palfed:before {
+  content: "\f3d8";
+}
+
+.fa-pallet:before {
+  content: "\f482";
+}
+
+.fa-paper-plane:before {
+  content: "\f1d8";
+}
+
+.fa-paperclip:before {
+  content: "\f0c6";
+}
+
+.fa-parachute-box:before {
+  content: "\f4cd";
+}
+
+.fa-paragraph:before {
+  content: "\f1dd";
+}
+
+.fa-parking:before {
+  content: "\f540";
+}
+
+.fa-passport:before {
+  content: "\f5ab";
+}
+
+.fa-pastafarianism:before {
+  content: "\f67b";
+}
+
+.fa-paste:before {
+  content: "\f0ea";
+}
+
+.fa-patreon:before {
+  content: "\f3d9";
+}
+
+.fa-pause:before {
+  content: "\f04c";
+}
+
+.fa-pause-circle:before {
+  content: "\f28b";
+}
+
+.fa-paw:before {
+  content: "\f1b0";
+}
+
+.fa-paypal:before {
+  content: "\f1ed";
+}
+
+.fa-peace:before {
+  content: "\f67c";
+}
+
+.fa-pen:before {
+  content: "\f304";
+}
+
+.fa-pen-alt:before {
+  content: "\f305";
+}
+
+.fa-pen-fancy:before {
+  content: "\f5ac";
+}
+
+.fa-pen-nib:before {
+  content: "\f5ad";
+}
+
+.fa-pen-square:before {
+  content: "\f14b";
+}
+
+.fa-pencil-alt:before {
+  content: "\f303";
+}
+
+.fa-pencil-ruler:before {
+  content: "\f5ae";
+}
+
+.fa-penny-arcade:before {
+  content: "\f704";
+}
+
+.fa-people-carry:before {
+  content: "\f4ce";
+}
+
+.fa-percent:before {
+  content: "\f295";
+}
+
+.fa-percentage:before {
+  content: "\f541";
+}
+
+.fa-periscope:before {
+  content: "\f3da";
+}
+
+.fa-person-booth:before {
+  content: "\f756";
+}
+
+.fa-phabricator:before {
+  content: "\f3db";
+}
+
+.fa-phoenix-framework:before {
+  content: "\f3dc";
+}
+
+.fa-phoenix-squadron:before {
+  content: "\f511";
+}
+
+.fa-phone:before {
+  content: "\f095";
+}
+
+.fa-phone-slash:before {
+  content: "\f3dd";
+}
+
+.fa-phone-square:before {
+  content: "\f098";
+}
+
+.fa-phone-volume:before {
+  content: "\f2a0";
+}
+
+.fa-php:before {
+  content: "\f457";
+}
+
+.fa-pied-piper:before {
+  content: "\f2ae";
+}
+
+.fa-pied-piper-alt:before {
+  content: "\f1a8";
+}
+
+.fa-pied-piper-hat:before {
+  content: "\f4e5";
+}
+
+.fa-pied-piper-pp:before {
+  content: "\f1a7";
+}
+
+.fa-piggy-bank:before {
+  content: "\f4d3";
+}
+
+.fa-pills:before {
+  content: "\f484";
+}
+
+.fa-pinterest:before {
+  content: "\f0d2";
+}
+
+.fa-pinterest-p:before {
+  content: "\f231";
+}
+
+.fa-pinterest-square:before {
+  content: "\f0d3";
+}
+
+.fa-place-of-worship:before {
+  content: "\f67f";
+}
+
+.fa-plane:before {
+  content: "\f072";
+}
+
+.fa-plane-arrival:before {
+  content: "\f5af";
+}
+
+.fa-plane-departure:before {
+  content: "\f5b0";
+}
+
+.fa-play:before {
+  content: "\f04b";
+}
+
+.fa-play-circle:before {
+  content: "\f144";
+}
+
+.fa-playstation:before {
+  content: "\f3df";
+}
+
+.fa-plug:before {
+  content: "\f1e6";
+}
+
+.fa-plus:before {
+  content: "\f067";
+}
+
+.fa-plus-circle:before {
+  content: "\f055";
+}
+
+.fa-plus-square:before {
+  content: "\f0fe";
+}
+
+.fa-podcast:before {
+  content: "\f2ce";
+}
+
+.fa-poll:before {
+  content: "\f681";
+}
+
+.fa-poll-h:before {
+  content: "\f682";
+}
+
+.fa-poo:before {
+  content: "\f2fe";
+}
+
+.fa-poo-storm:before {
+  content: "\f75a";
+}
+
+.fa-poop:before {
+  content: "\f619";
+}
+
+.fa-portrait:before {
+  content: "\f3e0";
+}
+
+.fa-pound-sign:before {
+  content: "\f154";
+}
+
+.fa-power-off:before {
+  content: "\f011";
+}
+
+.fa-pray:before {
+  content: "\f683";
+}
+
+.fa-praying-hands:before {
+  content: "\f684";
+}
+
+.fa-prescription:before {
+  content: "\f5b1";
+}
+
+.fa-prescription-bottle:before {
+  content: "\f485";
+}
+
+.fa-prescription-bottle-alt:before {
+  content: "\f486";
+}
+
+.fa-print:before {
+  content: "\f02f";
+}
+
+.fa-procedures:before {
+  content: "\f487";
+}
+
+.fa-product-hunt:before {
+  content: "\f288";
+}
+
+.fa-project-diagram:before {
+  content: "\f542";
+}
+
+.fa-pushed:before {
+  content: "\f3e1";
+}
+
+.fa-puzzle-piece:before {
+  content: "\f12e";
+}
+
+.fa-python:before {
+  content: "\f3e2";
+}
+
+.fa-qq:before {
+  content: "\f1d6";
+}
+
+.fa-qrcode:before {
+  content: "\f029";
+}
+
+.fa-question:before {
+  content: "\f128";
+}
+
+.fa-question-circle:before {
+  content: "\f059";
+}
+
+.fa-quidditch:before {
+  content: "\f458";
+}
+
+.fa-quinscape:before {
+  content: "\f459";
+}
+
+.fa-quora:before {
+  content: "\f2c4";
+}
+
+.fa-quote-left:before {
+  content: "\f10d";
+}
+
+.fa-quote-right:before {
+  content: "\f10e";
+}
+
+.fa-quran:before {
+  content: "\f687";
+}
+
+.fa-r-project:before {
+  content: "\f4f7";
+}
+
+.fa-radiation:before {
+  content: "\f7b9";
+}
+
+.fa-radiation-alt:before {
+  content: "\f7ba";
+}
+
+.fa-rainbow:before {
+  content: "\f75b";
+}
+
+.fa-random:before {
+  content: "\f074";
+}
+
+.fa-raspberry-pi:before {
+  content: "\f7bb";
+}
+
+.fa-ravelry:before {
+  content: "\f2d9";
+}
+
+.fa-react:before {
+  content: "\f41b";
+}
+
+.fa-reacteurope:before {
+  content: "\f75d";
+}
+
+.fa-readme:before {
+  content: "\f4d5";
+}
+
+.fa-rebel:before {
+  content: "\f1d0";
+}
+
+.fa-receipt:before {
+  content: "\f543";
+}
+
+.fa-recycle:before {
+  content: "\f1b8";
+}
+
+.fa-red-river:before {
+  content: "\f3e3";
+}
+
+.fa-reddit:before {
+  content: "\f1a1";
+}
+
+.fa-reddit-alien:before {
+  content: "\f281";
+}
+
+.fa-reddit-square:before {
+  content: "\f1a2";
+}
+
+.fa-redhat:before {
+  content: "\f7bc";
+}
+
+.fa-redo:before {
+  content: "\f01e";
+}
+
+.fa-redo-alt:before {
+  content: "\f2f9";
+}
+
+.fa-registered:before {
+  content: "\f25d";
+}
+
+.fa-renren:before {
+  content: "\f18b";
+}
+
+.fa-reply:before {
+  content: "\f3e5";
+}
+
+.fa-reply-all:before {
+  content: "\f122";
+}
+
+.fa-replyd:before {
+  content: "\f3e6";
+}
+
+.fa-republican:before {
+  content: "\f75e";
+}
+
+.fa-researchgate:before {
+  content: "\f4f8";
+}
+
+.fa-resolving:before {
+  content: "\f3e7";
+}
+
+.fa-restroom:before {
+  content: "\f7bd";
+}
+
+.fa-retweet:before {
+  content: "\f079";
+}
+
+.fa-rev:before {
+  content: "\f5b2";
+}
+
+.fa-ribbon:before {
+  content: "\f4d6";
+}
+
+.fa-ring:before {
+  content: "\f70b";
+}
+
+.fa-road:before {
+  content: "\f018";
+}
+
+.fa-robot:before {
+  content: "\f544";
+}
+
+.fa-rocket:before {
+  content: "\f135";
+}
+
+.fa-rocketchat:before {
+  content: "\f3e8";
+}
+
+.fa-rockrms:before {
+  content: "\f3e9";
+}
+
+.fa-route:before {
+  content: "\f4d7";
+}
+
+.fa-rss:before {
+  content: "\f09e";
+}
+
+.fa-rss-square:before {
+  content: "\f143";
+}
+
+.fa-ruble-sign:before {
+  content: "\f158";
+}
+
+.fa-ruler:before {
+  content: "\f545";
+}
+
+.fa-ruler-combined:before {
+  content: "\f546";
+}
+
+.fa-ruler-horizontal:before {
+  content: "\f547";
+}
+
+.fa-ruler-vertical:before {
+  content: "\f548";
+}
+
+.fa-running:before {
+  content: "\f70c";
+}
+
+.fa-rupee-sign:before {
+  content: "\f156";
+}
+
+.fa-sad-cry:before {
+  content: "\f5b3";
+}
+
+.fa-sad-tear:before {
+  content: "\f5b4";
+}
+
+.fa-safari:before {
+  content: "\f267";
+}
+
+.fa-sass:before {
+  content: "\f41e";
+}
+
+.fa-satellite:before {
+  content: "\f7bf";
+}
+
+.fa-satellite-dish:before {
+  content: "\f7c0";
+}
+
+.fa-save:before {
+  content: "\f0c7";
+}
+
+.fa-schlix:before {
+  content: "\f3ea";
+}
+
+.fa-school:before {
+  content: "\f549";
+}
+
+.fa-screwdriver:before {
+  content: "\f54a";
+}
+
+.fa-scribd:before {
+  content: "\f28a";
+}
+
+.fa-scroll:before {
+  content: "\f70e";
+}
+
+.fa-sd-card:before {
+  content: "\f7c2";
+}
+
+.fa-search:before {
+  content: "\f002";
+}
+
+.fa-search-dollar:before {
+  content: "\f688";
+}
+
+.fa-search-location:before {
+  content: "\f689";
+}
+
+.fa-search-minus:before {
+  content: "\f010";
+}
+
+.fa-search-plus:before {
+  content: "\f00e";
+}
+
+.fa-searchengin:before {
+  content: "\f3eb";
+}
+
+.fa-seedling:before {
+  content: "\f4d8";
+}
+
+.fa-sellcast:before {
+  content: "\f2da";
+}
+
+.fa-sellsy:before {
+  content: "\f213";
+}
+
+.fa-server:before {
+  content: "\f233";
+}
+
+.fa-servicestack:before {
+  content: "\f3ec";
+}
+
+.fa-shapes:before {
+  content: "\f61f";
+}
+
+.fa-share:before {
+  content: "\f064";
+}
+
+.fa-share-alt:before {
+  content: "\f1e0";
+}
+
+.fa-share-alt-square:before {
+  content: "\f1e1";
+}
+
+.fa-share-square:before {
+  content: "\f14d";
+}
+
+.fa-shekel-sign:before {
+  content: "\f20b";
+}
+
+.fa-shield-alt:before {
+  content: "\f3ed";
+}
+
+.fa-ship:before {
+  content: "\f21a";
+}
+
+.fa-shipping-fast:before {
+  content: "\f48b";
+}
+
+.fa-shirtsinbulk:before {
+  content: "\f214";
+}
+
+.fa-shoe-prints:before {
+  content: "\f54b";
+}
+
+.fa-shopping-bag:before {
+  content: "\f290";
+}
+
+.fa-shopping-basket:before {
+  content: "\f291";
+}
+
+.fa-shopping-cart:before {
+  content: "\f07a";
+}
+
+.fa-shopware:before {
+  content: "\f5b5";
+}
+
+.fa-shower:before {
+  content: "\f2cc";
+}
+
+.fa-shuttle-van:before {
+  content: "\f5b6";
+}
+
+.fa-sign:before {
+  content: "\f4d9";
+}
+
+.fa-sign-in-alt:before {
+  content: "\f2f6";
+}
+
+.fa-sign-language:before {
+  content: "\f2a7";
+}
+
+.fa-sign-out-alt:before {
+  content: "\f2f5";
+}
+
+.fa-signal:before {
+  content: "\f012";
+}
+
+.fa-signature:before {
+  content: "\f5b7";
+}
+
+.fa-sim-card:before {
+  content: "\f7c4";
+}
+
+.fa-simplybuilt:before {
+  content: "\f215";
+}
+
+.fa-sistrix:before {
+  content: "\f3ee";
+}
+
+.fa-sitemap:before {
+  content: "\f0e8";
+}
+
+.fa-sith:before {
+  content: "\f512";
+}
+
+.fa-skating:before {
+  content: "\f7c5";
+}
+
+.fa-sketch:before {
+  content: "\f7c6";
+}
+
+.fa-skiing:before {
+  content: "\f7c9";
+}
+
+.fa-skiing-nordic:before {
+  content: "\f7ca";
+}
+
+.fa-skull:before {
+  content: "\f54c";
+}
+
+.fa-skull-crossbones:before {
+  content: "\f714";
+}
+
+.fa-skyatlas:before {
+  content: "\f216";
+}
+
+.fa-skype:before {
+  content: "\f17e";
+}
+
+.fa-slack:before {
+  content: "\f198";
+}
+
+.fa-slack-hash:before {
+  content: "\f3ef";
+}
+
+.fa-slash:before {
+  content: "\f715";
+}
+
+.fa-sleigh:before {
+  content: "\f7cc";
+}
+
+.fa-sliders-h:before {
+  content: "\f1de";
+}
+
+.fa-slideshare:before {
+  content: "\f1e7";
+}
+
+.fa-smile:before {
+  content: "\f118";
+}
+
+.fa-smile-beam:before {
+  content: "\f5b8";
+}
+
+.fa-smile-wink:before {
+  content: "\f4da";
+}
+
+.fa-smog:before {
+  content: "\f75f";
+}
+
+.fa-smoking:before {
+  content: "\f48d";
+}
+
+.fa-smoking-ban:before {
+  content: "\f54d";
+}
+
+.fa-sms:before {
+  content: "\f7cd";
+}
+
+.fa-snapchat:before {
+  content: "\f2ab";
+}
+
+.fa-snapchat-ghost:before {
+  content: "\f2ac";
+}
+
+.fa-snapchat-square:before {
+  content: "\f2ad";
+}
+
+.fa-snowboarding:before {
+  content: "\f7ce";
+}
+
+.fa-snowflake:before {
+  content: "\f2dc";
+}
+
+.fa-snowman:before {
+  content: "\f7d0";
+}
+
+.fa-snowplow:before {
+  content: "\f7d2";
+}
+
+.fa-socks:before {
+  content: "\f696";
+}
+
+.fa-solar-panel:before {
+  content: "\f5ba";
+}
+
+.fa-sort:before {
+  content: "\f0dc";
+}
+
+.fa-sort-alpha-down:before {
+  content: "\f15d";
+}
+
+.fa-sort-alpha-up:before {
+  content: "\f15e";
+}
+
+.fa-sort-amount-down:before {
+  content: "\f160";
+}
+
+.fa-sort-amount-up:before {
+  content: "\f161";
+}
+
+.fa-sort-down:before {
+  content: "\f0dd";
+}
+
+.fa-sort-numeric-down:before {
+  content: "\f162";
+}
+
+.fa-sort-numeric-up:before {
+  content: "\f163";
+}
+
+.fa-sort-up:before {
+  content: "\f0de";
+}
+
+.fa-soundcloud:before {
+  content: "\f1be";
+}
+
+.fa-sourcetree:before {
+  content: "\f7d3";
+}
+
+.fa-spa:before {
+  content: "\f5bb";
+}
+
+.fa-space-shuttle:before {
+  content: "\f197";
+}
+
+.fa-speakap:before {
+  content: "\f3f3";
+}
+
+.fa-spider:before {
+  content: "\f717";
+}
+
+.fa-spinner:before {
+  content: "\f110";
+}
+
+.fa-splotch:before {
+  content: "\f5bc";
+}
+
+.fa-spotify:before {
+  content: "\f1bc";
+}
+
+.fa-spray-can:before {
+  content: "\f5bd";
+}
+
+.fa-square:before {
+  content: "\f0c8";
+}
+
+.fa-square-full:before {
+  content: "\f45c";
+}
+
+.fa-square-root-alt:before {
+  content: "\f698";
+}
+
+.fa-squarespace:before {
+  content: "\f5be";
+}
+
+.fa-stack-exchange:before {
+  content: "\f18d";
+}
+
+.fa-stack-overflow:before {
+  content: "\f16c";
+}
+
+.fa-stamp:before {
+  content: "\f5bf";
+}
+
+.fa-star:before {
+  content: "\f005";
+}
+
+.fa-star-and-crescent:before {
+  content: "\f699";
+}
+
+.fa-star-half:before {
+  content: "\f089";
+}
+
+.fa-star-half-alt:before {
+  content: "\f5c0";
+}
+
+.fa-star-of-david:before {
+  content: "\f69a";
+}
+
+.fa-star-of-life:before {
+  content: "\f621";
+}
+
+.fa-staylinked:before {
+  content: "\f3f5";
+}
+
+.fa-steam:before {
+  content: "\f1b6";
+}
+
+.fa-steam-square:before {
+  content: "\f1b7";
+}
+
+.fa-steam-symbol:before {
+  content: "\f3f6";
+}
+
+.fa-step-backward:before {
+  content: "\f048";
+}
+
+.fa-step-forward:before {
+  content: "\f051";
+}
+
+.fa-stethoscope:before {
+  content: "\f0f1";
+}
+
+.fa-sticker-mule:before {
+  content: "\f3f7";
+}
+
+.fa-sticky-note:before {
+  content: "\f249";
+}
+
+.fa-stop:before {
+  content: "\f04d";
+}
+
+.fa-stop-circle:before {
+  content: "\f28d";
+}
+
+.fa-stopwatch:before {
+  content: "\f2f2";
+}
+
+.fa-store:before {
+  content: "\f54e";
+}
+
+.fa-store-alt:before {
+  content: "\f54f";
+}
+
+.fa-strava:before {
+  content: "\f428";
+}
+
+.fa-stream:before {
+  content: "\f550";
+}
+
+.fa-street-view:before {
+  content: "\f21d";
+}
+
+.fa-strikethrough:before {
+  content: "\f0cc";
+}
+
+.fa-stripe:before {
+  content: "\f429";
+}
+
+.fa-stripe-s:before {
+  content: "\f42a";
+}
+
+.fa-stroopwafel:before {
+  content: "\f551";
+}
+
+.fa-studiovinari:before {
+  content: "\f3f8";
+}
+
+.fa-stumbleupon:before {
+  content: "\f1a4";
+}
+
+.fa-stumbleupon-circle:before {
+  content: "\f1a3";
+}
+
+.fa-subscript:before {
+  content: "\f12c";
+}
+
+.fa-subway:before {
+  content: "\f239";
+}
+
+.fa-suitcase:before {
+  content: "\f0f2";
+}
+
+.fa-suitcase-rolling:before {
+  content: "\f5c1";
+}
+
+.fa-sun:before {
+  content: "\f185";
+}
+
+.fa-superpowers:before {
+  content: "\f2dd";
+}
+
+.fa-superscript:before {
+  content: "\f12b";
+}
+
+.fa-supple:before {
+  content: "\f3f9";
+}
+
+.fa-surprise:before {
+  content: "\f5c2";
+}
+
+.fa-suse:before {
+  content: "\f7d6";
+}
+
+.fa-swatchbook:before {
+  content: "\f5c3";
+}
+
+.fa-swimmer:before {
+  content: "\f5c4";
+}
+
+.fa-swimming-pool:before {
+  content: "\f5c5";
+}
+
+.fa-synagogue:before {
+  content: "\f69b";
+}
+
+.fa-sync:before {
+  content: "\f021";
+}
+
+.fa-sync-alt:before {
+  content: "\f2f1";
+}
+
+.fa-syringe:before {
+  content: "\f48e";
+}
+
+.fa-table:before {
+  content: "\f0ce";
+}
+
+.fa-table-tennis:before {
+  content: "\f45d";
+}
+
+.fa-tablet:before {
+  content: "\f10a";
+}
+
+.fa-tablet-alt:before {
+  content: "\f3fa";
+}
+
+.fa-tablets:before {
+  content: "\f490";
+}
+
+.fa-tachometer-alt:before {
+  content: "\f3fd";
+}
+
+.fa-tag:before {
+  content: "\f02b";
+}
+
+.fa-tags:before {
+  content: "\f02c";
+}
+
+.fa-tape:before {
+  content: "\f4db";
+}
+
+.fa-tasks:before {
+  content: "\f0ae";
+}
+
+.fa-taxi:before {
+  content: "\f1ba";
+}
+
+.fa-teamspeak:before {
+  content: "\f4f9";
+}
+
+.fa-teeth:before {
+  content: "\f62e";
+}
+
+.fa-teeth-open:before {
+  content: "\f62f";
+}
+
+.fa-telegram:before {
+  content: "\f2c6";
+}
+
+.fa-telegram-plane:before {
+  content: "\f3fe";
+}
+
+.fa-temperature-high:before {
+  content: "\f769";
+}
+
+.fa-temperature-low:before {
+  content: "\f76b";
+}
+
+.fa-tencent-weibo:before {
+  content: "\f1d5";
+}
+
+.fa-tenge:before {
+  content: "\f7d7";
+}
+
+.fa-terminal:before {
+  content: "\f120";
+}
+
+.fa-text-height:before {
+  content: "\f034";
+}
+
+.fa-text-width:before {
+  content: "\f035";
+}
+
+.fa-th:before {
+  content: "\f00a";
+}
+
+.fa-th-large:before {
+  content: "\f009";
+}
+
+.fa-th-list:before {
+  content: "\f00b";
+}
+
+.fa-the-red-yeti:before {
+  content: "\f69d";
+}
+
+.fa-theater-masks:before {
+  content: "\f630";
+}
+
+.fa-themeco:before {
+  content: "\f5c6";
+}
+
+.fa-themeisle:before {
+  content: "\f2b2";
+}
+
+.fa-thermometer:before {
+  content: "\f491";
+}
+
+.fa-thermometer-empty:before {
+  content: "\f2cb";
+}
+
+.fa-thermometer-full:before {
+  content: "\f2c7";
+}
+
+.fa-thermometer-half:before {
+  content: "\f2c9";
+}
+
+.fa-thermometer-quarter:before {
+  content: "\f2ca";
+}
+
+.fa-thermometer-three-quarters:before {
+  content: "\f2c8";
+}
+
+.fa-think-peaks:before {
+  content: "\f731";
+}
+
+.fa-thumbs-down:before {
+  content: "\f165";
+}
+
+.fa-thumbs-up:before {
+  content: "\f164";
+}
+
+.fa-thumbtack:before {
+  content: "\f08d";
+}
+
+.fa-ticket-alt:before {
+  content: "\f3ff";
+}
+
+.fa-times:before {
+  content: "\f00d";
+}
+
+.fa-times-circle:before {
+  content: "\f057";
+}
+
+.fa-tint:before {
+  content: "\f043";
+}
+
+.fa-tint-slash:before {
+  content: "\f5c7";
+}
+
+.fa-tired:before {
+  content: "\f5c8";
+}
+
+.fa-toggle-off:before {
+  content: "\f204";
+}
+
+.fa-toggle-on:before {
+  content: "\f205";
+}
+
+.fa-toilet:before {
+  content: "\f7d8";
+}
+
+.fa-toilet-paper:before {
+  content: "\f71e";
+}
+
+.fa-toolbox:before {
+  content: "\f552";
+}
+
+.fa-tools:before {
+  content: "\f7d9";
+}
+
+.fa-tooth:before {
+  content: "\f5c9";
+}
+
+.fa-torah:before {
+  content: "\f6a0";
+}
+
+.fa-torii-gate:before {
+  content: "\f6a1";
+}
+
+.fa-tractor:before {
+  content: "\f722";
+}
+
+.fa-trade-federation:before {
+  content: "\f513";
+}
+
+.fa-trademark:before {
+  content: "\f25c";
+}
+
+.fa-traffic-light:before {
+  content: "\f637";
+}
+
+.fa-train:before {
+  content: "\f238";
+}
+
+.fa-tram:before {
+  content: "\f7da";
+}
+
+.fa-transgender:before {
+  content: "\f224";
+}
+
+.fa-transgender-alt:before {
+  content: "\f225";
+}
+
+.fa-trash:before {
+  content: "\f1f8";
+}
+
+.fa-trash-alt:before {
+  content: "\f2ed";
+}
+
+.fa-tree:before {
+  content: "\f1bb";
+}
+
+.fa-trello:before {
+  content: "\f181";
+}
+
+.fa-tripadvisor:before {
+  content: "\f262";
+}
+
+.fa-trophy:before {
+  content: "\f091";
+}
+
+.fa-truck:before {
+  content: "\f0d1";
+}
+
+.fa-truck-loading:before {
+  content: "\f4de";
+}
+
+.fa-truck-monster:before {
+  content: "\f63b";
+}
+
+.fa-truck-moving:before {
+  content: "\f4df";
+}
+
+.fa-truck-pickup:before {
+  content: "\f63c";
+}
+
+.fa-tshirt:before {
+  content: "\f553";
+}
+
+.fa-tty:before {
+  content: "\f1e4";
+}
+
+.fa-tumblr:before {
+  content: "\f173";
+}
+
+.fa-tumblr-square:before {
+  content: "\f174";
+}
+
+.fa-tv:before {
+  content: "\f26c";
+}
+
+.fa-twitch:before {
+  content: "\f1e8";
+}
+
+.fa-twitter:before {
+  content: "\f099";
+}
+
+.fa-twitter-square:before {
+  content: "\f081";
+}
+
+.fa-typo3:before {
+  content: "\f42b";
+}
+
+.fa-uber:before {
+  content: "\f402";
+}
+
+.fa-ubuntu:before {
+  content: "\f7df";
+}
+
+.fa-uikit:before {
+  content: "\f403";
+}
+
+.fa-umbrella:before {
+  content: "\f0e9";
+}
+
+.fa-umbrella-beach:before {
+  content: "\f5ca";
+}
+
+.fa-underline:before {
+  content: "\f0cd";
+}
+
+.fa-undo:before {
+  content: "\f0e2";
+}
+
+.fa-undo-alt:before {
+  content: "\f2ea";
+}
+
+.fa-uniregistry:before {
+  content: "\f404";
+}
+
+.fa-universal-access:before {
+  content: "\f29a";
+}
+
+.fa-university:before {
+  content: "\f19c";
+}
+
+.fa-unlink:before {
+  content: "\f127";
+}
+
+.fa-unlock:before {
+  content: "\f09c";
+}
+
+.fa-unlock-alt:before {
+  content: "\f13e";
+}
+
+.fa-untappd:before {
+  content: "\f405";
+}
+
+.fa-upload:before {
+  content: "\f093";
+}
+
+.fa-ups:before {
+  content: "\f7e0";
+}
+
+.fa-usb:before {
+  content: "\f287";
+}
+
+.fa-user:before {
+  content: "\f007";
+}
+
+.fa-user-alt:before {
+  content: "\f406";
+}
+
+.fa-user-alt-slash:before {
+  content: "\f4fa";
+}
+
+.fa-user-astronaut:before {
+  content: "\f4fb";
+}
+
+.fa-user-check:before {
+  content: "\f4fc";
+}
+
+.fa-user-circle:before {
+  content: "\f2bd";
+}
+
+.fa-user-clock:before {
+  content: "\f4fd";
+}
+
+.fa-user-cog:before {
+  content: "\f4fe";
+}
+
+.fa-user-edit:before {
+  content: "\f4ff";
+}
+
+.fa-user-friends:before {
+  content: "\f500";
+}
+
+.fa-user-graduate:before {
+  content: "\f501";
+}
+
+.fa-user-injured:before {
+  content: "\f728";
+}
+
+.fa-user-lock:before {
+  content: "\f502";
+}
+
+.fa-user-md:before {
+  content: "\f0f0";
+}
+
+.fa-user-minus:before {
+  content: "\f503";
+}
+
+.fa-user-ninja:before {
+  content: "\f504";
+}
+
+.fa-user-plus:before {
+  content: "\f234";
+}
+
+.fa-user-secret:before {
+  content: "\f21b";
+}
+
+.fa-user-shield:before {
+  content: "\f505";
+}
+
+.fa-user-slash:before {
+  content: "\f506";
+}
+
+.fa-user-tag:before {
+  content: "\f507";
+}
+
+.fa-user-tie:before {
+  content: "\f508";
+}
+
+.fa-user-times:before {
+  content: "\f235";
+}
+
+.fa-users:before {
+  content: "\f0c0";
+}
+
+.fa-users-cog:before {
+  content: "\f509";
+}
+
+.fa-usps:before {
+  content: "\f7e1";
+}
+
+.fa-ussunnah:before {
+  content: "\f407";
+}
+
+.fa-utensil-spoon:before {
+  content: "\f2e5";
+}
+
+.fa-utensils:before {
+  content: "\f2e7";
+}
+
+.fa-vaadin:before {
+  content: "\f408";
+}
+
+.fa-vector-square:before {
+  content: "\f5cb";
+}
+
+.fa-venus:before {
+  content: "\f221";
+}
+
+.fa-venus-double:before {
+  content: "\f226";
+}
+
+.fa-venus-mars:before {
+  content: "\f228";
+}
+
+.fa-viacoin:before {
+  content: "\f237";
+}
+
+.fa-viadeo:before {
+  content: "\f2a9";
+}
+
+.fa-viadeo-square:before {
+  content: "\f2aa";
+}
+
+.fa-vial:before {
+  content: "\f492";
+}
+
+.fa-vials:before {
+  content: "\f493";
+}
+
+.fa-viber:before {
+  content: "\f409";
+}
+
+.fa-video:before {
+  content: "\f03d";
+}
+
+.fa-video-slash:before {
+  content: "\f4e2";
+}
+
+.fa-vihara:before {
+  content: "\f6a7";
+}
+
+.fa-vimeo:before {
+  content: "\f40a";
+}
+
+.fa-vimeo-square:before {
+  content: "\f194";
+}
+
+.fa-vimeo-v:before {
+  content: "\f27d";
+}
+
+.fa-vine:before {
+  content: "\f1ca";
+}
+
+.fa-vk:before {
+  content: "\f189";
+}
+
+.fa-vnv:before {
+  content: "\f40b";
+}
+
+.fa-volleyball-ball:before {
+  content: "\f45f";
+}
+
+.fa-volume-down:before {
+  content: "\f027";
+}
+
+.fa-volume-mute:before {
+  content: "\f6a9";
+}
+
+.fa-volume-off:before {
+  content: "\f026";
+}
+
+.fa-volume-up:before {
+  content: "\f028";
+}
+
+.fa-vote-yea:before {
+  content: "\f772";
+}
+
+.fa-vr-cardboard:before {
+  content: "\f729";
+}
+
+.fa-vuejs:before {
+  content: "\f41f";
+}
+
+.fa-walking:before {
+  content: "\f554";
+}
+
+.fa-wallet:before {
+  content: "\f555";
+}
+
+.fa-warehouse:before {
+  content: "\f494";
+}
+
+.fa-water:before {
+  content: "\f773";
+}
+
+.fa-weebly:before {
+  content: "\f5cc";
+}
+
+.fa-weibo:before {
+  content: "\f18a";
+}
+
+.fa-weight:before {
+  content: "\f496";
+}
+
+.fa-weight-hanging:before {
+  content: "\f5cd";
+}
+
+.fa-weixin:before {
+  content: "\f1d7";
+}
+
+.fa-whatsapp:before {
+  content: "\f232";
+}
+
+.fa-whatsapp-square:before {
+  content: "\f40c";
+}
+
+.fa-wheelchair:before {
+  content: "\f193";
+}
+
+.fa-whmcs:before {
+  content: "\f40d";
+}
+
+.fa-wifi:before {
+  content: "\f1eb";
+}
+
+.fa-wikipedia-w:before {
+  content: "\f266";
+}
+
+.fa-wind:before {
+  content: "\f72e";
+}
+
+.fa-window-close:before {
+  content: "\f410";
+}
+
+.fa-window-maximize:before {
+  content: "\f2d0";
+}
+
+.fa-window-minimize:before {
+  content: "\f2d1";
+}
+
+.fa-window-restore:before {
+  content: "\f2d2";
+}
+
+.fa-windows:before {
+  content: "\f17a";
+}
+
+.fa-wine-bottle:before {
+  content: "\f72f";
+}
+
+.fa-wine-glass:before {
+  content: "\f4e3";
+}
+
+.fa-wine-glass-alt:before {
+  content: "\f5ce";
+}
+
+.fa-wix:before {
+  content: "\f5cf";
+}
+
+.fa-wizards-of-the-coast:before {
+  content: "\f730";
+}
+
+.fa-wolf-pack-battalion:before {
+  content: "\f514";
+}
+
+.fa-won-sign:before {
+  content: "\f159";
+}
+
+.fa-wordpress:before {
+  content: "\f19a";
+}
+
+.fa-wordpress-simple:before {
+  content: "\f411";
+}
+
+.fa-wpbeginner:before {
+  content: "\f297";
+}
+
+.fa-wpexplorer:before {
+  content: "\f2de";
+}
+
+.fa-wpforms:before {
+  content: "\f298";
+}
+
+.fa-wpressr:before {
+  content: "\f3e4";
+}
+
+.fa-wrench:before {
+  content: "\f0ad";
+}
+
+.fa-x-ray:before {
+  content: "\f497";
+}
+
+.fa-xbox:before {
+  content: "\f412";
+}
+
+.fa-xing:before {
+  content: "\f168";
+}
+
+.fa-xing-square:before {
+  content: "\f169";
+}
+
+.fa-y-combinator:before {
+  content: "\f23b";
+}
+
+.fa-yahoo:before {
+  content: "\f19e";
+}
+
+.fa-yandex:before {
+  content: "\f413";
+}
+
+.fa-yandex-international:before {
+  content: "\f414";
+}
+
+.fa-yarn:before {
+  content: "\f7e3";
+}
+
+.fa-yelp:before {
+  content: "\f1e9";
+}
+
+.fa-yen-sign:before {
+  content: "\f157";
+}
+
+.fa-yin-yang:before {
+  content: "\f6ad";
+}
+
+.fa-yoast:before {
+  content: "\f2b1";
+}
+
+.fa-youtube:before {
+  content: "\f167";
+}
+
+.fa-youtube-square:before {
+  content: "\f431";
+}
+
+.fa-zhihu:before {
+  content: "\f63f";
+}
+
+.fa,
+.fa,
+.fas,
+.far,
+.fal,
+.fab {
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  font-style: normal;
+  font-variant: normal;
+  text-rendering: auto;
+  line-height: 1;
+}
+
+@font-face {
+  font-family: "pf-v6-pficon";
+  src: url("./assets/pficon/pf-v6-pficon.woff2") format("woff2");
+}
+.pf-v6-pficon-zone:before, .pf-v6-pficon-warning-triangle:before, .pf-v6-pficon-volume:before, .pf-v6-pficon-virtual-machine:before, .pf-v6-pficon-users:before, .pf-v6-pficon-user:before, .pf-v6-pficon-unplugged:before, .pf-v6-pficon-unlocked:before, .pf-v6-pficon-unknown:before, .pf-v6-pficon-trend-up:before, .pf-v6-pficon-trend-down:before, .pf-v6-pficon-treeview:before, .pf-v6-pficon-topology:before, .pf-v6-pficon-thumb-tack:before, .pf-v6-pficon-tenant:before, .pf-v6-pficon-task:before, .pf-v6-pficon-storage-domain:before, .pf-v6-pficon-spinner2:before, .pf-v6-pficon-spinner:before, .pf-v6-pficon-severity-undefined:before, .pf-v6-pficon-severity-none:before, .pf-v6-pficon-severity-moderate:before, .pf-v6-pficon-severity-minor:before, .pf-v6-pficon-severity-important:before, .pf-v6-pficon-severity-critical:before, .pf-v6-pficon-services:before, .pf-v6-pficon-service:before, .pf-v6-pficon-service-catalog:before, .pf-v6-pficon-server:before, .pf-v6-pficon-server-group:before, .pf-v6-pficon-security:before, .pf-v6-pficon-screen:before, .pf-v6-pficon-save:before, .pf-v6-pficon-running:before, .pf-v6-pficon-resources-full:before, .pf-v6-pficon-resources-empty:before, .pf-v6-pficon-resources-almost-full:before, .pf-v6-pficon-resources-almost-empty:before, .pf-v6-pficon-resource-pool:before, .pf-v6-pficon-repository:before, .pf-v6-pficon-replicator:before, .pf-v6-pficon-remove2:before, .pf-v6-pficon-registry:before, .pf-v6-pficon-regions:before, .pf-v6-pficon-rebooting:before, .pf-v6-pficon-rebalance:before, .pf-v6-pficon-project:before, .pf-v6-pficon-process-automation:before, .pf-v6-pficon-private:before, .pf-v6-pficon-print:before, .pf-v6-pficon-port:before, .pf-v6-pficon-plugged:before, .pf-v6-pficon-pficon-vcenter:before, .pf-v6-pficon-pficon-template:before, .pf-v6-pficon-pficon-sort-common-desc:before, .pf-v6-pficon-pficon-sort-common-asc:before, .pf-v6-pficon-pficon-satellite:before, .pf-v6-pficon-pficon-network-range:before, .pf-v6-pficon-pficon-history:before, .pf-v6-pficon-pficon-dragdrop:before, .pf-v6-pficon-pending:before, .pf-v6-pficon-paused:before, .pf-v6-pficon-panel-open:before, .pf-v6-pficon-panel-close:before, .pf-v6-pficon-package:before, .pf-v6-pficon-os-image:before, .pf-v6-pficon-orders:before, .pf-v6-pficon-optimize:before, .pf-v6-pficon-openstack:before, .pf-v6-pficon-openshift:before, .pf-v6-pficon-open-drawer-right:before, .pf-v6-pficon-on:before, .pf-v6-pficon-on-running:before, .pf-v6-pficon-ok:before, .pf-v6-pficon-off:before, .pf-v6-pficon-not-started:before, .pf-v6-pficon-new-process:before, .pf-v6-pficon-network:before, .pf-v6-pficon-namespaces:before, .pf-v6-pficon-multicluster:before, .pf-v6-pficon-monitoring:before, .pf-v6-pficon-module:before, .pf-v6-pficon-migration:before, .pf-v6-pficon-middleware:before, .pf-v6-pficon-messages:before, .pf-v6-pficon-memory:before, .pf-v6-pficon-maintenance:before, .pf-v6-pficon-locked:before, .pf-v6-pficon-key:before, .pf-v6-pficon-integration:before, .pf-v6-pficon-infrastructure:before, .pf-v6-pficon-info:before, .pf-v6-pficon-in-progress:before, .pf-v6-pficon-import:before, .pf-v6-pficon-home:before, .pf-v6-pficon-history:before, .pf-v6-pficon-help:before, .pf-v6-pficon-globe-route:before, .pf-v6-pficon-folder-open:before, .pf-v6-pficon-folder-close:before, .pf-v6-pficon-flavor:before, .pf-v6-pficon-filter:before, .pf-v6-pficon-export:before, .pf-v6-pficon-error-circle-o:before, .pf-v6-pficon-equalizer:before, .pf-v6-pficon-enterprise:before, .pf-v6-pficon-enhancement:before, .pf-v6-pficon-edit:before, .pf-v6-pficon-domain:before, .pf-v6-pficon-disconnected:before, .pf-v6-pficon-degraded:before, .pf-v6-pficon-data-source:before, .pf-v6-pficon-data-sink:before, .pf-v6-pficon-data-processor:before, .pf-v6-pficon-critical-risk:before, .pf-v6-pficon-cpu:before, .pf-v6-pficon-container-node:before, .pf-v6-pficon-connected:before, .pf-v6-pficon-cluster:before, .pf-v6-pficon-cloud-tenant:before, .pf-v6-pficon-cloud-security:before, .pf-v6-pficon-close:before, .pf-v6-pficon-chat:before, .pf-v6-pficon-catalog:before, .pf-v6-pficon-bundle:before, .pf-v6-pficon-builder-image:before, .pf-v6-pficon-build:before, .pf-v6-pficon-blueprint:before, .pf-v6-pficon-bell:before, .pf-v6-pficon-automation:before, .pf-v6-pficon-attention-bell:before, .pf-v6-pficon-asleep:before, .pf-v6-pficon-arrow:before, .pf-v6-pficon-applications:before, .pf-v6-pficon-ansible-tower:before, .pf-v6-pficon-add-circle-o:before {
+  font-family: "pf-v6-pficon";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-style: normal;
+  font-variant: normal;
+  font-weight: normal;
+  text-decoration-line: none;
+  text-transform: none;
+}
+
+.pf-v6-pficon-add-circle-o:before {
+  content: "\e61b";
+}
+
+.pf-v6-pficon-ansible-tower:before {
+  content: "\e950";
+}
+
+.pf-v6-pficon-applications:before {
+  content: "\e936";
+}
+
+.pf-v6-pficon-arrow:before {
+  content: "\e929";
+}
+
+.pf-v6-pficon-asleep:before {
+  content: "\e92e";
+}
+
+.pf-v6-pficon-attention-bell:before {
+  content: "\e951";
+}
+
+.pf-v6-pficon-automation:before {
+  content: "\e937";
+}
+
+.pf-v6-pficon-bell:before {
+  content: "\e952";
+}
+
+.pf-v6-pficon-blueprint:before {
+  content: "\e915";
+}
+
+.pf-v6-pficon-build:before {
+  content: "\e902";
+}
+
+.pf-v6-pficon-builder-image:before {
+  content: "\e800";
+}
+
+.pf-v6-pficon-bundle:before {
+  content: "\e918";
+}
+
+.pf-v6-pficon-catalog:before {
+  content: "\e953";
+}
+
+.pf-v6-pficon-chat:before {
+  content: "\e954";
+}
+
+.pf-v6-pficon-close:before {
+  content: "\e60b";
+}
+
+.pf-v6-pficon-cloud-security:before {
+  content: "\e903";
+}
+
+.pf-v6-pficon-cloud-tenant:before {
+  content: "\e904";
+}
+
+.pf-v6-pficon-cluster:before {
+  content: "\e620";
+}
+
+.pf-v6-pficon-connected:before {
+  content: "\e938";
+}
+
+.pf-v6-pficon-container-node:before {
+  content: "\e621";
+}
+
+.pf-v6-pficon-cpu:before {
+  content: "\e927";
+}
+
+.pf-v6-pficon-critical-risk:before {
+  content: "\e976";
+}
+
+.pf-v6-pficon-data-processor:before {
+  content: "\e97b";
+}
+
+.pf-v6-pficon-data-sink:before {
+  content: "\e978";
+}
+
+.pf-v6-pficon-data-source:before {
+  content: "\e979";
+}
+
+.pf-v6-pficon-degraded:before {
+  content: "\e91b";
+}
+
+.pf-v6-pficon-disconnected:before {
+  content: "\e955";
+}
+
+.pf-v6-pficon-domain:before {
+  content: "\e919";
+}
+
+.pf-v6-pficon-edit:before {
+  content: "\e60a";
+}
+
+.pf-v6-pficon-enhancement:before {
+  content: "\e93a";
+}
+
+.pf-v6-pficon-enterprise:before {
+  content: "\e906";
+}
+
+.pf-v6-pficon-equalizer:before {
+  content: "\e956";
+}
+
+.pf-v6-pficon-error-circle-o:before {
+  content: "\e926";
+}
+
+.pf-v6-pficon-export:before {
+  content: "\e616";
+}
+
+.pf-v6-pficon-filter:before {
+  content: "\e943";
+}
+
+.pf-v6-pficon-flavor:before {
+  content: "\e957";
+}
+
+.pf-v6-pficon-folder-close:before {
+  content: "\e607";
+}
+
+.pf-v6-pficon-folder-open:before {
+  content: "\e606";
+}
+
+.pf-v6-pficon-globe-route:before {
+  content: "\e958";
+}
+
+.pf-v6-pficon-help:before {
+  content: "\e605";
+}
+
+.pf-v6-pficon-history:before {
+  content: "\e617";
+}
+
+.pf-v6-pficon-home:before {
+  content: "\e618";
+}
+
+.pf-v6-pficon-import:before {
+  content: "\e615";
+}
+
+.pf-v6-pficon-in-progress:before {
+  content: "\e933";
+}
+
+.pf-v6-pficon-info:before {
+  content: "\e92b";
+}
+
+.pf-v6-pficon-infrastructure:before {
+  content: "\e93d";
+}
+
+.pf-v6-pficon-integration:before {
+  content: "\e948";
+}
+
+.pf-v6-pficon-key:before {
+  content: "\e924";
+}
+
+.pf-v6-pficon-locked:before {
+  content: "\e923";
+}
+
+.pf-v6-pficon-maintenance:before {
+  content: "\e932";
+}
+
+.pf-v6-pficon-memory:before {
+  content: "\e908";
+}
+
+.pf-v6-pficon-messages:before {
+  content: "\e603";
+}
+
+.pf-v6-pficon-middleware:before {
+  content: "\e917";
+}
+
+.pf-v6-pficon-migration:before {
+  content: "\e931";
+}
+
+.pf-v6-pficon-module:before {
+  content: "\e959";
+}
+
+.pf-v6-pficon-monitoring:before {
+  content: "\e95a";
+}
+
+.pf-v6-pficon-multicluster:before {
+  content: "\e97c";
+}
+
+.pf-v6-pficon-namespaces:before {
+  content: "\e95b";
+}
+
+.pf-v6-pficon-network:before {
+  content: "\e909";
+}
+
+.pf-v6-pficon-new-process:before {
+  content: "\e95c";
+}
+
+.pf-v6-pficon-not-started:before {
+  content: "\e95d";
+}
+
+.pf-v6-pficon-off:before {
+  content: "\e92d";
+}
+
+.pf-v6-pficon-ok:before {
+  content: "\e602";
+}
+
+.pf-v6-pficon-on-running:before {
+  content: "\e925";
+}
+
+.pf-v6-pficon-on:before {
+  content: "\e92c";
+}
+
+.pf-v6-pficon-open-drawer-right:before {
+  content: "\e977";
+}
+
+.pf-v6-pficon-openshift:before {
+  content: "\e95e";
+}
+
+.pf-v6-pficon-openstack:before {
+  content: "\e95f";
+}
+
+.pf-v6-pficon-optimize:before {
+  content: "\e93e";
+}
+
+.pf-v6-pficon-orders:before {
+  content: "\e93f";
+}
+
+.pf-v6-pficon-os-image:before {
+  content: "\e960";
+}
+
+.pf-v6-pficon-package:before {
+  content: "\e961";
+}
+
+.pf-v6-pficon-panel-close:before {
+  content: "\e962";
+}
+
+.pf-v6-pficon-panel-open:before {
+  content: "\e963";
+}
+
+.pf-v6-pficon-paused:before {
+  content: "\e92f";
+}
+
+.pf-v6-pficon-pending:before {
+  content: "\e964";
+}
+
+.pf-v6-pficon-pficon-dragdrop:before {
+  content: "\e965";
+}
+
+.pf-v6-pficon-pficon-history:before {
+  content: "\e966";
+}
+
+.pf-v6-pficon-pficon-network-range:before {
+  content: "\e967";
+}
+
+.pf-v6-pficon-pficon-satellite:before {
+  content: "\e968";
+}
+
+.pf-v6-pficon-pficon-sort-common-asc:before {
+  content: "\e94e";
+}
+
+.pf-v6-pficon-pficon-sort-common-desc:before {
+  content: "\e94f";
+}
+
+.pf-v6-pficon-pficon-template:before {
+  content: "\e94c";
+}
+
+.pf-v6-pficon-pficon-vcenter:before {
+  content: "\e969";
+}
+
+.pf-v6-pficon-plugged:before {
+  content: "\e96a";
+}
+
+.pf-v6-pficon-port:before {
+  content: "\e96b";
+}
+
+.pf-v6-pficon-print:before {
+  content: "\e612";
+}
+
+.pf-v6-pficon-private:before {
+  content: "\e914";
+}
+
+.pf-v6-pficon-process-automation:before {
+  content: "\e949";
+}
+
+.pf-v6-pficon-project:before {
+  content: "\e96c";
+}
+
+.pf-v6-pficon-rebalance:before {
+  content: "\e91c";
+}
+
+.pf-v6-pficon-rebooting:before {
+  content: "\e96d";
+}
+
+.pf-v6-pficon-regions:before {
+  content: "\e90a";
+}
+
+.pf-v6-pficon-registry:before {
+  content: "\e623";
+}
+
+.pf-v6-pficon-remove2:before {
+  content: "\e96e";
+}
+
+.pf-v6-pficon-replicator:before {
+  content: "\e624";
+}
+
+.pf-v6-pficon-repository:before {
+  content: "\e90b";
+}
+
+.pf-v6-pficon-resource-pool:before {
+  content: "\e90c";
+}
+
+.pf-v6-pficon-resources-almost-empty:before {
+  content: "\e91d";
+}
+
+.pf-v6-pficon-resources-almost-full:before {
+  content: "\e912";
+}
+
+.pf-v6-pficon-resources-empty:before {
+  content: "\e96f";
+}
+
+.pf-v6-pficon-resources-full:before {
+  content: "\e913";
+}
+
+.pf-v6-pficon-running:before {
+  content: "\e970";
+}
+
+.pf-v6-pficon-save:before {
+  content: "\e601";
+}
+
+.pf-v6-pficon-screen:before {
+  content: "\e971";
+}
+
+.pf-v6-pficon-security:before {
+  content: "\e946";
+}
+
+.pf-v6-pficon-server-group:before {
+  content: "\e91a";
+}
+
+.pf-v6-pficon-server:before {
+  content: "\e90d";
+}
+
+.pf-v6-pficon-service-catalog:before {
+  content: "\e972";
+}
+
+.pf-v6-pficon-service:before {
+  content: "\e61e";
+}
+
+.pf-v6-pficon-services:before {
+  content: "\e947";
+}
+
+.pf-v6-pficon-severity-critical:before {
+  content: "\e97e";
+}
+
+.pf-v6-pficon-severity-important:before {
+  content: "\e97f";
+}
+
+.pf-v6-pficon-severity-minor:before {
+  content: "\e980";
+}
+
+.pf-v6-pficon-severity-moderate:before {
+  content: "\e981";
+}
+
+.pf-v6-pficon-severity-none:before {
+  content: "\e982";
+}
+
+.pf-v6-pficon-severity-undefined:before {
+  content: "\e983";
+}
+
+.pf-v6-pficon-spinner:before {
+  content: "\e973";
+}
+
+.pf-v6-pficon-spinner2:before {
+  content: "\e613";
+}
+
+.pf-v6-pficon-storage-domain:before {
+  content: "\e90e";
+}
+
+.pf-v6-pficon-task:before {
+  content: "\e974";
+}
+
+.pf-v6-pficon-tenant:before {
+  content: "\e916";
+}
+
+.pf-v6-pficon-thumb-tack:before {
+  content: "\e920";
+}
+
+.pf-v6-pficon-topology:before {
+  content: "\e608";
+}
+
+.pf-v6-pficon-treeview:before {
+  content: "\e97d";
+}
+
+.pf-v6-pficon-trend-down:before {
+  content: "\e900";
+}
+
+.pf-v6-pficon-trend-up:before {
+  content: "\e901";
+}
+
+.pf-v6-pficon-unknown:before {
+  content: "\e935";
+}
+
+.pf-v6-pficon-unlocked:before {
+  content: "\e922";
+}
+
+.pf-v6-pficon-unplugged:before {
+  content: "\e942";
+}
+
+.pf-v6-pficon-user:before {
+  content: "\e91e";
+}
+
+.pf-v6-pficon-users:before {
+  content: "\e91f";
+}
+
+.pf-v6-pficon-virtual-machine:before {
+  content: "\e90f";
+}
+
+.pf-v6-pficon-volume:before {
+  content: "\e910";
+}
+
+.pf-v6-pficon-warning-triangle:before {
+  content: "\e975";
+}
+
+.pf-v6-pficon-zone:before {
+  content: "\e911";
+}
+
+.pf-v6-svg {
+  width: 1em;
+  height: 1em;
+  vertical-align: -0.125em;
+}
+
+.pf-v6-svg .pf-v6-icon-rh-ui {
+  display: none;
+}
+
+.pf-v6-icon-set-rh-ui .pf-v6-svg .pf-v6-icon-default {
+  display: none;
+}
+.pf-v6-icon-set-rh-ui .pf-v6-svg .pf-v6-icon-rh-ui {
+  display: revert;
+}
+
+.pf-v6-icon-rh-standard {
+  width: 3rem;
+  height: 3rem;
+  color: var(--pf-t--global--icon--color--brand--accent--default);
+}
+
+:root {
+  --pf-v6-global--inverse--multiplier: 1;
+  --pf-t--color--black: #000000;
+  --pf-t--color--blue--10: #e0f0ff;
+  --pf-t--color--blue--20: #b9dafc;
+  --pf-t--color--blue--30: #92c5f9;
+  --pf-t--color--blue--40: #4394e5;
+  --pf-t--color--blue--50: #0066cc;
+  --pf-t--color--blue--60: #004d99;
+  --pf-t--color--blue--70: #003366;
+  --pf-t--color--blue--80: #032142;
+  --pf-t--color--gray--10: #f2f2f2;
+  --pf-t--color--gray--20: #e0e0e0;
+  --pf-t--color--gray--30: #c7c7c7;
+  --pf-t--color--gray--40: #a3a3a3;
+  --pf-t--color--gray--45: #8c8c8c;
+  --pf-t--color--gray--50: #707070;
+  --pf-t--color--gray--60: #4d4d4d;
+  --pf-t--color--gray--70: #383838;
+  --pf-t--color--gray--80: #292929;
+  --pf-t--color--gray--90: #1f1f1f;
+  --pf-t--color--gray--95: #151515;
+  --pf-t--color--green--10: #e9f7df;
+  --pf-t--color--green--20: #d1f1bb;
+  --pf-t--color--green--30: #afdc8f;
+  --pf-t--color--green--40: #87bb62;
+  --pf-t--color--green--50: #63993d;
+  --pf-t--color--green--60: #3d7317;
+  --pf-t--color--green--70: #204d00;
+  --pf-t--color--green--80: #183301;
+  --pf-t--color--orange--10: #ffe8cc;
+  --pf-t--color--orange--20: #fccb8f;
+  --pf-t--color--orange--30: #f8ae54;
+  --pf-t--color--orange--40: #f5921b;
+  --pf-t--color--orange--50: #ca6c0f;
+  --pf-t--color--orange--60: #9e4a06;
+  --pf-t--color--orange--70: #732e00;
+  --pf-t--color--orange--80: #4d1f00;
+  --pf-t--color--purple--10: #ece6ff;
+  --pf-t--color--purple--20: #d0c5f4;
+  --pf-t--color--purple--30: #b6a6e9;
+  --pf-t--color--purple--40: #876fd4;
+  --pf-t--color--purple--50: #5e40be;
+  --pf-t--color--purple--60: #3d2785;
+  --pf-t--color--purple--70: #21134d;
+  --pf-t--color--purple--80: #1b0d33;
+  --pf-t--color--red--05: #fef0f0;
+  --pf-t--color--red--10: #fce3e3;
+  --pf-t--color--red--20: #fbc5c5;
+  --pf-t--color--red--30: #f9a8a8;
+  --pf-t--color--red--40: #f56e6e;
+  --pf-t--color--red--50: #ee0000;
+  --pf-t--color--red--60: #a60000;
+  --pf-t--color--red--70: #5f0000;
+  --pf-t--color--red--80: #3f0000;
+  --pf-t--color--red-orange--10: #ffe3d9;
+  --pf-t--color--red-orange--20: #fbbea8;
+  --pf-t--color--red-orange--30: #f89b78;
+  --pf-t--color--red-orange--40: #f4784a;
+  --pf-t--color--red-orange--50: #f0561d;
+  --pf-t--color--red-orange--60: #b1380b;
+  --pf-t--color--red-orange--70: #731f00;
+  --pf-t--color--red-orange--80: #4c1405;
+  --pf-t--color--teal--10: #daf2f2;
+  --pf-t--color--teal--20: #b9e5e5;
+  --pf-t--color--teal--30: #9ad8d8;
+  --pf-t--color--teal--40: #63bdbd;
+  --pf-t--color--teal--50: #37a3a3;
+  --pf-t--color--teal--60: #147878;
+  --pf-t--color--teal--70: #004d4d;
+  --pf-t--color--teal--80: #003333;
+  --pf-t--color--white: #ffffff;
+  --pf-t--color--yellow--10: #fff4cc;
+  --pf-t--color--yellow--20: #ffe072;
+  --pf-t--color--yellow--30: #ffcc17;
+  --pf-t--color--yellow--40: #dca614;
+  --pf-t--color--yellow--50: #b98412;
+  --pf-t--color--yellow--60: #96640f;
+  --pf-t--color--yellow--70: #73480b;
+  --pf-t--color--yellow--80: #54330b;
+  --pf-t--global--background--color--500: rgba(21, 21, 21, 0.4000);
+  --pf-t--global--background--color--600: rgba(199, 199, 199, 0.2500);
+  --pf-t--global--background--color--700: rgba(199, 199, 199, 0.1000);
+  --pf-t--global--background--color--action--plain--default: rgba(255, 255, 255, 0.0000);
+  --pf-t--global--background--filter--glass--blur--primary: initial;
+  --pf-t--global--border--color--high-contrast: rgba(255, 255, 255, 0.0000);
+  --pf-t--global--border--radius--0: 0px;
+  --pf-t--global--border--radius--100: 4px;
+  --pf-t--global--border--radius--200: 6px;
+  --pf-t--global--border--radius--300: 16px;
+  --pf-t--global--border--radius--400: 24px;
+  --pf-t--global--border--radius--500: 999px;
+  --pf-t--global--border--width--100: 1px;
+  --pf-t--global--border--width--200: 2px;
+  --pf-t--global--border--width--300: 3px;
+  --pf-t--global--border--width--400: 4px;
+  --pf-t--global--border--width--action--plain--clicked: 0px;
+  --pf-t--global--border--width--action--plain--default: 0px;
+  --pf-t--global--border--width--action--plain--hover: 0px;
+  --pf-t--global--border--width--high-contrast--extra-strong: 0px;
+  --pf-t--global--border--width--high-contrast--regular: 0px;
+  --pf-t--global--border--width--high-contrast--strong: 0px;
+  --pf-t--global--box-shadow--X--100: -10px;
+  --pf-t--global--box-shadow--X--200: -4px;
+  --pf-t--global--box-shadow--X--300: -2px;
+  --pf-t--global--box-shadow--X--400: 0px;
+  --pf-t--global--box-shadow--X--50: -20px;
+  --pf-t--global--box-shadow--X--500: 2px;
+  --pf-t--global--box-shadow--X--600: 4px;
+  --pf-t--global--box-shadow--X--700: 10px;
+  --pf-t--global--box-shadow--X--800: 20px;
+  --pf-t--global--box-shadow--Y--100: -10px;
+  --pf-t--global--box-shadow--Y--200: -4px;
+  --pf-t--global--box-shadow--Y--300: -1px;
+  --pf-t--global--box-shadow--Y--400: 0px;
+  --pf-t--global--box-shadow--Y--50: -20px;
+  --pf-t--global--box-shadow--Y--500: 1px;
+  --pf-t--global--box-shadow--Y--600: 4px;
+  --pf-t--global--box-shadow--Y--700: 10px;
+  --pf-t--global--box-shadow--Y--800: 20px;
+  --pf-t--global--box-shadow--blur--100: 6px;
+  --pf-t--global--box-shadow--blur--200: 10px;
+  --pf-t--global--box-shadow--blur--300: 20px;
+  --pf-t--global--box-shadow--color--100: rgba(41, 41, 41, 0.1500);
+  --pf-t--global--box-shadow--color--200: rgba(41, 41, 41, 0.2000);
+  --pf-t--global--box-shadow--spread--100: 0px;
+  --pf-t--global--box-shadow--spread--200: -4px;
+  --pf-t--global--box-shadow--spread--300: -8px;
+  --pf-t--global--box-shadow--spread--400: -20px;
+  --pf-t--global--breakpoint--100: 0rem;
+  --pf-t--global--breakpoint--200: 36rem;
+  --pf-t--global--breakpoint--250: 40rem;
+  --pf-t--global--breakpoint--300: 48rem;
+  --pf-t--global--breakpoint--350: 60rem;
+  --pf-t--global--breakpoint--400: 62rem;
+  --pf-t--global--breakpoint--500: 75rem;
+  --pf-t--global--breakpoint--550: 80rem;
+  --pf-t--global--breakpoint--600: 90.625rem;
+  --pf-t--global--color--nonstatus--green--400: #3d7019;
+  --pf-t--global--color--status--success--150: #3d7019;
+  --pf-t--global--delay--100: 0ms;
+  --pf-t--global--delay--200: 50ms;
+  --pf-t--global--delay--300: 100ms;
+  --pf-t--global--delay--400: 7000ms;
+  --pf-t--global--duration--100: 100ms;
+  --pf-t--global--duration--200: 200ms;
+  --pf-t--global--duration--300: 300ms;
+  --pf-t--global--duration--400: 400ms;
+  --pf-t--global--duration--50: 50ms;
+  --pf-t--global--duration--500: 500ms;
+  --pf-t--global--duration--600: 600ms;
+  --pf-t--global--focus-ring--position--inset: -4px;
+  --pf-t--global--focus-ring--position--offset: 2px;
+  --pf-t--global--focus-ring--width--inset: 3px;
+  --pf-t--global--focus-ring--width--offset: 2px;
+  --pf-t--global--font--family--100: "Red Hat Text", "RedHatText", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", Helvetica, Arial, sans-serif;
+  --pf-t--global--font--family--200: "Red Hat Display", "RedHatDisplay", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", Helvetica, Arial, sans-serif;
+  --pf-t--global--font--family--300: "Red Hat Mono", "RedHatMono", "Courier New", Courier, monospace;
+  --pf-t--global--font--line-height--100: 1.3;
+  --pf-t--global--font--line-height--200: 1.5;
+  --pf-t--global--font--size--100: 0.75rem;
+  --pf-t--global--font--size--200: 0.875rem;
+  --pf-t--global--font--size--300: 1rem;
+  --pf-t--global--font--size--400: 1.125rem;
+  --pf-t--global--font--size--500: 1.25rem;
+  --pf-t--global--font--size--600: 1.5rem;
+  --pf-t--global--font--size--700: 1.75rem;
+  --pf-t--global--font--size--800: 2.25rem;
+  --pf-t--global--font--weight--100: 400;
+  --pf-t--global--font--weight--200: 500;
+  --pf-t--global--font--weight--300: 500;
+  --pf-t--global--font--weight--400: 700;
+  --pf-t--global--icon--size--100: 0.75rem;
+  --pf-t--global--icon--size--200: 0.875rem;
+  --pf-t--global--icon--size--250: 1rem;
+  --pf-t--global--icon--size--300: 1.5rem;
+  --pf-t--global--icon--size--400: 3.5rem;
+  --pf-t--global--icon--size--500: 6rem;
+  --pf-t--global--spacer--100: 0.25rem;
+  --pf-t--global--spacer--200: 0.5rem;
+  --pf-t--global--spacer--300: 1rem;
+  --pf-t--global--spacer--400: 1.5rem;
+  --pf-t--global--spacer--500: 2rem;
+  --pf-t--global--spacer--600: 3rem;
+  --pf-t--global--spacer--700: 4rem;
+  --pf-t--global--spacer--800: 5rem;
+  --pf-t--global--text-decoration--line--100: none;
+  --pf-t--global--text-decoration--line--200: underline;
+  --pf-t--global--text-decoration--style--100: solid;
+  --pf-t--global--text-decoration--style--200: dashed;
+  --pf-t--global--timing-function--100: cubic-bezier(.4, 0, .7, .2);
+  --pf-t--global--timing-function--200: cubic-bezier(.4, 0, .2, 1);
+  --pf-t--global--timing-function--300: cubic-bezier(0, 0, .2, 1);
+  --pf-t--global--z-index--100: 100;
+  --pf-t--global--z-index--200: 200;
+  --pf-t--global--z-index--300: 300;
+  --pf-t--global--z-index--400: 400;
+  --pf-t--global--z-index--500: 500;
+  --pf-t--global--z-index--600: 600;
+  --pf-t--global--background--color--100: var(--pf-t--color--white);
+  --pf-t--global--background--color--200: var(--pf-t--color--gray--10);
+  --pf-t--global--background--color--300: var(--pf-t--color--gray--20);
+  --pf-t--global--background--color--400: var(--pf-t--color--gray--80);
+  --pf-t--global--background--color--450: var(--pf-t--color--gray--70);
+  --pf-t--global--background--color--action--plain--clicked: var(--pf-t--global--background--color--600);
+  --pf-t--global--background--color--action--plain--hover: var(--pf-t--global--background--color--600);
+  --pf-t--global--background--color--backdrop--default: var(--pf-t--global--background--color--500);
+  --pf-t--global--background--color--highlight--100: var(--pf-t--color--yellow--30);
+  --pf-t--global--background--color--highlight--200: var(--pf-t--color--yellow--40);
+  --pf-t--global--background--color--loading--skeleton--default: var(--pf-t--global--background--color--600);
+  --pf-t--global--background--color--loading--skeleton--subtle: var(--pf-t--global--background--color--700);
+  --pf-t--global--background--color--striped--row--default: var(--pf-t--global--background--color--700);
+  --pf-t--global--background--color--tertiary--default: var(--pf-t--global--background--color--600);
+  --pf-t--global--border--color--100: var(--pf-t--color--gray--30);
+  --pf-t--global--border--color--200: var(--pf-t--color--gray--40);
+  --pf-t--global--border--color--300: var(--pf-t--color--gray--45);
+  --pf-t--global--border--color--400: var(--pf-t--color--gray--60);
+  --pf-t--global--border--color--50: var(--pf-t--color--gray--20);
+  --pf-t--global--border--radius--large: var(--pf-t--global--border--radius--400);
+  --pf-t--global--border--radius--medium: var(--pf-t--global--border--radius--300);
+  --pf-t--global--border--radius--pill: var(--pf-t--global--border--radius--500);
+  --pf-t--global--border--radius--sharp: var(--pf-t--global--border--radius--0);
+  --pf-t--global--border--radius--small: var(--pf-t--global--border--radius--200);
+  --pf-t--global--border--radius--tiny: var(--pf-t--global--border--radius--100);
+  --pf-t--global--border--width--action--clicked: var(--pf-t--global--border--width--200);
+  --pf-t--global--border--width--action--default: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--action--hover: var(--pf-t--global--border--width--200);
+  --pf-t--global--border--width--box--clicked: var(--pf-t--global--border--width--300);
+  --pf-t--global--border--width--box--default: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--box--hover: var(--pf-t--global--border--width--200);
+  --pf-t--global--border--width--box--status--default: var(--pf-t--global--border--width--200);
+  --pf-t--global--border--width--box--status--read: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--control--clicked: var(--pf-t--global--border--width--200);
+  --pf-t--global--border--width--control--default: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--control--hover: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--divider--clicked: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--divider--default: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--divider--hover: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--extra-strong: var(--pf-t--global--border--width--300);
+  --pf-t--global--border--width--main--default: var(--pf-t--global--border--width--400);
+  --pf-t--global--border--width--regular: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--strong: var(--pf-t--global--border--width--200);
+  --pf-t--global--box-shadow--X--lg--bottom: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--lg--default: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--lg--left: var(--pf-t--global--box-shadow--X--50);
+  --pf-t--global--box-shadow--X--lg--right: var(--pf-t--global--box-shadow--X--800);
+  --pf-t--global--box-shadow--X--lg--top: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--md--bottom: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--md--default: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--md--left: var(--pf-t--global--box-shadow--X--100);
+  --pf-t--global--box-shadow--X--md--right: var(--pf-t--global--box-shadow--X--700);
+  --pf-t--global--box-shadow--X--md--top: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--sm--bottom: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--sm--default: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--sm--left: var(--pf-t--global--box-shadow--X--200);
+  --pf-t--global--box-shadow--X--sm--right: var(--pf-t--global--box-shadow--X--600);
+  --pf-t--global--box-shadow--X--sm--top: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--Y--lg--bottom: var(--pf-t--global--box-shadow--Y--800);
+  --pf-t--global--box-shadow--Y--lg--default: var(--pf-t--global--box-shadow--Y--700);
+  --pf-t--global--box-shadow--Y--lg--left: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--lg--right: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--lg--top: var(--pf-t--global--box-shadow--Y--50);
+  --pf-t--global--box-shadow--Y--md--bottom: var(--pf-t--global--box-shadow--Y--700);
+  --pf-t--global--box-shadow--Y--md--default: var(--pf-t--global--box-shadow--Y--600);
+  --pf-t--global--box-shadow--Y--md--left: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--md--right: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--md--top: var(--pf-t--global--box-shadow--Y--100);
+  --pf-t--global--box-shadow--Y--sm--bottom: var(--pf-t--global--box-shadow--Y--600);
+  --pf-t--global--box-shadow--Y--sm--default: var(--pf-t--global--box-shadow--Y--500);
+  --pf-t--global--box-shadow--Y--sm--left: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--sm--right: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--sm--top: var(--pf-t--global--box-shadow--Y--200);
+  --pf-t--global--box-shadow--blur--lg: var(--pf-t--global--box-shadow--blur--300);
+  --pf-t--global--box-shadow--blur--md: var(--pf-t--global--box-shadow--blur--200);
+  --pf-t--global--box-shadow--blur--sm: var(--pf-t--global--box-shadow--blur--100);
+  --pf-t--global--box-shadow--color--lg--default: var(--pf-t--global--box-shadow--color--100);
+  --pf-t--global--box-shadow--color--lg--directional: var(--pf-t--global--box-shadow--color--200);
+  --pf-t--global--box-shadow--color--md--default: var(--pf-t--global--box-shadow--color--100);
+  --pf-t--global--box-shadow--color--md--directional: var(--pf-t--global--box-shadow--color--100);
+  --pf-t--global--box-shadow--color--sm--default: var(--pf-t--global--box-shadow--color--100);
+  --pf-t--global--box-shadow--color--sm--directional: var(--pf-t--global--box-shadow--color--200);
+  --pf-t--global--box-shadow--spread--lg--default: var(--pf-t--global--box-shadow--spread--100);
+  --pf-t--global--box-shadow--spread--lg--directional: var(--pf-t--global--box-shadow--spread--400);
+  --pf-t--global--box-shadow--spread--md--default: var(--pf-t--global--box-shadow--spread--100);
+  --pf-t--global--box-shadow--spread--md--directional: var(--pf-t--global--box-shadow--spread--300);
+  --pf-t--global--box-shadow--spread--sm--default: var(--pf-t--global--box-shadow--spread--100);
+  --pf-t--global--box-shadow--spread--sm--directional: var(--pf-t--global--box-shadow--spread--200);
+  --pf-t--global--breakpoint--2xl: var(--pf-t--global--breakpoint--600);
+  --pf-t--global--breakpoint--height--2xl: var(--pf-t--global--breakpoint--550);
+  --pf-t--global--breakpoint--height--lg: var(--pf-t--global--breakpoint--300);
+  --pf-t--global--breakpoint--height--md: var(--pf-t--global--breakpoint--250);
+  --pf-t--global--breakpoint--height--sm: var(--pf-t--global--breakpoint--100);
+  --pf-t--global--breakpoint--height--xl: var(--pf-t--global--breakpoint--350);
+  --pf-t--global--breakpoint--lg: var(--pf-t--global--breakpoint--400);
+  --pf-t--global--breakpoint--md: var(--pf-t--global--breakpoint--300);
+  --pf-t--global--breakpoint--sm: var(--pf-t--global--breakpoint--200);
+  --pf-t--global--breakpoint--xl: var(--pf-t--global--breakpoint--500);
+  --pf-t--global--breakpoint--xs: var(--pf-t--global--breakpoint--100);
+  --pf-t--global--color--brand--100: var(--pf-t--color--blue--40);
+  --pf-t--global--color--brand--200: var(--pf-t--color--blue--50);
+  --pf-t--global--color--brand--300: var(--pf-t--color--blue--60);
+  --pf-t--global--color--brand--400: var(--pf-t--color--blue--70);
+  --pf-t--global--color--brand--500: var(--pf-t--color--blue--80);
+  --pf-t--global--color--brand--accent--100: var(--pf-t--color--red--50);
+  --pf-t--global--color--brand--accent--200: var(--pf-t--color--red--60);
+  --pf-t--global--color--brand--accent--300: var(--pf-t--color--gray--60);
+  --pf-t--global--color--brand--accent--400: var(--pf-t--color--black);
+  --pf-t--global--color--brand--subtle--100: var(--pf-t--color--blue--10);
+  --pf-t--global--color--brand--subtle--200: var(--pf-t--color--blue--20);
+  --pf-t--global--color--brand--subtle--300: var(--pf-t--color--blue--40);
+  --pf-t--global--color--brand--subtle--400: var(--pf-t--color--blue--50);
+  --pf-t--global--color--disabled--100: var(--pf-t--color--gray--30);
+  --pf-t--global--color--disabled--200: var(--pf-t--color--gray--40);
+  --pf-t--global--color--disabled--300: var(--pf-t--color--gray--50);
+  --pf-t--global--color--favorite--100: var(--pf-t--color--yellow--30);
+  --pf-t--global--color--favorite--200: var(--pf-t--color--yellow--40);
+  --pf-t--global--color--favorite--300: var(--pf-t--color--yellow--70);
+  --pf-t--global--color--favorite--400: var(--pf-t--color--yellow--80);
+  --pf-t--global--color--nonstatus--blue--100: var(--pf-t--color--blue--20);
+  --pf-t--global--color--nonstatus--blue--200: var(--pf-t--color--blue--30);
+  --pf-t--global--color--nonstatus--blue--300: var(--pf-t--color--blue--40);
+  --pf-t--global--color--nonstatus--blue--400: var(--pf-t--color--blue--60);
+  --pf-t--global--color--nonstatus--blue--500: var(--pf-t--color--blue--70);
+  --pf-t--global--color--nonstatus--gray--100: var(--pf-t--color--gray--20);
+  --pf-t--global--color--nonstatus--gray--200: var(--pf-t--color--gray--30);
+  --pf-t--global--color--nonstatus--gray--300: var(--pf-t--color--gray--40);
+  --pf-t--global--color--nonstatus--gray--400: var(--pf-t--color--gray--60);
+  --pf-t--global--color--nonstatus--gray--50: var(--pf-t--color--gray--10);
+  --pf-t--global--color--nonstatus--gray--500: var(--pf-t--color--gray--70);
+  --pf-t--global--color--nonstatus--green--100: var(--pf-t--color--green--20);
+  --pf-t--global--color--nonstatus--green--200: var(--pf-t--color--green--30);
+  --pf-t--global--color--nonstatus--green--300: var(--pf-t--color--green--40);
+  --pf-t--global--color--nonstatus--green--500: var(--pf-t--color--green--70);
+  --pf-t--global--color--nonstatus--orange--100: var(--pf-t--color--orange--20);
+  --pf-t--global--color--nonstatus--orange--200: var(--pf-t--color--orange--30);
+  --pf-t--global--color--nonstatus--orange--300: var(--pf-t--color--orange--40);
+  --pf-t--global--color--nonstatus--orange--400: var(--pf-t--color--orange--60);
+  --pf-t--global--color--nonstatus--orange--500: var(--pf-t--color--orange--70);
+  --pf-t--global--color--nonstatus--orangered--100: var(--pf-t--color--red-orange--20);
+  --pf-t--global--color--nonstatus--orangered--200: var(--pf-t--color--red-orange--30);
+  --pf-t--global--color--nonstatus--orangered--300: var(--pf-t--color--red-orange--40);
+  --pf-t--global--color--nonstatus--orangered--400: var(--pf-t--color--red-orange--60);
+  --pf-t--global--color--nonstatus--orangered--500: var(--pf-t--color--red-orange--70);
+  --pf-t--global--color--nonstatus--purple--100: var(--pf-t--color--purple--20);
+  --pf-t--global--color--nonstatus--purple--200: var(--pf-t--color--purple--30);
+  --pf-t--global--color--nonstatus--purple--300: var(--pf-t--color--purple--40);
+  --pf-t--global--color--nonstatus--purple--400: var(--pf-t--color--purple--50);
+  --pf-t--global--color--nonstatus--purple--500: var(--pf-t--color--purple--60);
+  --pf-t--global--color--nonstatus--red--100: var(--pf-t--color--red--20);
+  --pf-t--global--color--nonstatus--red--200: var(--pf-t--color--red--30);
+  --pf-t--global--color--nonstatus--red--300: var(--pf-t--color--red--40);
+  --pf-t--global--color--nonstatus--red--400: var(--pf-t--color--red--60);
+  --pf-t--global--color--nonstatus--red--500: var(--pf-t--color--red--70);
+  --pf-t--global--color--nonstatus--teal--100: var(--pf-t--color--teal--20);
+  --pf-t--global--color--nonstatus--teal--200: var(--pf-t--color--teal--30);
+  --pf-t--global--color--nonstatus--teal--300: var(--pf-t--color--teal--40);
+  --pf-t--global--color--nonstatus--teal--400: var(--pf-t--color--teal--70);
+  --pf-t--global--color--nonstatus--teal--500: var(--pf-t--color--teal--80);
+  --pf-t--global--color--nonstatus--yellow--100: var(--pf-t--color--yellow--20);
+  --pf-t--global--color--nonstatus--yellow--200: var(--pf-t--color--yellow--30);
+  --pf-t--global--color--nonstatus--yellow--300: var(--pf-t--color--yellow--40);
+  --pf-t--global--color--nonstatus--yellow--400: var(--pf-t--color--yellow--70);
+  --pf-t--global--color--nonstatus--yellow--500: var(--pf-t--color--yellow--80);
+  --pf-t--global--color--severity--critical--100: var(--pf-t--color--red-orange--60);
+  --pf-t--global--color--severity--important--100: var(--pf-t--color--orange--50);
+  --pf-t--global--color--severity--important--200: var(--pf-t--color--orange--60);
+  --pf-t--global--color--severity--minor--100: var(--pf-t--color--gray--50);
+  --pf-t--global--color--severity--minor--200: var(--pf-t--color--gray--80);
+  --pf-t--global--color--severity--moderate--100: var(--pf-t--color--yellow--40);
+  --pf-t--global--color--severity--moderate--200: var(--pf-t--color--yellow--70);
+  --pf-t--global--color--severity--none--100: var(--pf-t--color--blue--40);
+  --pf-t--global--color--severity--none--200: var(--pf-t--color--blue--60);
+  --pf-t--global--color--severity--undefined--100: var(--pf-t--color--gray--30);
+  --pf-t--global--color--severity--undefined--200: var(--pf-t--color--gray--60);
+  --pf-t--global--color--status--custom--100: var(--pf-t--color--teal--60);
+  --pf-t--global--color--status--custom--200: var(--pf-t--color--teal--70);
+  --pf-t--global--color--status--custom--300: var(--pf-t--color--teal--80);
+  --pf-t--global--color--status--danger--100: var(--pf-t--color--red-orange--60);
+  --pf-t--global--color--status--danger--200: var(--pf-t--color--red-orange--70);
+  --pf-t--global--color--status--danger--300: var(--pf-t--color--red-orange--70);
+  --pf-t--global--color--status--info--100: var(--pf-t--color--purple--50);
+  --pf-t--global--color--status--info--200: var(--pf-t--color--purple--60);
+  --pf-t--global--color--status--info--300: var(--pf-t--color--purple--70);
+  --pf-t--global--color--status--success--100: var(--pf-t--color--green--60);
+  --pf-t--global--color--status--success--200: var(--pf-t--color--green--70);
+  --pf-t--global--color--status--success--300: var(--pf-t--color--green--80);
+  --pf-t--global--color--status--warning--100: var(--pf-t--color--yellow--30);
+  --pf-t--global--color--status--warning--200: var(--pf-t--color--yellow--40);
+  --pf-t--global--color--status--warning--300: var(--pf-t--color--yellow--50);
+  --pf-t--global--color--status--warning--400: var(--pf-t--color--yellow--60);
+  --pf-t--global--color--status--warning--500: var(--pf-t--color--yellow--70);
+  --pf-t--global--color--status--warning--600: var(--pf-t--color--yellow--80);
+  --pf-t--global--focus-ring--color--100: var(--pf-t--color--blue--50);
+  --pf-t--global--focus-ring--color--200: var(--pf-t--color--blue--60);
+  --pf-t--global--font--family--body: var(--pf-t--global--font--family--100);
+  --pf-t--global--font--family--heading: var(--pf-t--global--font--family--200);
+  --pf-t--global--font--family--mono: var(--pf-t--global--font--family--300);
+  --pf-t--global--font--line-height--body: var(--pf-t--global--font--line-height--200);
+  --pf-t--global--font--line-height--heading: var(--pf-t--global--font--line-height--100);
+  --pf-t--global--font--size--2xl: var(--pf-t--global--font--size--600);
+  --pf-t--global--font--size--3xl: var(--pf-t--global--font--size--700);
+  --pf-t--global--font--size--4xl: var(--pf-t--global--font--size--800);
+  --pf-t--global--font--size--lg: var(--pf-t--global--font--size--400);
+  --pf-t--global--font--size--md: var(--pf-t--global--font--size--300);
+  --pf-t--global--font--size--sm: var(--pf-t--global--font--size--200);
+  --pf-t--global--font--size--xl: var(--pf-t--global--font--size--500);
+  --pf-t--global--font--size--xs: var(--pf-t--global--font--size--100);
+  --pf-t--global--font--weight--body--bold: var(--pf-t--global--font--weight--200);
+  --pf-t--global--font--weight--body--default: var(--pf-t--global--font--weight--100);
+  --pf-t--global--font--weight--heading--bold: var(--pf-t--global--font--weight--400);
+  --pf-t--global--font--weight--heading--default: var(--pf-t--global--font--weight--300);
+  --pf-t--global--icon--color--100: var(--pf-t--color--gray--90);
+  --pf-t--global--icon--color--150: var(--pf-t--color--gray--60);
+  --pf-t--global--icon--color--200: var(--pf-t--color--gray--50);
+  --pf-t--global--icon--color--300: var(--pf-t--color--white);
+  --pf-t--global--icon--size--2xl: var(--pf-t--global--icon--size--400);
+  --pf-t--global--icon--size--3xl: var(--pf-t--global--icon--size--500);
+  --pf-t--global--icon--size--lg: var(--pf-t--global--icon--size--250);
+  --pf-t--global--icon--size--md: var(--pf-t--global--icon--size--200);
+  --pf-t--global--icon--size--sm: var(--pf-t--global--icon--size--100);
+  --pf-t--global--icon--size--xl: var(--pf-t--global--icon--size--300);
+  --pf-t--global--motion--delay--default: var(--pf-t--global--delay--300);
+  --pf-t--global--motion--delay--long: var(--pf-t--global--delay--400);
+  --pf-t--global--motion--delay--none: var(--pf-t--global--delay--100);
+  --pf-t--global--motion--delay--short: var(--pf-t--global--delay--200);
+  --pf-t--global--motion--duration--2xl: var(--pf-t--global--duration--500);
+  --pf-t--global--motion--duration--3xl: var(--pf-t--global--duration--600);
+  --pf-t--global--motion--duration--lg: var(--pf-t--global--duration--300);
+  --pf-t--global--motion--duration--md: var(--pf-t--global--duration--200);
+  --pf-t--global--motion--duration--sm: var(--pf-t--global--duration--100);
+  --pf-t--global--motion--duration--xl: var(--pf-t--global--duration--400);
+  --pf-t--global--motion--duration--xs: var(--pf-t--global--duration--50);
+  --pf-t--global--motion--timing-function--accelerate: var(--pf-t--global--timing-function--100);
+  --pf-t--global--motion--timing-function--decelerate: var(--pf-t--global--timing-function--300);
+  --pf-t--global--motion--timing-function--default: var(--pf-t--global--timing-function--200);
+  --pf-t--global--spacer--2xl: var(--pf-t--global--spacer--600);
+  --pf-t--global--spacer--3xl: var(--pf-t--global--spacer--700);
+  --pf-t--global--spacer--4xl: var(--pf-t--global--spacer--800);
+  --pf-t--global--spacer--lg: var(--pf-t--global--spacer--400);
+  --pf-t--global--spacer--md: var(--pf-t--global--spacer--300);
+  --pf-t--global--spacer--sm: var(--pf-t--global--spacer--200);
+  --pf-t--global--spacer--xl: var(--pf-t--global--spacer--500);
+  --pf-t--global--spacer--xs: var(--pf-t--global--spacer--100);
+  --pf-t--global--text--color--100: var(--pf-t--color--gray--95);
+  --pf-t--global--text--color--200: var(--pf-t--color--gray--60);
+  --pf-t--global--text--color--250: var(--pf-t--color--gray--70);
+  --pf-t--global--text--color--300: var(--pf-t--color--white);
+  --pf-t--global--text--color--400: var(--pf-t--color--red-orange--40);
+  --pf-t--global--text--color--500: var(--pf-t--color--red-orange--70);
+  --pf-t--global--text--color--link--100: var(--pf-t--color--blue--50);
+  --pf-t--global--text--color--link--200: var(--pf-t--color--blue--60);
+  --pf-t--global--text--color--link--250: var(--pf-t--color--blue--70);
+  --pf-t--global--text--color--link--300: var(--pf-t--color--purple--50);
+  --pf-t--global--text--color--link--350: var(--pf-t--color--purple--60);
+  --pf-t--global--text-decoration--editable-text--line--default: var(--pf-t--global--text-decoration--line--200);
+  --pf-t--global--text-decoration--editable-text--line--hover: var(--pf-t--global--text-decoration--line--200);
+  --pf-t--global--text-decoration--editable-text--style--default: var(--pf-t--global--text-decoration--style--200);
+  --pf-t--global--text-decoration--editable-text--style--hover: var(--pf-t--global--text-decoration--style--200);
+  --pf-t--global--text-decoration--help-text--line--default: var(--pf-t--global--text-decoration--line--200);
+  --pf-t--global--text-decoration--help-text--line--hover: var(--pf-t--global--text-decoration--line--200);
+  --pf-t--global--text-decoration--help-text--style--default: var(--pf-t--global--text-decoration--style--200);
+  --pf-t--global--text-decoration--help-text--style--hover: var(--pf-t--global--text-decoration--style--200);
+  --pf-t--global--text-decoration--link--line--default: var(--pf-t--global--text-decoration--line--200);
+  --pf-t--global--text-decoration--link--line--hover: var(--pf-t--global--text-decoration--line--200);
+  --pf-t--global--text-decoration--link--style--default: var(--pf-t--global--text-decoration--style--200);
+  --pf-t--global--text-decoration--link--style--hover: var(--pf-t--global--text-decoration--style--200);
+  --pf-t--global--z-index--2xl: var(--pf-t--global--z-index--600);
+  --pf-t--global--z-index--lg: var(--pf-t--global--z-index--400);
+  --pf-t--global--z-index--md: var(--pf-t--global--z-index--300);
+  --pf-t--global--z-index--sm: var(--pf-t--global--z-index--200);
+  --pf-t--global--z-index--xl: var(--pf-t--global--z-index--500);
+  --pf-t--global--z-index--xs: var(--pf-t--global--z-index--100);
+  --pf-t--global--background--color--action--plain--alt--clicked: var(--pf-t--global--background--color--100);
+  --pf-t--global--background--color--action--plain--alt--hover: var(--pf-t--global--background--color--100);
+  --pf-t--global--background--color--control--read-only: var(--pf-t--global--background--color--200);
+  --pf-t--global--background--color--disabled--default: var(--pf-t--global--color--disabled--100);
+  --pf-t--global--background--color--floating--clicked: var(--pf-t--global--background--color--200);
+  --pf-t--global--background--color--floating--default: var(--pf-t--global--background--color--100);
+  --pf-t--global--background--color--floating--hover: var(--pf-t--global--background--color--200);
+  --pf-t--global--background--color--highlight--clicked: var(--pf-t--global--background--color--highlight--200);
+  --pf-t--global--background--color--highlight--default: var(--pf-t--global--background--color--highlight--100);
+  --pf-t--global--background--color--inverse--clicked: var(--pf-t--global--background--color--450);
+  --pf-t--global--background--color--inverse--default: var(--pf-t--global--background--color--400);
+  --pf-t--global--background--color--inverse--hover: var(--pf-t--global--background--color--450);
+  --pf-t--global--background--color--primary--clicked: var(--pf-t--global--background--color--200);
+  --pf-t--global--background--color--primary--default: var(--pf-t--global--background--color--100);
+  --pf-t--global--background--color--primary--hover: var(--pf-t--global--background--color--200);
+  --pf-t--global--background--color--secondary--clicked: var(--pf-t--global--background--color--300);
+  --pf-t--global--background--color--secondary--default: var(--pf-t--global--background--color--200);
+  --pf-t--global--background--color--secondary--hover: var(--pf-t--global--background--color--300);
+  --pf-t--global--background--color--sticky--default: var(--pf-t--global--background--color--100);
+  --pf-t--global--border--color--brand--subtle--clicked: var(--pf-t--global--color--brand--subtle--300);
+  --pf-t--global--border--color--brand--subtle--default: var(--pf-t--global--color--brand--subtle--200);
+  --pf-t--global--border--color--brand--subtle--hover: var(--pf-t--global--color--brand--subtle--300);
+  --pf-t--global--border--color--clicked: var(--pf-t--global--color--brand--200);
+  --pf-t--global--border--color--control--default: var(--pf-t--global--border--color--300);
+  --pf-t--global--border--color--control--read-only: var(--pf-t--global--border--color--100);
+  --pf-t--global--border--color--default: var(--pf-t--global--border--color--50);
+  --pf-t--global--border--color--disabled: var(--pf-t--global--color--disabled--200);
+  --pf-t--global--border--color--hover: var(--pf-t--global--color--brand--100);
+  --pf-t--global--border--color--nonstatus--blue--clicked: var(--pf-t--global--color--nonstatus--blue--300);
+  --pf-t--global--border--color--nonstatus--blue--default: var(--pf-t--global--color--nonstatus--blue--200);
+  --pf-t--global--border--color--nonstatus--blue--hover: var(--pf-t--global--color--nonstatus--blue--300);
+  --pf-t--global--border--color--nonstatus--gray--clicked: var(--pf-t--global--color--nonstatus--gray--300);
+  --pf-t--global--border--color--nonstatus--gray--default: var(--pf-t--global--color--nonstatus--gray--200);
+  --pf-t--global--border--color--nonstatus--gray--hover: var(--pf-t--global--color--nonstatus--gray--300);
+  --pf-t--global--border--color--nonstatus--green--clicked: var(--pf-t--global--color--nonstatus--green--300);
+  --pf-t--global--border--color--nonstatus--green--default: var(--pf-t--global--color--nonstatus--green--200);
+  --pf-t--global--border--color--nonstatus--green--hover: var(--pf-t--global--color--nonstatus--green--300);
+  --pf-t--global--border--color--nonstatus--orange--clicked: var(--pf-t--global--color--nonstatus--orange--300);
+  --pf-t--global--border--color--nonstatus--orange--default: var(--pf-t--global--color--nonstatus--orange--200);
+  --pf-t--global--border--color--nonstatus--orange--hover: var(--pf-t--global--color--nonstatus--orange--300);
+  --pf-t--global--border--color--nonstatus--orangered--clicked: var(--pf-t--global--color--nonstatus--orangered--300);
+  --pf-t--global--border--color--nonstatus--orangered--default: var(--pf-t--global--color--nonstatus--orangered--200);
+  --pf-t--global--border--color--nonstatus--orangered--hover: var(--pf-t--global--color--nonstatus--orangered--300);
+  --pf-t--global--border--color--nonstatus--purple--clicked: var(--pf-t--global--color--nonstatus--purple--300);
+  --pf-t--global--border--color--nonstatus--purple--default: var(--pf-t--global--color--nonstatus--purple--200);
+  --pf-t--global--border--color--nonstatus--purple--hover: var(--pf-t--global--color--nonstatus--purple--300);
+  --pf-t--global--border--color--nonstatus--red--clicked: var(--pf-t--global--color--nonstatus--red--300);
+  --pf-t--global--border--color--nonstatus--red--default: var(--pf-t--global--color--nonstatus--red--200);
+  --pf-t--global--border--color--nonstatus--red--hover: var(--pf-t--global--color--nonstatus--red--300);
+  --pf-t--global--border--color--nonstatus--teal--clicked: var(--pf-t--global--color--nonstatus--teal--300);
+  --pf-t--global--border--color--nonstatus--teal--default: var(--pf-t--global--color--nonstatus--teal--200);
+  --pf-t--global--border--color--nonstatus--teal--hover: var(--pf-t--global--color--nonstatus--teal--300);
+  --pf-t--global--border--color--nonstatus--yellow--clicked: var(--pf-t--global--color--nonstatus--yellow--300);
+  --pf-t--global--border--color--nonstatus--yellow--default: var(--pf-t--global--color--nonstatus--yellow--200);
+  --pf-t--global--border--color--nonstatus--yellow--hover: var(--pf-t--global--color--nonstatus--yellow--300);
+  --pf-t--global--border--color--on-secondary: var(--pf-t--global--border--color--300);
+  --pf-t--global--border--color--status--warning--clicked: var(--pf-t--global--color--status--warning--300);
+  --pf-t--global--border--color--status--warning--default: var(--pf-t--global--color--status--warning--200);
+  --pf-t--global--border--color--status--warning--hover: var(--pf-t--global--color--status--warning--300);
+  --pf-t--global--border--color--subtle: var(--pf-t--global--border--color--50);
+  --pf-t--global--border--radius--action--default: var(--pf-t--global--border--radius--pill);
+  --pf-t--global--border--radius--action--plain--default: var(--pf-t--global--border--radius--small);
+  --pf-t--global--border--radius--control--default: var(--pf-t--global--border--radius--small);
+  --pf-t--global--border--radius--control--form-element: var(--pf-t--global--border--radius--small);
+  --pf-t--global--border--radius--glass--default: initial;
+  --pf-t--global--border--width--glass--default: initial;
+  --pf-t--global--color--brand--clicked: var(--pf-t--global--color--brand--300);
+  --pf-t--global--color--brand--default: var(--pf-t--global--color--brand--200);
+  --pf-t--global--color--brand--hover: var(--pf-t--global--color--brand--300);
+  --pf-t--global--color--brand--subtle--clicked: var(--pf-t--global--color--brand--subtle--200);
+  --pf-t--global--color--brand--subtle--default: var(--pf-t--global--color--brand--subtle--100);
+  --pf-t--global--color--brand--subtle--hover: var(--pf-t--global--color--brand--subtle--200);
+  --pf-t--global--color--favorite--clicked: var(--pf-t--global--color--favorite--200);
+  --pf-t--global--color--favorite--default: var(--pf-t--global--color--favorite--100);
+  --pf-t--global--color--favorite--hover: var(--pf-t--global--color--favorite--200);
+  --pf-t--global--color--nonstatus--blue--clicked: var(--pf-t--global--color--nonstatus--blue--200);
+  --pf-t--global--color--nonstatus--blue--default: var(--pf-t--global--color--nonstatus--blue--100);
+  --pf-t--global--color--nonstatus--blue--hover: var(--pf-t--global--color--nonstatus--blue--200);
+  --pf-t--global--color--nonstatus--gray--clicked: var(--pf-t--global--color--nonstatus--gray--200);
+  --pf-t--global--color--nonstatus--gray--default: var(--pf-t--global--color--nonstatus--gray--100);
+  --pf-t--global--color--nonstatus--gray--hover: var(--pf-t--global--color--nonstatus--gray--200);
+  --pf-t--global--color--nonstatus--green--clicked: var(--pf-t--global--color--nonstatus--green--200);
+  --pf-t--global--color--nonstatus--green--default: var(--pf-t--global--color--nonstatus--green--100);
+  --pf-t--global--color--nonstatus--green--hover: var(--pf-t--global--color--nonstatus--green--200);
+  --pf-t--global--color--nonstatus--orange--clicked: var(--pf-t--global--color--nonstatus--orange--200);
+  --pf-t--global--color--nonstatus--orange--default: var(--pf-t--global--color--nonstatus--orange--100);
+  --pf-t--global--color--nonstatus--orange--hover: var(--pf-t--global--color--nonstatus--orange--200);
+  --pf-t--global--color--nonstatus--orangered--clicked: var(--pf-t--global--color--nonstatus--orangered--200);
+  --pf-t--global--color--nonstatus--orangered--default: var(--pf-t--global--color--nonstatus--orangered--100);
+  --pf-t--global--color--nonstatus--orangered--hover: var(--pf-t--global--color--nonstatus--orangered--200);
+  --pf-t--global--color--nonstatus--purple--clicked: var(--pf-t--global--color--nonstatus--purple--200);
+  --pf-t--global--color--nonstatus--purple--default: var(--pf-t--global--color--nonstatus--purple--100);
+  --pf-t--global--color--nonstatus--purple--hover: var(--pf-t--global--color--nonstatus--purple--200);
+  --pf-t--global--color--nonstatus--red--clicked: var(--pf-t--global--color--nonstatus--red--200);
+  --pf-t--global--color--nonstatus--red--default: var(--pf-t--global--color--nonstatus--red--100);
+  --pf-t--global--color--nonstatus--red--hover: var(--pf-t--global--color--nonstatus--red--200);
+  --pf-t--global--color--nonstatus--teal--clicked: var(--pf-t--global--color--nonstatus--teal--200);
+  --pf-t--global--color--nonstatus--teal--default: var(--pf-t--global--color--nonstatus--teal--100);
+  --pf-t--global--color--nonstatus--teal--hover: var(--pf-t--global--color--nonstatus--teal--200);
+  --pf-t--global--color--nonstatus--yellow--clicked: var(--pf-t--global--color--nonstatus--yellow--200);
+  --pf-t--global--color--nonstatus--yellow--default: var(--pf-t--global--color--nonstatus--yellow--100);
+  --pf-t--global--color--nonstatus--yellow--hover: var(--pf-t--global--color--nonstatus--yellow--200);
+  --pf-t--global--color--status--custom--clicked: var(--pf-t--global--color--status--custom--200);
+  --pf-t--global--color--status--custom--default: var(--pf-t--global--color--status--custom--100);
+  --pf-t--global--color--status--custom--hover: var(--pf-t--global--color--status--custom--200);
+  --pf-t--global--color--status--danger--clicked: var(--pf-t--global--color--status--danger--200);
+  --pf-t--global--color--status--danger--default: var(--pf-t--global--color--status--danger--100);
+  --pf-t--global--color--status--danger--hover: var(--pf-t--global--color--status--danger--200);
+  --pf-t--global--color--status--info--clicked: var(--pf-t--global--color--status--info--200);
+  --pf-t--global--color--status--info--default: var(--pf-t--global--color--status--info--100);
+  --pf-t--global--color--status--info--hover: var(--pf-t--global--color--status--info--200);
+  --pf-t--global--color--status--success--clicked: var(--pf-t--global--color--status--success--200);
+  --pf-t--global--color--status--success--default: var(--pf-t--global--color--status--success--100);
+  --pf-t--global--color--status--success--hover: var(--pf-t--global--color--status--success--200);
+  --pf-t--global--color--status--warning--clicked: var(--pf-t--global--color--status--warning--200);
+  --pf-t--global--color--status--warning--default: var(--pf-t--global--color--status--warning--100);
+  --pf-t--global--color--status--warning--hover: var(--pf-t--global--color--status--warning--200);
+  --pf-t--global--focus-ring--color--default: var(--pf-t--global--focus-ring--color--100);
+  --pf-t--global--font--size--body--default: var(--pf-t--global--font--size--sm);
+  --pf-t--global--font--size--body--lg: var(--pf-t--global--font--size--md);
+  --pf-t--global--font--size--body--sm: var(--pf-t--global--font--size--xs);
+  --pf-t--global--font--size--heading--h1: var(--pf-t--global--font--size--2xl);
+  --pf-t--global--font--size--heading--h2: var(--pf-t--global--font--size--xl);
+  --pf-t--global--font--size--heading--h3: var(--pf-t--global--font--size--lg);
+  --pf-t--global--font--size--heading--h4: var(--pf-t--global--font--size--md);
+  --pf-t--global--font--size--heading--h5: var(--pf-t--global--font--size--md);
+  --pf-t--global--font--size--heading--h6: var(--pf-t--global--font--size--md);
+  --pf-t--global--icon--color--disabled: var(--pf-t--global--color--disabled--200);
+  --pf-t--global--icon--color--inverse: var(--pf-t--global--icon--color--300);
+  --pf-t--global--icon--color--on-disabled: var(--pf-t--global--color--disabled--300);
+  --pf-t--global--icon--color--regular: var(--pf-t--global--icon--color--100);
+  --pf-t--global--icon--color--severity--critical--default: var(--pf-t--global--color--severity--critical--100);
+  --pf-t--global--icon--color--severity--important--default: var(--pf-t--global--color--severity--important--100);
+  --pf-t--global--icon--color--severity--minor--default: var(--pf-t--global--color--severity--minor--100);
+  --pf-t--global--icon--color--severity--moderate--default: var(--pf-t--global--color--severity--moderate--100);
+  --pf-t--global--icon--color--severity--none--default: var(--pf-t--global--color--severity--none--100);
+  --pf-t--global--icon--color--severity--undefined--default: var(--pf-t--global--color--severity--undefined--100);
+  --pf-t--global--icon--color--status--warning--clicked: var(--pf-t--global--color--status--warning--300);
+  --pf-t--global--icon--color--status--warning--default: var(--pf-t--global--color--status--warning--200);
+  --pf-t--global--icon--color--status--warning--hover: var(--pf-t--global--color--status--warning--300);
+  --pf-t--global--icon--color--subtle: var(--pf-t--global--icon--color--200);
+  --pf-t--global--icon--size--font--2xl: var(--pf-t--global--font--size--2xl);
+  --pf-t--global--icon--size--font--3xl: var(--pf-t--global--font--size--3xl);
+  --pf-t--global--icon--size--font--4xl: var(--pf-t--global--font--size--4xl);
+  --pf-t--global--icon--size--font--lg: var(--pf-t--global--font--size--lg);
+  --pf-t--global--icon--size--font--md: var(--pf-t--global--font--size--md);
+  --pf-t--global--icon--size--font--sm: var(--pf-t--global--font--size--sm);
+  --pf-t--global--icon--size--font--xl: var(--pf-t--global--font--size--xl);
+  --pf-t--global--icon--size--font--xs: var(--pf-t--global--font--size--xs);
+  --pf-t--global--motion--duration--fade--default: var(--pf-t--global--motion--duration--md);
+  --pf-t--global--motion--duration--fade--long: var(--pf-t--global--motion--duration--lg);
+  --pf-t--global--motion--duration--fade--short: var(--pf-t--global--motion--duration--sm);
+  --pf-t--global--motion--duration--icon--default: var(--pf-t--global--motion--duration--sm);
+  --pf-t--global--motion--duration--icon--long: var(--pf-t--global--motion--duration--md);
+  --pf-t--global--motion--duration--icon--short: var(--pf-t--global--motion--duration--xs);
+  --pf-t--global--motion--duration--slide-in--default: var(--pf-t--global--motion--duration--xl);
+  --pf-t--global--motion--duration--slide-in--long: var(--pf-t--global--motion--duration--2xl);
+  --pf-t--global--motion--duration--slide-in--short: var(--pf-t--global--motion--duration--lg);
+  --pf-t--global--motion--duration--slide-out--default: var(--pf-t--global--motion--duration--xl);
+  --pf-t--global--motion--duration--slide-out--long: var(--pf-t--global--motion--duration--2xl);
+  --pf-t--global--motion--duration--slide-out--short: var(--pf-t--global--motion--duration--lg);
+  --pf-t--global--spacer--action--horizontal--compact: var(--pf-t--global--spacer--md);
+  --pf-t--global--spacer--action--horizontal--default: var(--pf-t--global--spacer--lg);
+  --pf-t--global--spacer--action--horizontal--plain--compact: var(--pf-t--global--spacer--xs);
+  --pf-t--global--spacer--action--horizontal--plain--default: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--action--horizontal--spacious: var(--pf-t--global--spacer--xl);
+  --pf-t--global--spacer--control--horizontal--compact: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--control--horizontal--default: var(--pf-t--global--spacer--md);
+  --pf-t--global--spacer--control--horizontal--plain: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--control--horizontal--spacious: var(--pf-t--global--spacer--lg);
+  --pf-t--global--spacer--control--vertical--compact: var(--pf-t--global--spacer--xs);
+  --pf-t--global--spacer--control--vertical--default: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--control--vertical--plain: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--control--vertical--spacious: var(--pf-t--global--spacer--md);
+  --pf-t--global--spacer--gap--action-to-action--default: var(--pf-t--global--spacer--md);
+  --pf-t--global--spacer--gap--action-to-action--plain: var(--pf-t--global--spacer--xs);
+  --pf-t--global--spacer--gap--control-to-control--default: var(--pf-t--global--spacer--xs);
+  --pf-t--global--spacer--gap--group--horizontal: var(--pf-t--global--spacer--md);
+  --pf-t--global--spacer--gap--group--vertical: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--gap--group-to-group--horizontal--compact: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--gap--group-to-group--horizontal--default: var(--pf-t--global--spacer--2xl);
+  --pf-t--global--spacer--gap--group-to-group--vertical--compact: var(--pf-t--global--spacer--md);
+  --pf-t--global--spacer--gap--group-to-group--vertical--default: var(--pf-t--global--spacer--lg);
+  --pf-t--global--spacer--gap--text-to-element--compact: var(--pf-t--global--spacer--xs);
+  --pf-t--global--spacer--gap--text-to-element--default: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--gutter--default: var(--pf-t--global--spacer--md);
+  --pf-t--global--spacer--inset--page-chrome: var(--pf-t--global--spacer--lg);
+  --pf-t--global--text--color--disabled: var(--pf-t--global--color--disabled--200);
+  --pf-t--global--text--color--inverse: var(--pf-t--global--text--color--300);
+  --pf-t--global--text--color--link--default: var(--pf-t--global--text--color--link--100);
+  --pf-t--global--text--color--link--hover: var(--pf-t--global--text--color--link--200);
+  --pf-t--global--text--color--link--visited: var(--pf-t--global--text--color--link--300);
+  --pf-t--global--text--color--on-disabled: var(--pf-t--global--color--disabled--300);
+  --pf-t--global--text--color--on-highlight: var(--pf-t--global--text--color--100);
+  --pf-t--global--text--color--regular: var(--pf-t--global--text--color--100);
+  --pf-t--global--text--color--required: var(--pf-t--global--text--color--400);
+  --pf-t--global--text--color--status--warning--clicked: var(--pf-t--global--color--status--warning--300);
+  --pf-t--global--text--color--status--warning--default: var(--pf-t--global--color--status--warning--200);
+  --pf-t--global--text--color--status--warning--hover: var(--pf-t--global--color--status--warning--300);
+  --pf-t--global--text--color--subtle: var(--pf-t--global--text--color--200);
+  --pf-t--global--text-decoration--color--default: var(--pf-t--global--border--color--300);
+  --pf-t--global--text-decoration--offset--default: var(--pf-t--global--spacer--xs);
+  --pf-t--global--text-decoration--width--default: var(--pf-t--global--border--width--regular);
+  --pf-t--global--text-decoration--width--hover: var(--pf-t--global--border--width--regular);
+  --pf-t--global--background--color--control--default: var(--pf-t--global--background--color--primary--default);
+  --pf-t--global--background--color--floating--secondary--default: var(--pf-t--global--background--color--secondary--default);
+  --pf-t--global--background--color--glass--primary--default: initial;
+  --pf-t--global--border--color--alt: var(--pf-t--global--background--color--primary--default);
+  --pf-t--global--border--color--brand--clicked: var(--pf-t--global--color--brand--clicked);
+  --pf-t--global--border--color--brand--default: var(--pf-t--global--color--brand--default);
+  --pf-t--global--border--color--brand--hover: var(--pf-t--global--color--brand--hover);
+  --pf-t--global--border--color--glass--default: initial;
+  --pf-t--global--border--color--main--default: var(--pf-t--global--background--color--primary--default);
+  --pf-t--global--border--color--status--custom--clicked: var(--pf-t--global--color--status--custom--clicked);
+  --pf-t--global--border--color--status--custom--default: var(--pf-t--global--color--status--custom--default);
+  --pf-t--global--border--color--status--custom--hover: var(--pf-t--global--color--status--custom--hover);
+  --pf-t--global--border--color--status--danger--clicked: var(--pf-t--global--color--status--danger--clicked);
+  --pf-t--global--border--color--status--danger--default: var(--pf-t--global--color--status--danger--default);
+  --pf-t--global--border--color--status--danger--hover: var(--pf-t--global--color--status--danger--hover);
+  --pf-t--global--border--color--status--info--clicked: var(--pf-t--global--color--status--info--clicked);
+  --pf-t--global--border--color--status--info--default: var(--pf-t--global--color--status--info--default);
+  --pf-t--global--border--color--status--info--hover: var(--pf-t--global--color--status--info--hover);
+  --pf-t--global--border--color--status--success--clicked: var(--pf-t--global--color--status--success--clicked);
+  --pf-t--global--border--color--status--success--default: var(--pf-t--global--color--status--success--default);
+  --pf-t--global--border--color--status--success--hover: var(--pf-t--global--color--status--success--hover);
+  --pf-t--global--color--brand--accent--clicked: var(--pf-t--global--color--brand--clicked);
+  --pf-t--global--color--brand--accent--default: var(--pf-t--global--color--brand--default);
+  --pf-t--global--color--brand--accent--hover: var(--pf-t--global--color--brand--hover);
+  --pf-t--global--color--status--read--on-primary: var(--pf-t--global--background--color--secondary--default);
+  --pf-t--global--color--status--unread--attention--clicked: var(--pf-t--global--color--status--danger--clicked);
+  --pf-t--global--color--status--unread--attention--default: var(--pf-t--global--color--status--danger--default);
+  --pf-t--global--color--status--unread--attention--hover: var(--pf-t--global--color--status--danger--hover);
+  --pf-t--global--color--status--unread--clicked: var(--pf-t--global--color--brand--clicked);
+  --pf-t--global--color--status--unread--default: var(--pf-t--global--color--brand--default);
+  --pf-t--global--color--status--unread--hover: var(--pf-t--global--color--brand--hover);
+  --pf-t--global--icon--color--brand--clicked: var(--pf-t--global--color--brand--clicked);
+  --pf-t--global--icon--color--brand--default: var(--pf-t--global--color--brand--default);
+  --pf-t--global--icon--color--brand--hover: var(--pf-t--global--color--brand--hover);
+  --pf-t--global--icon--color--favorite--clicked: var(--pf-t--global--color--favorite--clicked);
+  --pf-t--global--icon--color--favorite--default: var(--pf-t--global--color--favorite--default);
+  --pf-t--global--icon--color--favorite--hover: var(--pf-t--global--color--favorite--hover);
+  --pf-t--global--icon--color--nonstatus--on-blue--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-blue--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-blue--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-gray--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-gray--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-gray--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-green--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-green--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-green--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-orange--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-orange--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-orange--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-orangered--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-orangered--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-orangered--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-purple--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-purple--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-purple--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-red--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-red--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-red--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-teal--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-teal--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-teal--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-yellow--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-yellow--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-yellow--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--on-brand--accent--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--accent--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--accent--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--subtle--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--on-brand--subtle--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--on-brand--subtle--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--status--custom--clicked: var(--pf-t--global--color--status--custom--clicked);
+  --pf-t--global--icon--color--status--custom--default: var(--pf-t--global--color--status--custom--default);
+  --pf-t--global--icon--color--status--custom--hover: var(--pf-t--global--color--status--custom--hover);
+  --pf-t--global--icon--color--status--danger--clicked: var(--pf-t--global--color--status--danger--clicked);
+  --pf-t--global--icon--color--status--danger--default: var(--pf-t--global--color--status--danger--default);
+  --pf-t--global--icon--color--status--danger--hover: var(--pf-t--global--color--status--danger--hover);
+  --pf-t--global--icon--color--status--info--clicked: var(--pf-t--global--color--status--info--clicked);
+  --pf-t--global--icon--color--status--info--default: var(--pf-t--global--color--status--info--default);
+  --pf-t--global--icon--color--status--info--hover: var(--pf-t--global--color--status--info--hover);
+  --pf-t--global--icon--color--status--on-custom--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-custom--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-custom--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-danger--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-danger--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-danger--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-info--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-info--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-info--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-success--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-success--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-success--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-warning--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--status--on-warning--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--status--on-warning--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--status--success--clicked: var(--pf-t--global--color--status--success--clicked);
+  --pf-t--global--icon--color--status--success--default: var(--pf-t--global--color--status--success--default);
+  --pf-t--global--icon--color--status--success--hover: var(--pf-t--global--color--status--success--hover);
+  --pf-t--global--icon--color--status--unread--on-attention--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-attention--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-attention--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-default--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-default--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-default--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--size--font--body--default: var(--pf-t--global--font--size--body--default);
+  --pf-t--global--icon--size--font--body--lg: var(--pf-t--global--font--size--body--lg);
+  --pf-t--global--icon--size--font--body--sm: var(--pf-t--global--font--size--body--sm);
+  --pf-t--global--icon--size--font--heading--h1: var(--pf-t--global--font--size--heading--h1);
+  --pf-t--global--icon--size--font--heading--h2: var(--pf-t--global--font--size--heading--h2);
+  --pf-t--global--icon--size--font--heading--h3: var(--pf-t--global--font--size--heading--h3);
+  --pf-t--global--icon--size--font--heading--h4: var(--pf-t--global--font--size--heading--h4);
+  --pf-t--global--icon--size--font--heading--h5: var(--pf-t--global--font--size--heading--h5);
+  --pf-t--global--icon--size--font--heading--h6: var(--pf-t--global--font--size--heading--h6);
+  --pf-t--global--text--color--brand--clicked: var(--pf-t--global--color--brand--clicked);
+  --pf-t--global--text--color--brand--default: var(--pf-t--global--color--brand--default);
+  --pf-t--global--text--color--brand--hover: var(--pf-t--global--color--brand--hover);
+  --pf-t--global--text--color--nonstatus--on-blue--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-blue--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-blue--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-gray--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-gray--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-gray--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-green--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-green--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-green--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-orange--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-orange--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-orange--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-orangered--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-orangered--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-orangered--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-purple--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-purple--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-purple--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-red--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-red--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-red--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-teal--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-teal--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-teal--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-yellow--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-yellow--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-yellow--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--on-brand--accent--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--accent--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--accent--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--subtle--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--on-brand--subtle--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--on-brand--subtle--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--placeholder: var(--pf-t--global--text--color--subtle);
+  --pf-t--global--text--color--status--custom--clicked: var(--pf-t--global--color--status--custom--clicked);
+  --pf-t--global--text--color--status--custom--default: var(--pf-t--global--color--status--custom--default);
+  --pf-t--global--text--color--status--custom--hover: var(--pf-t--global--color--status--custom--hover);
+  --pf-t--global--text--color--status--danger--clicked: var(--pf-t--global--color--status--danger--clicked);
+  --pf-t--global--text--color--status--danger--default: var(--pf-t--global--color--status--danger--default);
+  --pf-t--global--text--color--status--danger--hover: var(--pf-t--global--color--status--danger--hover);
+  --pf-t--global--text--color--status--info--clicked: var(--pf-t--global--color--status--info--clicked);
+  --pf-t--global--text--color--status--info--default: var(--pf-t--global--color--status--info--default);
+  --pf-t--global--text--color--status--info--hover: var(--pf-t--global--color--status--info--hover);
+  --pf-t--global--text--color--status--on-custom--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-custom--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-custom--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-danger--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--text--color--status--on-danger--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-danger--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-info--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-info--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-info--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-success--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-success--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-success--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-warning--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--status--on-warning--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--status--on-warning--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--status--success--clicked: var(--pf-t--global--color--status--success--clicked);
+  --pf-t--global--text--color--status--success--default: var(--pf-t--global--color--status--success--default);
+  --pf-t--global--text--color--status--success--hover: var(--pf-t--global--color--status--success--hover);
+  --pf-t--global--text--color--status--unread--on-attention--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-attention--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-attention--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-default--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-default--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-default--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text-decoration--color--hover: var(--pf-t--global--border--color--hover);
+  --pf-t--global--border--color--brand--accent--clicked: var(--pf-t--global--color--brand--accent--clicked);
+  --pf-t--global--border--color--brand--accent--default: var(--pf-t--global--color--brand--accent--default);
+  --pf-t--global--border--color--brand--accent--hover: var(--pf-t--global--color--brand--accent--hover);
+  --pf-t--global--color--status--read--on-secondary: var(--pf-t--global--background--color--control--default);
+  --pf-t--global--icon--color--brand--accent--clicked: var(--pf-t--global--color--brand--accent--clicked);
+  --pf-t--global--icon--color--brand--accent--default: var(--pf-t--global--color--brand--accent--default);
+  --pf-t--global--icon--color--brand--accent--hover: var(--pf-t--global--color--brand--accent--hover);
+  --pf-t--global--text-decoration--color--default: var(--pf-t--global--border--color--default);
+  --pf-t--global--text-decoration--color--hover: currentcolor;
+  --pf-t--global--text-decoration--offset--hover: calc(var(--pf-t--global--spacer--xs) + 1px);
+  --pf-t--global--text-decoration--link--style--default: var(--pf-t--global--text-decoration--style--200);
+  --pf-t--global--text-decoration--link--style--hover: var(--pf-t--global--text-decoration--style--200);
+  --pf-t--global--font--size--heading--xs: var(--pf-t--global--font--size--md);
+  --pf-t--global--font--size--heading--sm: var(--pf-t--global--font--size--lg);
+  --pf-t--global--font--size--heading--md: var(--pf-t--global--font--size--xl);
+  --pf-t--global--font--size--heading--lg: var(--pf-t--global--font--size--2xl);
+  --pf-t--global--font--size--heading--xl: var(--pf-t--global--font--size--3xl);
+  --pf-t--global--font--size--heading--2xl: var(--pf-t--global--font--size--4xl);
+  --pf-t--global--font--family--body--legacy: redhattext, helvetica, arial, sans-serif;
+  --pf-t--global--font--family--heading--legacy: redhatdisplay, helvetica, arial, sans-serif;
+  --pf-t--global--font--family--mono--legacy: redhatmono, liberationmono, consolas, sfmono-regular, menlo, monaco, courier new, monospace;
+  --pf-t--global--font--weight--body--legacy: 400;
+  --pf-t--global--font--weight--body--bold--legacy: 700;
+  --pf-t--global--font--weight--heading--legacy: 400;
+  --pf-t--global--font--weight--heading--bold--legacy: 700;
+  --pf-t--global--box-shadow--sm:
+    var(--pf-t--global--box-shadow--X--sm--default)
+    var(--pf-t--global--box-shadow--Y--sm--default)
+    var(--pf-t--global--box-shadow--blur--sm)
+    var(--pf-t--global--box-shadow--spread--sm--default)
+    var(--pf-t--global--box-shadow--color--sm--default);
+  --pf-t--global--box-shadow--sm--top:
+    var(--pf-t--global--box-shadow--X--sm--top)
+    var(--pf-t--global--box-shadow--Y--sm--top)
+    var(--pf-t--global--box-shadow--blur--sm)
+    var(--pf-t--global--box-shadow--spread--sm--directional)
+    var(--pf-t--global--box-shadow--color--sm--directional);
+  --pf-t--global--box-shadow--sm--bottom:
+    var(--pf-t--global--box-shadow--X--sm--bottom)
+    var(--pf-t--global--box-shadow--Y--sm--bottom)
+    var(--pf-t--global--box-shadow--blur--sm)
+    var(--pf-t--global--box-shadow--spread--sm--directional)
+    var(--pf-t--global--box-shadow--color--sm--directional);
+  --pf-t--global--box-shadow--sm--left:
+    var(--pf-t--global--box-shadow--X--sm--left)
+    var(--pf-t--global--box-shadow--Y--sm--left)
+    var(--pf-t--global--box-shadow--blur--sm)
+    var(--pf-t--global--box-shadow--spread--sm--directional)
+    var(--pf-t--global--box-shadow--color--sm--directional);
+  --pf-t--global--box-shadow--sm--right:
+    var(--pf-t--global--box-shadow--X--sm--right)
+    var(--pf-t--global--box-shadow--Y--sm--right)
+    var(--pf-t--global--box-shadow--blur--sm)
+    var(--pf-t--global--box-shadow--spread--sm--directional)
+    var(--pf-t--global--box-shadow--color--sm--directional);
+  --pf-t--global--box-shadow--md:
+    var(--pf-t--global--box-shadow--X--md--default)
+    var(--pf-t--global--box-shadow--Y--md--default)
+    var(--pf-t--global--box-shadow--blur--md)
+    var(--pf-t--global--box-shadow--spread--md--default)
+    var(--pf-t--global--box-shadow--color--md--default);
+  --pf-t--global--box-shadow--md--top:
+    var(--pf-t--global--box-shadow--X--md--top)
+    var(--pf-t--global--box-shadow--Y--md--top)
+    var(--pf-t--global--box-shadow--blur--md)
+    var(--pf-t--global--box-shadow--spread--md--directional)
+    var(--pf-t--global--box-shadow--color--md--directional);
+  --pf-t--global--box-shadow--md--bottom:
+    var(--pf-t--global--box-shadow--X--md--bottom)
+    var(--pf-t--global--box-shadow--Y--md--bottom)
+    var(--pf-t--global--box-shadow--blur--md)
+    var(--pf-t--global--box-shadow--spread--md--directional)
+    var(--pf-t--global--box-shadow--color--md--directional);
+  --pf-t--global--box-shadow--md--left:
+    var(--pf-t--global--box-shadow--X--md--left)
+    var(--pf-t--global--box-shadow--Y--md--left)
+    var(--pf-t--global--box-shadow--blur--md)
+    var(--pf-t--global--box-shadow--spread--md--directional)
+    var(--pf-t--global--box-shadow--color--md--directional);
+  --pf-t--global--box-shadow--md--right:
+    var(--pf-t--global--box-shadow--X--md--right)
+    var(--pf-t--global--box-shadow--Y--md--right)
+    var(--pf-t--global--box-shadow--blur--md)
+    var(--pf-t--global--box-shadow--spread--md--directional)
+    var(--pf-t--global--box-shadow--color--md--directional);
+  --pf-t--global--box-shadow--lg:
+    var(--pf-t--global--box-shadow--X--lg--default)
+    var(--pf-t--global--box-shadow--Y--lg--default)
+    var(--pf-t--global--box-shadow--blur--lg)
+    var(--pf-t--global--box-shadow--spread--lg--default)
+    var(--pf-t--global--box-shadow--color--lg--default);
+  --pf-t--global--box-shadow--lg--top:
+    var(--pf-t--global--box-shadow--X--lg--top)
+    var(--pf-t--global--box-shadow--Y--lg--top)
+    var(--pf-t--global--box-shadow--blur--lg)
+    var(--pf-t--global--box-shadow--spread--lg--directional)
+    var(--pf-t--global--box-shadow--color--lg--directional);
+  --pf-t--global--box-shadow--lg--bottom:
+    var(--pf-t--global--box-shadow--X--lg--bottom)
+    var(--pf-t--global--box-shadow--Y--lg--bottom)
+    var(--pf-t--global--box-shadow--blur--lg)
+    var(--pf-t--global--box-shadow--spread--lg--directional)
+    var(--pf-t--global--box-shadow--color--lg--directional);
+  --pf-t--global--box-shadow--lg--left:
+    var(--pf-t--global--box-shadow--X--lg--left)
+    var(--pf-t--global--box-shadow--Y--lg--left)
+    var(--pf-t--global--box-shadow--blur--lg)
+    var(--pf-t--global--box-shadow--spread--lg--directional)
+    var(--pf-t--global--box-shadow--color--lg--directional);
+  --pf-t--global--box-shadow--lg--right:
+    var(--pf-t--global--box-shadow--X--lg--right)
+    var(--pf-t--global--box-shadow--Y--lg--right)
+    var(--pf-t--global--box-shadow--blur--lg)
+    var(--pf-t--global--box-shadow--spread--lg--directional)
+    var(--pf-t--global--box-shadow--color--lg--directional);
+  --pf-t--global--list-style: disc outside;
+  --pf-t--temp--dev--tbd: #BC11E0;
+  --pf-t--global--background--image--default: none;
+}
+
+:root:where(.pf-v6-theme-felt) {
+  --pf-t--global--border--color--brand--accent--clicked: var(--pf-t--global--color--brand--accent--400);
+  --pf-t--global--border--color--brand--accent--default: var(--pf-t--global--color--brand--accent--400);
+  --pf-t--global--border--color--brand--accent--hover: var(--pf-t--global--color--brand--accent--400);
+  --pf-t--global--border--radius--action--plain--default: var(--pf-t--global--border--radius--pill);
+  --pf-t--global--border--radius--control--default: var(--pf-t--global--border--radius--pill);
+  --pf-t--global--color--brand--accent--clicked: var(--pf-t--global--color--brand--accent--200);
+  --pf-t--global--color--brand--accent--default: var(--pf-t--global--color--brand--accent--100);
+  --pf-t--global--color--brand--accent--hover: var(--pf-t--global--color--brand--accent--200);
+}
+
+:root:where(.pf-v6-theme-high-contrast) {
+  --pf-t--global--background--color--500: rgba(21, 21, 21, 0.4000);
+  --pf-t--global--background--color--600: rgba(199, 199, 199, 0.2500);
+  --pf-t--global--background--color--700: rgba(199, 199, 199, 0.1000);
+  --pf-t--global--background--color--action--plain--default: rgba(255, 255, 255, 0.0000);
+  --pf-t--global--background--filter--glass--blur--primary: initial;
+  --pf-t--global--border--radius--0: 0px;
+  --pf-t--global--border--radius--100: 4px;
+  --pf-t--global--border--radius--200: 6px;
+  --pf-t--global--border--radius--300: 16px;
+  --pf-t--global--border--radius--400: 24px;
+  --pf-t--global--border--radius--500: 999px;
+  --pf-t--global--border--width--100: 1px;
+  --pf-t--global--border--width--200: 2px;
+  --pf-t--global--border--width--300: 3px;
+  --pf-t--global--border--width--400: 4px;
+  --pf-t--global--border--width--action--plain--default: 0px;
+  --pf-t--global--box-shadow--X--100: -10px;
+  --pf-t--global--box-shadow--X--200: -4px;
+  --pf-t--global--box-shadow--X--300: -2px;
+  --pf-t--global--box-shadow--X--400: 0px;
+  --pf-t--global--box-shadow--X--50: -20px;
+  --pf-t--global--box-shadow--X--500: 2px;
+  --pf-t--global--box-shadow--X--600: 4px;
+  --pf-t--global--box-shadow--X--700: 10px;
+  --pf-t--global--box-shadow--X--800: 20px;
+  --pf-t--global--box-shadow--Y--100: -10px;
+  --pf-t--global--box-shadow--Y--200: -4px;
+  --pf-t--global--box-shadow--Y--300: -1px;
+  --pf-t--global--box-shadow--Y--400: 0px;
+  --pf-t--global--box-shadow--Y--50: -20px;
+  --pf-t--global--box-shadow--Y--500: 1px;
+  --pf-t--global--box-shadow--Y--600: 4px;
+  --pf-t--global--box-shadow--Y--700: 10px;
+  --pf-t--global--box-shadow--Y--800: 20px;
+  --pf-t--global--box-shadow--blur--100: 6px;
+  --pf-t--global--box-shadow--blur--200: 10px;
+  --pf-t--global--box-shadow--blur--300: 20px;
+  --pf-t--global--box-shadow--color--100: rgba(41, 41, 41, 0.1500);
+  --pf-t--global--box-shadow--color--200: rgba(41, 41, 41, 0.2000);
+  --pf-t--global--box-shadow--spread--100: 0px;
+  --pf-t--global--box-shadow--spread--200: -4px;
+  --pf-t--global--box-shadow--spread--300: -8px;
+  --pf-t--global--box-shadow--spread--400: -20px;
+  --pf-t--global--breakpoint--100: 0rem;
+  --pf-t--global--breakpoint--200: 36rem;
+  --pf-t--global--breakpoint--250: 40rem;
+  --pf-t--global--breakpoint--300: 48rem;
+  --pf-t--global--breakpoint--350: 60rem;
+  --pf-t--global--breakpoint--400: 62rem;
+  --pf-t--global--breakpoint--500: 75rem;
+  --pf-t--global--breakpoint--550: 80rem;
+  --pf-t--global--breakpoint--600: 90.625rem;
+  --pf-t--global--color--nonstatus--green--400: #3d7019;
+  --pf-t--global--color--status--success--150: #3d7019;
+  --pf-t--global--focus-ring--position--inset: -4px;
+  --pf-t--global--focus-ring--position--offset: 2px;
+  --pf-t--global--focus-ring--width--inset: 3px;
+  --pf-t--global--focus-ring--width--offset: 2px;
+  --pf-t--global--font--family--100: "Red Hat Text", "RedHatText", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", Helvetica, Arial, sans-serif;
+  --pf-t--global--font--family--200: "Red Hat Display", "RedHatDisplay", "Noto Sans Arabic", "Noto Sans Hebrew", "Noto Sans JP", "Noto Sans KR", "Noto Sans Malayalam", "Noto Sans SC", "Noto Sans TC", "Noto Sans Thai", Helvetica, Arial, sans-serif;
+  --pf-t--global--font--family--300: "Red Hat Mono", "RedHatMono", "Courier New", Courier, monospace;
+  --pf-t--global--font--line-height--100: 1.3;
+  --pf-t--global--font--line-height--200: 1.5;
+  --pf-t--global--font--size--100: 0.75rem;
+  --pf-t--global--font--size--200: 0.875rem;
+  --pf-t--global--font--size--300: 1rem;
+  --pf-t--global--font--size--400: 1.125rem;
+  --pf-t--global--font--size--500: 1.25rem;
+  --pf-t--global--font--size--600: 1.5rem;
+  --pf-t--global--font--size--700: 1.75rem;
+  --pf-t--global--font--size--800: 2.25rem;
+  --pf-t--global--font--weight--100: 400;
+  --pf-t--global--font--weight--200: 500;
+  --pf-t--global--font--weight--300: 500;
+  --pf-t--global--font--weight--400: 700;
+  --pf-t--global--icon--size--100: 0.75rem;
+  --pf-t--global--icon--size--200: 0.875rem;
+  --pf-t--global--icon--size--250: 1rem;
+  --pf-t--global--icon--size--300: 1.5rem;
+  --pf-t--global--icon--size--400: 3.5rem;
+  --pf-t--global--icon--size--500: 6rem;
+  --pf-t--global--spacer--100: 0.25rem;
+  --pf-t--global--spacer--200: 0.5rem;
+  --pf-t--global--spacer--300: 1rem;
+  --pf-t--global--spacer--400: 1.5rem;
+  --pf-t--global--spacer--500: 2rem;
+  --pf-t--global--spacer--600: 3rem;
+  --pf-t--global--spacer--700: 4rem;
+  --pf-t--global--spacer--800: 5rem;
+  --pf-t--global--text-decoration--line--100: none;
+  --pf-t--global--text-decoration--line--200: underline;
+  --pf-t--global--text-decoration--style--100: solid;
+  --pf-t--global--text-decoration--style--200: dashed;
+  --pf-t--global--z-index--100: 100;
+  --pf-t--global--z-index--200: 200;
+  --pf-t--global--z-index--300: 300;
+  --pf-t--global--z-index--400: 400;
+  --pf-t--global--z-index--500: 500;
+  --pf-t--global--z-index--600: 600;
+  --pf-t--global--background--color--100: var(--pf-t--color--white);
+  --pf-t--global--background--color--200: var(--pf-t--color--gray--10);
+  --pf-t--global--background--color--300: var(--pf-t--color--gray--20);
+  --pf-t--global--background--color--400: var(--pf-t--color--gray--80);
+  --pf-t--global--background--color--450: var(--pf-t--color--gray--70);
+  --pf-t--global--background--color--action--plain--clicked: var(--pf-t--global--background--color--600);
+  --pf-t--global--background--color--action--plain--hover: var(--pf-t--global--background--color--600);
+  --pf-t--global--background--color--backdrop--default: var(--pf-t--global--background--color--500);
+  --pf-t--global--background--color--highlight--100: var(--pf-t--color--yellow--30);
+  --pf-t--global--background--color--highlight--200: var(--pf-t--color--yellow--40);
+  --pf-t--global--background--color--loading--skeleton--default: var(--pf-t--global--background--color--600);
+  --pf-t--global--background--color--loading--skeleton--subtle: var(--pf-t--global--background--color--700);
+  --pf-t--global--background--color--striped--row--default: var(--pf-t--global--background--color--700);
+  --pf-t--global--background--color--tertiary--default: var(--pf-t--global--background--color--600);
+  --pf-t--global--border--color--100: var(--pf-t--color--gray--30);
+  --pf-t--global--border--color--200: var(--pf-t--color--gray--40);
+  --pf-t--global--border--color--300: var(--pf-t--color--gray--45);
+  --pf-t--global--border--color--400: var(--pf-t--color--gray--60);
+  --pf-t--global--border--color--50: var(--pf-t--color--gray--20);
+  --pf-t--global--border--color--nonstatus--green--default: var(--pf-t--global--color--nonstatus--green--400);
+  --pf-t--global--border--color--status--success--default: var(--pf-t--global--color--status--success--150);
+  --pf-t--global--border--radius--large: var(--pf-t--global--border--radius--400);
+  --pf-t--global--border--radius--medium: var(--pf-t--global--border--radius--300);
+  --pf-t--global--border--radius--pill: var(--pf-t--global--border--radius--500);
+  --pf-t--global--border--radius--sharp: var(--pf-t--global--border--radius--0);
+  --pf-t--global--border--radius--small: var(--pf-t--global--border--radius--200);
+  --pf-t--global--border--radius--tiny: var(--pf-t--global--border--radius--100);
+  --pf-t--global--border--width--action--clicked: var(--pf-t--global--border--width--200);
+  --pf-t--global--border--width--action--default: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--action--hover: var(--pf-t--global--border--width--200);
+  --pf-t--global--border--width--action--plain--clicked: var(--pf-t--global--border--width--200);
+  --pf-t--global--border--width--action--plain--hover: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--box--clicked: var(--pf-t--global--border--width--300);
+  --pf-t--global--border--width--box--default: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--box--hover: var(--pf-t--global--border--width--200);
+  --pf-t--global--border--width--box--status--default: var(--pf-t--global--border--width--200);
+  --pf-t--global--border--width--box--status--read: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--control--clicked: var(--pf-t--global--border--width--200);
+  --pf-t--global--border--width--control--default: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--control--hover: var(--pf-t--global--border--width--200);
+  --pf-t--global--border--width--divider--clicked: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--divider--default: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--divider--hover: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--extra-strong: var(--pf-t--global--border--width--300);
+  --pf-t--global--border--width--main--default: var(--pf-t--global--border--width--200);
+  --pf-t--global--border--width--regular: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--strong: var(--pf-t--global--border--width--200);
+  --pf-t--global--box-shadow--X--lg--bottom: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--lg--default: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--lg--left: var(--pf-t--global--box-shadow--X--50);
+  --pf-t--global--box-shadow--X--lg--right: var(--pf-t--global--box-shadow--X--800);
+  --pf-t--global--box-shadow--X--lg--top: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--md--bottom: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--md--default: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--md--left: var(--pf-t--global--box-shadow--X--100);
+  --pf-t--global--box-shadow--X--md--right: var(--pf-t--global--box-shadow--X--700);
+  --pf-t--global--box-shadow--X--md--top: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--sm--bottom: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--sm--default: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--X--sm--left: var(--pf-t--global--box-shadow--X--200);
+  --pf-t--global--box-shadow--X--sm--right: var(--pf-t--global--box-shadow--X--600);
+  --pf-t--global--box-shadow--X--sm--top: var(--pf-t--global--box-shadow--X--400);
+  --pf-t--global--box-shadow--Y--lg--bottom: var(--pf-t--global--box-shadow--Y--800);
+  --pf-t--global--box-shadow--Y--lg--default: var(--pf-t--global--box-shadow--Y--700);
+  --pf-t--global--box-shadow--Y--lg--left: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--lg--right: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--lg--top: var(--pf-t--global--box-shadow--Y--50);
+  --pf-t--global--box-shadow--Y--md--bottom: var(--pf-t--global--box-shadow--Y--700);
+  --pf-t--global--box-shadow--Y--md--default: var(--pf-t--global--box-shadow--Y--600);
+  --pf-t--global--box-shadow--Y--md--left: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--md--right: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--md--top: var(--pf-t--global--box-shadow--Y--100);
+  --pf-t--global--box-shadow--Y--sm--bottom: var(--pf-t--global--box-shadow--Y--600);
+  --pf-t--global--box-shadow--Y--sm--default: var(--pf-t--global--box-shadow--Y--500);
+  --pf-t--global--box-shadow--Y--sm--left: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--sm--right: var(--pf-t--global--box-shadow--Y--400);
+  --pf-t--global--box-shadow--Y--sm--top: var(--pf-t--global--box-shadow--Y--200);
+  --pf-t--global--box-shadow--blur--lg: var(--pf-t--global--box-shadow--blur--300);
+  --pf-t--global--box-shadow--blur--md: var(--pf-t--global--box-shadow--blur--200);
+  --pf-t--global--box-shadow--blur--sm: var(--pf-t--global--box-shadow--blur--100);
+  --pf-t--global--box-shadow--color--lg--default: var(--pf-t--global--box-shadow--color--100);
+  --pf-t--global--box-shadow--color--lg--directional: var(--pf-t--global--box-shadow--color--200);
+  --pf-t--global--box-shadow--color--md--default: var(--pf-t--global--box-shadow--color--100);
+  --pf-t--global--box-shadow--color--md--directional: var(--pf-t--global--box-shadow--color--100);
+  --pf-t--global--box-shadow--color--sm--default: var(--pf-t--global--box-shadow--color--100);
+  --pf-t--global--box-shadow--color--sm--directional: var(--pf-t--global--box-shadow--color--200);
+  --pf-t--global--box-shadow--spread--lg--default: var(--pf-t--global--box-shadow--spread--100);
+  --pf-t--global--box-shadow--spread--lg--directional: var(--pf-t--global--box-shadow--spread--400);
+  --pf-t--global--box-shadow--spread--md--default: var(--pf-t--global--box-shadow--spread--100);
+  --pf-t--global--box-shadow--spread--md--directional: var(--pf-t--global--box-shadow--spread--300);
+  --pf-t--global--box-shadow--spread--sm--default: var(--pf-t--global--box-shadow--spread--100);
+  --pf-t--global--box-shadow--spread--sm--directional: var(--pf-t--global--box-shadow--spread--200);
+  --pf-t--global--breakpoint--2xl: var(--pf-t--global--breakpoint--600);
+  --pf-t--global--breakpoint--height--2xl: var(--pf-t--global--breakpoint--550);
+  --pf-t--global--breakpoint--height--lg: var(--pf-t--global--breakpoint--300);
+  --pf-t--global--breakpoint--height--md: var(--pf-t--global--breakpoint--250);
+  --pf-t--global--breakpoint--height--sm: var(--pf-t--global--breakpoint--100);
+  --pf-t--global--breakpoint--height--xl: var(--pf-t--global--breakpoint--350);
+  --pf-t--global--breakpoint--lg: var(--pf-t--global--breakpoint--400);
+  --pf-t--global--breakpoint--md: var(--pf-t--global--breakpoint--300);
+  --pf-t--global--breakpoint--sm: var(--pf-t--global--breakpoint--200);
+  --pf-t--global--breakpoint--xl: var(--pf-t--global--breakpoint--500);
+  --pf-t--global--breakpoint--xs: var(--pf-t--global--breakpoint--100);
+  --pf-t--global--color--brand--100: var(--pf-t--color--blue--40);
+  --pf-t--global--color--brand--200: var(--pf-t--color--blue--50);
+  --pf-t--global--color--brand--300: var(--pf-t--color--blue--60);
+  --pf-t--global--color--brand--400: var(--pf-t--color--blue--70);
+  --pf-t--global--color--brand--500: var(--pf-t--color--blue--80);
+  --pf-t--global--color--brand--accent--100: var(--pf-t--color--red--50);
+  --pf-t--global--color--brand--accent--200: var(--pf-t--color--red--60);
+  --pf-t--global--color--brand--accent--300: var(--pf-t--color--gray--60);
+  --pf-t--global--color--brand--accent--400: var(--pf-t--color--black);
+  --pf-t--global--color--brand--subtle--100: var(--pf-t--color--blue--10);
+  --pf-t--global--color--brand--subtle--200: var(--pf-t--color--blue--20);
+  --pf-t--global--color--brand--subtle--300: var(--pf-t--color--blue--40);
+  --pf-t--global--color--brand--subtle--400: var(--pf-t--color--blue--50);
+  --pf-t--global--color--disabled--100: var(--pf-t--color--gray--30);
+  --pf-t--global--color--disabled--200: var(--pf-t--color--gray--40);
+  --pf-t--global--color--disabled--300: var(--pf-t--color--gray--50);
+  --pf-t--global--color--favorite--100: var(--pf-t--color--yellow--30);
+  --pf-t--global--color--favorite--200: var(--pf-t--color--yellow--40);
+  --pf-t--global--color--favorite--300: var(--pf-t--color--yellow--70);
+  --pf-t--global--color--favorite--400: var(--pf-t--color--yellow--80);
+  --pf-t--global--color--nonstatus--blue--100: var(--pf-t--color--blue--20);
+  --pf-t--global--color--nonstatus--blue--200: var(--pf-t--color--blue--30);
+  --pf-t--global--color--nonstatus--blue--300: var(--pf-t--color--blue--40);
+  --pf-t--global--color--nonstatus--blue--400: var(--pf-t--color--blue--60);
+  --pf-t--global--color--nonstatus--blue--500: var(--pf-t--color--blue--70);
+  --pf-t--global--color--nonstatus--gray--100: var(--pf-t--color--gray--20);
+  --pf-t--global--color--nonstatus--gray--200: var(--pf-t--color--gray--30);
+  --pf-t--global--color--nonstatus--gray--300: var(--pf-t--color--gray--40);
+  --pf-t--global--color--nonstatus--gray--400: var(--pf-t--color--gray--60);
+  --pf-t--global--color--nonstatus--gray--50: var(--pf-t--color--gray--10);
+  --pf-t--global--color--nonstatus--gray--500: var(--pf-t--color--gray--70);
+  --pf-t--global--color--nonstatus--green--100: var(--pf-t--color--green--20);
+  --pf-t--global--color--nonstatus--green--200: var(--pf-t--color--green--30);
+  --pf-t--global--color--nonstatus--green--300: var(--pf-t--color--green--40);
+  --pf-t--global--color--nonstatus--green--500: var(--pf-t--color--green--70);
+  --pf-t--global--color--nonstatus--orange--100: var(--pf-t--color--orange--20);
+  --pf-t--global--color--nonstatus--orange--200: var(--pf-t--color--orange--30);
+  --pf-t--global--color--nonstatus--orange--300: var(--pf-t--color--orange--40);
+  --pf-t--global--color--nonstatus--orange--400: var(--pf-t--color--orange--60);
+  --pf-t--global--color--nonstatus--orange--500: var(--pf-t--color--orange--70);
+  --pf-t--global--color--nonstatus--orangered--100: var(--pf-t--color--red-orange--20);
+  --pf-t--global--color--nonstatus--orangered--200: var(--pf-t--color--red-orange--30);
+  --pf-t--global--color--nonstatus--orangered--300: var(--pf-t--color--red-orange--40);
+  --pf-t--global--color--nonstatus--orangered--400: var(--pf-t--color--red-orange--60);
+  --pf-t--global--color--nonstatus--orangered--500: var(--pf-t--color--red-orange--70);
+  --pf-t--global--color--nonstatus--purple--100: var(--pf-t--color--purple--20);
+  --pf-t--global--color--nonstatus--purple--200: var(--pf-t--color--purple--30);
+  --pf-t--global--color--nonstatus--purple--300: var(--pf-t--color--purple--40);
+  --pf-t--global--color--nonstatus--purple--400: var(--pf-t--color--purple--50);
+  --pf-t--global--color--nonstatus--purple--500: var(--pf-t--color--purple--60);
+  --pf-t--global--color--nonstatus--red--100: var(--pf-t--color--red--20);
+  --pf-t--global--color--nonstatus--red--200: var(--pf-t--color--red--30);
+  --pf-t--global--color--nonstatus--red--300: var(--pf-t--color--red--40);
+  --pf-t--global--color--nonstatus--red--400: var(--pf-t--color--red--60);
+  --pf-t--global--color--nonstatus--red--500: var(--pf-t--color--red--70);
+  --pf-t--global--color--nonstatus--teal--100: var(--pf-t--color--teal--20);
+  --pf-t--global--color--nonstatus--teal--200: var(--pf-t--color--teal--30);
+  --pf-t--global--color--nonstatus--teal--300: var(--pf-t--color--teal--40);
+  --pf-t--global--color--nonstatus--teal--400: var(--pf-t--color--teal--70);
+  --pf-t--global--color--nonstatus--teal--500: var(--pf-t--color--teal--80);
+  --pf-t--global--color--nonstatus--yellow--100: var(--pf-t--color--yellow--20);
+  --pf-t--global--color--nonstatus--yellow--200: var(--pf-t--color--yellow--30);
+  --pf-t--global--color--nonstatus--yellow--300: var(--pf-t--color--yellow--40);
+  --pf-t--global--color--nonstatus--yellow--400: var(--pf-t--color--yellow--70);
+  --pf-t--global--color--nonstatus--yellow--500: var(--pf-t--color--yellow--80);
+  --pf-t--global--color--severity--critical--100: var(--pf-t--color--red-orange--60);
+  --pf-t--global--color--severity--important--100: var(--pf-t--color--orange--50);
+  --pf-t--global--color--severity--important--200: var(--pf-t--color--orange--60);
+  --pf-t--global--color--severity--minor--100: var(--pf-t--color--gray--50);
+  --pf-t--global--color--severity--minor--200: var(--pf-t--color--gray--80);
+  --pf-t--global--color--severity--moderate--100: var(--pf-t--color--yellow--40);
+  --pf-t--global--color--severity--moderate--200: var(--pf-t--color--yellow--70);
+  --pf-t--global--color--severity--none--100: var(--pf-t--color--blue--40);
+  --pf-t--global--color--severity--none--200: var(--pf-t--color--blue--60);
+  --pf-t--global--color--severity--undefined--100: var(--pf-t--color--gray--30);
+  --pf-t--global--color--severity--undefined--200: var(--pf-t--color--gray--60);
+  --pf-t--global--color--status--custom--100: var(--pf-t--color--teal--60);
+  --pf-t--global--color--status--custom--200: var(--pf-t--color--teal--70);
+  --pf-t--global--color--status--custom--300: var(--pf-t--color--teal--80);
+  --pf-t--global--color--status--danger--100: var(--pf-t--color--red-orange--60);
+  --pf-t--global--color--status--danger--200: var(--pf-t--color--red-orange--70);
+  --pf-t--global--color--status--danger--300: var(--pf-t--color--red-orange--70);
+  --pf-t--global--color--status--info--100: var(--pf-t--color--purple--50);
+  --pf-t--global--color--status--info--200: var(--pf-t--color--purple--60);
+  --pf-t--global--color--status--info--300: var(--pf-t--color--purple--70);
+  --pf-t--global--color--status--success--100: var(--pf-t--color--green--60);
+  --pf-t--global--color--status--success--200: var(--pf-t--color--green--70);
+  --pf-t--global--color--status--success--300: var(--pf-t--color--green--80);
+  --pf-t--global--color--status--warning--100: var(--pf-t--color--yellow--30);
+  --pf-t--global--color--status--warning--200: var(--pf-t--color--yellow--40);
+  --pf-t--global--color--status--warning--300: var(--pf-t--color--yellow--50);
+  --pf-t--global--color--status--warning--400: var(--pf-t--color--yellow--60);
+  --pf-t--global--color--status--warning--500: var(--pf-t--color--yellow--70);
+  --pf-t--global--color--status--warning--600: var(--pf-t--color--yellow--80);
+  --pf-t--global--focus-ring--color--100: var(--pf-t--color--blue--50);
+  --pf-t--global--focus-ring--color--200: var(--pf-t--color--blue--60);
+  --pf-t--global--font--family--body: var(--pf-t--global--font--family--100);
+  --pf-t--global--font--family--heading: var(--pf-t--global--font--family--200);
+  --pf-t--global--font--family--mono: var(--pf-t--global--font--family--300);
+  --pf-t--global--font--line-height--body: var(--pf-t--global--font--line-height--200);
+  --pf-t--global--font--line-height--heading: var(--pf-t--global--font--line-height--100);
+  --pf-t--global--font--size--2xl: var(--pf-t--global--font--size--600);
+  --pf-t--global--font--size--3xl: var(--pf-t--global--font--size--700);
+  --pf-t--global--font--size--4xl: var(--pf-t--global--font--size--800);
+  --pf-t--global--font--size--lg: var(--pf-t--global--font--size--400);
+  --pf-t--global--font--size--md: var(--pf-t--global--font--size--300);
+  --pf-t--global--font--size--sm: var(--pf-t--global--font--size--200);
+  --pf-t--global--font--size--xl: var(--pf-t--global--font--size--500);
+  --pf-t--global--font--size--xs: var(--pf-t--global--font--size--100);
+  --pf-t--global--font--weight--body--bold: var(--pf-t--global--font--weight--200);
+  --pf-t--global--font--weight--body--default: var(--pf-t--global--font--weight--100);
+  --pf-t--global--font--weight--heading--bold: var(--pf-t--global--font--weight--400);
+  --pf-t--global--font--weight--heading--default: var(--pf-t--global--font--weight--300);
+  --pf-t--global--icon--color--100: var(--pf-t--color--gray--90);
+  --pf-t--global--icon--color--150: var(--pf-t--color--gray--60);
+  --pf-t--global--icon--color--200: var(--pf-t--color--gray--50);
+  --pf-t--global--icon--color--300: var(--pf-t--color--white);
+  --pf-t--global--icon--size--2xl: var(--pf-t--global--icon--size--400);
+  --pf-t--global--icon--size--3xl: var(--pf-t--global--icon--size--500);
+  --pf-t--global--icon--size--lg: var(--pf-t--global--icon--size--250);
+  --pf-t--global--icon--size--md: var(--pf-t--global--icon--size--200);
+  --pf-t--global--icon--size--sm: var(--pf-t--global--icon--size--100);
+  --pf-t--global--icon--size--xl: var(--pf-t--global--icon--size--300);
+  --pf-t--global--spacer--2xl: var(--pf-t--global--spacer--600);
+  --pf-t--global--spacer--3xl: var(--pf-t--global--spacer--700);
+  --pf-t--global--spacer--4xl: var(--pf-t--global--spacer--800);
+  --pf-t--global--spacer--lg: var(--pf-t--global--spacer--400);
+  --pf-t--global--spacer--md: var(--pf-t--global--spacer--300);
+  --pf-t--global--spacer--sm: var(--pf-t--global--spacer--200);
+  --pf-t--global--spacer--xl: var(--pf-t--global--spacer--500);
+  --pf-t--global--spacer--xs: var(--pf-t--global--spacer--100);
+  --pf-t--global--text--color--100: var(--pf-t--color--gray--95);
+  --pf-t--global--text--color--200: var(--pf-t--color--gray--60);
+  --pf-t--global--text--color--250: var(--pf-t--color--gray--70);
+  --pf-t--global--text--color--300: var(--pf-t--color--white);
+  --pf-t--global--text--color--400: var(--pf-t--color--red-orange--40);
+  --pf-t--global--text--color--500: var(--pf-t--color--red-orange--70);
+  --pf-t--global--text--color--link--100: var(--pf-t--color--blue--50);
+  --pf-t--global--text--color--link--200: var(--pf-t--color--blue--60);
+  --pf-t--global--text--color--link--250: var(--pf-t--color--blue--70);
+  --pf-t--global--text--color--link--300: var(--pf-t--color--purple--50);
+  --pf-t--global--text--color--link--350: var(--pf-t--color--purple--60);
+  --pf-t--global--text-decoration--editable-text--line--default: var(--pf-t--global--text-decoration--line--200);
+  --pf-t--global--text-decoration--editable-text--line--hover: var(--pf-t--global--text-decoration--line--200);
+  --pf-t--global--text-decoration--editable-text--style--default: var(--pf-t--global--text-decoration--style--200);
+  --pf-t--global--text-decoration--editable-text--style--hover: var(--pf-t--global--text-decoration--style--200);
+  --pf-t--global--text-decoration--help-text--line--default: var(--pf-t--global--text-decoration--line--200);
+  --pf-t--global--text-decoration--help-text--line--hover: var(--pf-t--global--text-decoration--line--200);
+  --pf-t--global--text-decoration--help-text--style--default: var(--pf-t--global--text-decoration--style--200);
+  --pf-t--global--text-decoration--help-text--style--hover: var(--pf-t--global--text-decoration--style--200);
+  --pf-t--global--text-decoration--link--line--default: var(--pf-t--global--text-decoration--line--200);
+  --pf-t--global--text-decoration--link--line--hover: var(--pf-t--global--text-decoration--line--200);
+  --pf-t--global--text-decoration--link--style--default: var(--pf-t--global--text-decoration--style--200);
+  --pf-t--global--text-decoration--link--style--hover: var(--pf-t--global--text-decoration--style--200);
+  --pf-t--global--z-index--2xl: var(--pf-t--global--z-index--600);
+  --pf-t--global--z-index--lg: var(--pf-t--global--z-index--400);
+  --pf-t--global--z-index--md: var(--pf-t--global--z-index--300);
+  --pf-t--global--z-index--sm: var(--pf-t--global--z-index--200);
+  --pf-t--global--z-index--xl: var(--pf-t--global--z-index--500);
+  --pf-t--global--z-index--xs: var(--pf-t--global--z-index--100);
+  --pf-t--global--background--color--control--read-only: var(--pf-t--global--background--color--200);
+  --pf-t--global--background--color--disabled--default: var(--pf-t--global--color--disabled--100);
+  --pf-t--global--background--color--floating--clicked: var(--pf-t--global--background--color--200);
+  --pf-t--global--background--color--floating--default: var(--pf-t--global--background--color--100);
+  --pf-t--global--background--color--floating--hover: var(--pf-t--global--background--color--200);
+  --pf-t--global--background--color--highlight--clicked: var(--pf-t--global--background--color--highlight--200);
+  --pf-t--global--background--color--highlight--default: var(--pf-t--global--background--color--highlight--100);
+  --pf-t--global--background--color--inverse--clicked: var(--pf-t--global--background--color--450);
+  --pf-t--global--background--color--inverse--default: var(--pf-t--global--background--color--400);
+  --pf-t--global--background--color--inverse--hover: var(--pf-t--global--background--color--450);
+  --pf-t--global--background--color--primary--clicked: var(--pf-t--global--background--color--200);
+  --pf-t--global--background--color--primary--default: var(--pf-t--global--background--color--100);
+  --pf-t--global--background--color--primary--hover: var(--pf-t--global--background--color--200);
+  --pf-t--global--background--color--secondary--clicked: var(--pf-t--global--background--color--300);
+  --pf-t--global--background--color--secondary--default: var(--pf-t--global--background--color--200);
+  --pf-t--global--background--color--secondary--hover: var(--pf-t--global--background--color--300);
+  --pf-t--global--background--color--sticky--default: var(--pf-t--global--background--color--100);
+  --pf-t--global--border--color--brand--subtle--clicked: var(--pf-t--global--color--brand--subtle--400);
+  --pf-t--global--border--color--brand--subtle--default: var(--pf-t--global--color--brand--subtle--200);
+  --pf-t--global--border--color--brand--subtle--hover: var(--pf-t--global--color--brand--subtle--400);
+  --pf-t--global--border--color--clicked: var(--pf-t--global--color--brand--400);
+  --pf-t--global--border--color--control--default: var(--pf-t--global--border--color--400);
+  --pf-t--global--border--color--control--read-only: var(--pf-t--global--border--color--100);
+  --pf-t--global--border--color--default: var(--pf-t--global--border--color--400);
+  --pf-t--global--border--color--disabled: var(--pf-t--global--color--disabled--200);
+  --pf-t--global--border--color--hover: var(--pf-t--global--color--brand--300);
+  --pf-t--global--border--color--nonstatus--blue--clicked: var(--pf-t--global--color--nonstatus--blue--500);
+  --pf-t--global--border--color--nonstatus--blue--default: var(--pf-t--global--color--nonstatus--blue--400);
+  --pf-t--global--border--color--nonstatus--blue--hover: var(--pf-t--global--color--nonstatus--blue--500);
+  --pf-t--global--border--color--nonstatus--gray--clicked: var(--pf-t--global--color--nonstatus--gray--500);
+  --pf-t--global--border--color--nonstatus--gray--default: var(--pf-t--global--color--nonstatus--gray--400);
+  --pf-t--global--border--color--nonstatus--gray--hover: var(--pf-t--global--color--nonstatus--gray--500);
+  --pf-t--global--border--color--nonstatus--green--clicked: var(--pf-t--global--color--nonstatus--green--500);
+  --pf-t--global--border--color--nonstatus--green--hover: var(--pf-t--global--color--nonstatus--green--500);
+  --pf-t--global--border--color--nonstatus--orange--clicked: var(--pf-t--global--color--nonstatus--orange--500);
+  --pf-t--global--border--color--nonstatus--orange--default: var(--pf-t--global--color--nonstatus--orange--400);
+  --pf-t--global--border--color--nonstatus--orange--hover: var(--pf-t--global--color--nonstatus--orange--500);
+  --pf-t--global--border--color--nonstatus--orangered--clicked: var(--pf-t--global--color--nonstatus--orangered--500);
+  --pf-t--global--border--color--nonstatus--orangered--default: var(--pf-t--global--color--nonstatus--orangered--400);
+  --pf-t--global--border--color--nonstatus--orangered--hover: var(--pf-t--global--color--nonstatus--orangered--500);
+  --pf-t--global--border--color--nonstatus--purple--clicked: var(--pf-t--global--color--nonstatus--purple--500);
+  --pf-t--global--border--color--nonstatus--purple--default: var(--pf-t--global--color--nonstatus--purple--400);
+  --pf-t--global--border--color--nonstatus--purple--hover: var(--pf-t--global--color--nonstatus--purple--500);
+  --pf-t--global--border--color--nonstatus--red--clicked: var(--pf-t--global--color--nonstatus--red--500);
+  --pf-t--global--border--color--nonstatus--red--default: var(--pf-t--global--color--nonstatus--red--400);
+  --pf-t--global--border--color--nonstatus--red--hover: var(--pf-t--global--color--nonstatus--red--500);
+  --pf-t--global--border--color--nonstatus--teal--clicked: var(--pf-t--global--color--nonstatus--teal--500);
+  --pf-t--global--border--color--nonstatus--teal--default: var(--pf-t--global--color--nonstatus--teal--400);
+  --pf-t--global--border--color--nonstatus--teal--hover: var(--pf-t--global--color--nonstatus--teal--500);
+  --pf-t--global--border--color--nonstatus--yellow--clicked: var(--pf-t--global--color--nonstatus--yellow--500);
+  --pf-t--global--border--color--nonstatus--yellow--default: var(--pf-t--global--color--nonstatus--yellow--400);
+  --pf-t--global--border--color--nonstatus--yellow--hover: var(--pf-t--global--color--nonstatus--yellow--500);
+  --pf-t--global--border--color--on-secondary: var(--pf-t--global--border--color--400);
+  --pf-t--global--border--color--status--success--clicked: var(--pf-t--global--color--status--success--200);
+  --pf-t--global--border--color--status--success--hover: var(--pf-t--global--color--status--success--200);
+  --pf-t--global--border--color--status--warning--clicked: var(--pf-t--global--color--status--warning--600);
+  --pf-t--global--border--color--status--warning--default: var(--pf-t--global--color--status--warning--500);
+  --pf-t--global--border--color--status--warning--hover: var(--pf-t--global--color--status--warning--600);
+  --pf-t--global--border--color--subtle: var(--pf-t--global--border--color--400);
+  --pf-t--global--border--radius--action--default: var(--pf-t--global--border--radius--pill);
+  --pf-t--global--border--radius--action--plain--default: var(--pf-t--global--border--radius--small);
+  --pf-t--global--border--radius--control--default: var(--pf-t--global--border--radius--small);
+  --pf-t--global--border--radius--control--form-element: var(--pf-t--global--border--radius--small);
+  --pf-t--global--border--radius--glass--default: initial;
+  --pf-t--global--border--width--glass--default: initial;
+  --pf-t--global--border--width--high-contrast--extra-strong: var(--pf-t--global--border--width--extra-strong);
+  --pf-t--global--border--width--high-contrast--regular: var(--pf-t--global--border--width--regular);
+  --pf-t--global--border--width--high-contrast--strong: var(--pf-t--global--border--width--strong);
+  --pf-t--global--color--brand--clicked: var(--pf-t--global--color--brand--400);
+  --pf-t--global--color--brand--default: var(--pf-t--global--color--brand--300);
+  --pf-t--global--color--brand--hover: var(--pf-t--global--color--brand--400);
+  --pf-t--global--color--brand--subtle--clicked: var(--pf-t--global--color--brand--subtle--200);
+  --pf-t--global--color--brand--subtle--default: var(--pf-t--global--color--brand--subtle--100);
+  --pf-t--global--color--brand--subtle--hover: var(--pf-t--global--color--brand--subtle--200);
+  --pf-t--global--color--favorite--clicked: var(--pf-t--global--color--favorite--400);
+  --pf-t--global--color--favorite--default: var(--pf-t--global--color--favorite--300);
+  --pf-t--global--color--favorite--hover: var(--pf-t--global--color--favorite--400);
+  --pf-t--global--color--nonstatus--blue--clicked: var(--pf-t--global--color--nonstatus--blue--200);
+  --pf-t--global--color--nonstatus--blue--default: var(--pf-t--global--color--nonstatus--blue--100);
+  --pf-t--global--color--nonstatus--blue--hover: var(--pf-t--global--color--nonstatus--blue--200);
+  --pf-t--global--color--nonstatus--gray--clicked: var(--pf-t--global--color--nonstatus--gray--100);
+  --pf-t--global--color--nonstatus--gray--default: var(--pf-t--global--color--nonstatus--gray--50);
+  --pf-t--global--color--nonstatus--gray--hover: var(--pf-t--global--color--nonstatus--gray--100);
+  --pf-t--global--color--nonstatus--green--clicked: var(--pf-t--global--color--nonstatus--green--200);
+  --pf-t--global--color--nonstatus--green--default: var(--pf-t--global--color--nonstatus--green--100);
+  --pf-t--global--color--nonstatus--green--hover: var(--pf-t--global--color--nonstatus--green--200);
+  --pf-t--global--color--nonstatus--orange--clicked: var(--pf-t--global--color--nonstatus--orange--200);
+  --pf-t--global--color--nonstatus--orange--default: var(--pf-t--global--color--nonstatus--orange--100);
+  --pf-t--global--color--nonstatus--orange--hover: var(--pf-t--global--color--nonstatus--orange--200);
+  --pf-t--global--color--nonstatus--orangered--clicked: var(--pf-t--global--color--nonstatus--orangered--200);
+  --pf-t--global--color--nonstatus--orangered--default: var(--pf-t--global--color--nonstatus--orangered--100);
+  --pf-t--global--color--nonstatus--orangered--hover: var(--pf-t--global--color--nonstatus--orangered--200);
+  --pf-t--global--color--nonstatus--purple--clicked: var(--pf-t--global--color--nonstatus--purple--200);
+  --pf-t--global--color--nonstatus--purple--default: var(--pf-t--global--color--nonstatus--purple--100);
+  --pf-t--global--color--nonstatus--purple--hover: var(--pf-t--global--color--nonstatus--purple--200);
+  --pf-t--global--color--nonstatus--red--clicked: var(--pf-t--global--color--nonstatus--red--200);
+  --pf-t--global--color--nonstatus--red--default: var(--pf-t--global--color--nonstatus--red--100);
+  --pf-t--global--color--nonstatus--red--hover: var(--pf-t--global--color--nonstatus--red--200);
+  --pf-t--global--color--nonstatus--teal--clicked: var(--pf-t--global--color--nonstatus--teal--200);
+  --pf-t--global--color--nonstatus--teal--default: var(--pf-t--global--color--nonstatus--teal--100);
+  --pf-t--global--color--nonstatus--teal--hover: var(--pf-t--global--color--nonstatus--teal--200);
+  --pf-t--global--color--nonstatus--yellow--clicked: var(--pf-t--global--color--nonstatus--yellow--200);
+  --pf-t--global--color--nonstatus--yellow--default: var(--pf-t--global--color--nonstatus--yellow--100);
+  --pf-t--global--color--nonstatus--yellow--hover: var(--pf-t--global--color--nonstatus--yellow--200);
+  --pf-t--global--color--status--custom--clicked: var(--pf-t--global--color--status--custom--300);
+  --pf-t--global--color--status--custom--default: var(--pf-t--global--color--status--custom--200);
+  --pf-t--global--color--status--custom--hover: var(--pf-t--global--color--status--custom--300);
+  --pf-t--global--color--status--danger--clicked: var(--pf-t--global--color--status--danger--300);
+  --pf-t--global--color--status--danger--default: var(--pf-t--global--color--status--danger--200);
+  --pf-t--global--color--status--danger--hover: var(--pf-t--global--color--status--danger--300);
+  --pf-t--global--color--status--info--clicked: var(--pf-t--global--color--status--info--300);
+  --pf-t--global--color--status--info--default: var(--pf-t--global--color--status--info--200);
+  --pf-t--global--color--status--info--hover: var(--pf-t--global--color--status--info--300);
+  --pf-t--global--color--status--success--clicked: var(--pf-t--global--color--status--success--300);
+  --pf-t--global--color--status--success--default: var(--pf-t--global--color--status--success--200);
+  --pf-t--global--color--status--success--hover: var(--pf-t--global--color--status--success--300);
+  --pf-t--global--color--status--warning--clicked: var(--pf-t--global--color--status--warning--600);
+  --pf-t--global--color--status--warning--default: var(--pf-t--global--color--status--warning--500);
+  --pf-t--global--color--status--warning--hover: var(--pf-t--global--color--status--warning--600);
+  --pf-t--global--focus-ring--color--default: var(--pf-t--global--focus-ring--color--200);
+  --pf-t--global--font--size--body--default: var(--pf-t--global--font--size--sm);
+  --pf-t--global--font--size--body--lg: var(--pf-t--global--font--size--md);
+  --pf-t--global--font--size--body--sm: var(--pf-t--global--font--size--xs);
+  --pf-t--global--font--size--heading--h1: var(--pf-t--global--font--size--2xl);
+  --pf-t--global--font--size--heading--h2: var(--pf-t--global--font--size--xl);
+  --pf-t--global--font--size--heading--h3: var(--pf-t--global--font--size--lg);
+  --pf-t--global--font--size--heading--h4: var(--pf-t--global--font--size--md);
+  --pf-t--global--font--size--heading--h5: var(--pf-t--global--font--size--md);
+  --pf-t--global--font--size--heading--h6: var(--pf-t--global--font--size--md);
+  --pf-t--global--icon--color--brand--clicked: var(--pf-t--global--color--brand--400);
+  --pf-t--global--icon--color--brand--default: var(--pf-t--global--color--brand--300);
+  --pf-t--global--icon--color--brand--hover: var(--pf-t--global--color--brand--400);
+  --pf-t--global--icon--color--disabled: var(--pf-t--global--color--disabled--200);
+  --pf-t--global--icon--color--inverse: var(--pf-t--global--icon--color--300);
+  --pf-t--global--icon--color--on-disabled: var(--pf-t--global--color--disabled--300);
+  --pf-t--global--icon--color--regular: var(--pf-t--global--icon--color--100);
+  --pf-t--global--icon--color--severity--critical--default: var(--pf-t--global--color--severity--critical--100);
+  --pf-t--global--icon--color--severity--important--default: var(--pf-t--global--color--severity--important--200);
+  --pf-t--global--icon--color--severity--minor--default: var(--pf-t--global--color--severity--minor--200);
+  --pf-t--global--icon--color--severity--moderate--default: var(--pf-t--global--color--severity--moderate--200);
+  --pf-t--global--icon--color--severity--none--default: var(--pf-t--global--color--severity--none--200);
+  --pf-t--global--icon--color--severity--undefined--default: var(--pf-t--global--color--severity--undefined--200);
+  --pf-t--global--icon--color--status--danger--clicked: var(--pf-t--global--color--status--danger--200);
+  --pf-t--global--icon--color--status--danger--default: var(--pf-t--global--color--status--danger--100);
+  --pf-t--global--icon--color--status--danger--hover: var(--pf-t--global--color--status--danger--200);
+  --pf-t--global--icon--color--status--warning--clicked: var(--pf-t--global--color--status--warning--600);
+  --pf-t--global--icon--color--status--warning--default: var(--pf-t--global--color--status--warning--500);
+  --pf-t--global--icon--color--status--warning--hover: var(--pf-t--global--color--status--warning--600);
+  --pf-t--global--icon--color--subtle: var(--pf-t--global--icon--color--150);
+  --pf-t--global--icon--size--font--2xl: var(--pf-t--global--font--size--2xl);
+  --pf-t--global--icon--size--font--3xl: var(--pf-t--global--font--size--3xl);
+  --pf-t--global--icon--size--font--4xl: var(--pf-t--global--font--size--4xl);
+  --pf-t--global--icon--size--font--lg: var(--pf-t--global--font--size--lg);
+  --pf-t--global--icon--size--font--md: var(--pf-t--global--font--size--md);
+  --pf-t--global--icon--size--font--sm: var(--pf-t--global--font--size--sm);
+  --pf-t--global--icon--size--font--xl: var(--pf-t--global--font--size--xl);
+  --pf-t--global--icon--size--font--xs: var(--pf-t--global--font--size--xs);
+  --pf-t--global--spacer--action--horizontal--compact: var(--pf-t--global--spacer--md);
+  --pf-t--global--spacer--action--horizontal--default: var(--pf-t--global--spacer--lg);
+  --pf-t--global--spacer--action--horizontal--plain--compact: var(--pf-t--global--spacer--xs);
+  --pf-t--global--spacer--action--horizontal--plain--default: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--action--horizontal--spacious: var(--pf-t--global--spacer--xl);
+  --pf-t--global--spacer--control--horizontal--compact: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--control--horizontal--default: var(--pf-t--global--spacer--md);
+  --pf-t--global--spacer--control--horizontal--plain: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--control--horizontal--spacious: var(--pf-t--global--spacer--lg);
+  --pf-t--global--spacer--control--vertical--compact: var(--pf-t--global--spacer--xs);
+  --pf-t--global--spacer--control--vertical--default: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--control--vertical--plain: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--control--vertical--spacious: var(--pf-t--global--spacer--md);
+  --pf-t--global--spacer--gap--action-to-action--default: var(--pf-t--global--spacer--md);
+  --pf-t--global--spacer--gap--action-to-action--plain: var(--pf-t--global--spacer--xs);
+  --pf-t--global--spacer--gap--control-to-control--default: var(--pf-t--global--spacer--xs);
+  --pf-t--global--spacer--gap--group--horizontal: var(--pf-t--global--spacer--md);
+  --pf-t--global--spacer--gap--group--vertical: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--gap--group-to-group--horizontal--compact: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--gap--group-to-group--horizontal--default: var(--pf-t--global--spacer--2xl);
+  --pf-t--global--spacer--gap--group-to-group--vertical--compact: var(--pf-t--global--spacer--md);
+  --pf-t--global--spacer--gap--group-to-group--vertical--default: var(--pf-t--global--spacer--lg);
+  --pf-t--global--spacer--gap--text-to-element--compact: var(--pf-t--global--spacer--xs);
+  --pf-t--global--spacer--gap--text-to-element--default: var(--pf-t--global--spacer--sm);
+  --pf-t--global--spacer--gutter--default: var(--pf-t--global--spacer--md);
+  --pf-t--global--spacer--inset--page-chrome: var(--pf-t--global--spacer--lg);
+  --pf-t--global--text--color--brand--clicked: var(--pf-t--global--color--brand--500);
+  --pf-t--global--text--color--brand--default: var(--pf-t--global--color--brand--400);
+  --pf-t--global--text--color--brand--hover: var(--pf-t--global--color--brand--500);
+  --pf-t--global--text--color--disabled: var(--pf-t--global--color--disabled--200);
+  --pf-t--global--text--color--inverse: var(--pf-t--global--text--color--300);
+  --pf-t--global--text--color--link--default: var(--pf-t--global--text--color--link--200);
+  --pf-t--global--text--color--link--hover: var(--pf-t--global--text--color--link--250);
+  --pf-t--global--text--color--link--visited: var(--pf-t--global--text--color--link--350);
+  --pf-t--global--text--color--on-disabled: var(--pf-t--global--color--disabled--300);
+  --pf-t--global--text--color--on-highlight: var(--pf-t--global--text--color--100);
+  --pf-t--global--text--color--regular: var(--pf-t--global--text--color--100);
+  --pf-t--global--text--color--required: var(--pf-t--global--text--color--500);
+  --pf-t--global--text--color--status--success--clicked: var(--pf-t--global--color--status--success--300);
+  --pf-t--global--text--color--status--success--default: var(--pf-t--global--color--status--success--200);
+  --pf-t--global--text--color--status--success--hover: var(--pf-t--global--color--status--success--300);
+  --pf-t--global--text--color--status--warning--clicked: var(--pf-t--global--color--status--warning--600);
+  --pf-t--global--text--color--status--warning--default: var(--pf-t--global--color--status--warning--500);
+  --pf-t--global--text--color--status--warning--hover: var(--pf-t--global--color--status--warning--600);
+  --pf-t--global--text--color--subtle: var(--pf-t--global--text--color--250);
+  --pf-t--global--text-decoration--color--default: var(--pf-t--global--border--color--400);
+  --pf-t--global--text-decoration--offset--default: var(--pf-t--global--spacer--xs);
+  --pf-t--global--text-decoration--width--default: var(--pf-t--global--border--width--regular);
+  --pf-t--global--text-decoration--width--hover: var(--pf-t--global--border--width--strong);
+  --pf-t--global--background--color--action--plain--alt--clicked: var(--pf-t--global--background--color--primary--default);
+  --pf-t--global--background--color--action--plain--alt--hover: var(--pf-t--global--background--color--primary--default);
+  --pf-t--global--background--color--control--default: var(--pf-t--global--background--color--primary--default);
+  --pf-t--global--background--color--floating--secondary--default: var(--pf-t--global--background--color--secondary--default);
+  --pf-t--global--background--color--glass--primary--default: initial;
+  --pf-t--global--border--color--alt: var(--pf-t--global--background--color--primary--default);
+  --pf-t--global--border--color--brand--clicked: var(--pf-t--global--color--brand--clicked);
+  --pf-t--global--border--color--brand--default: var(--pf-t--global--color--brand--default);
+  --pf-t--global--border--color--brand--hover: var(--pf-t--global--color--brand--hover);
+  --pf-t--global--border--color--glass--default: initial;
+  --pf-t--global--border--color--high-contrast: var(--pf-t--global--border--color--default);
+  --pf-t--global--border--color--main--default: var(--pf-t--global--border--color--default);
+  --pf-t--global--border--color--status--custom--clicked: var(--pf-t--global--color--status--custom--clicked);
+  --pf-t--global--border--color--status--custom--default: var(--pf-t--global--color--status--custom--default);
+  --pf-t--global--border--color--status--custom--hover: var(--pf-t--global--color--status--custom--hover);
+  --pf-t--global--border--color--status--danger--clicked: var(--pf-t--global--color--status--danger--clicked);
+  --pf-t--global--border--color--status--danger--default: var(--pf-t--global--color--status--danger--default);
+  --pf-t--global--border--color--status--danger--hover: var(--pf-t--global--color--status--danger--hover);
+  --pf-t--global--border--color--status--info--clicked: var(--pf-t--global--color--status--info--clicked);
+  --pf-t--global--border--color--status--info--default: var(--pf-t--global--color--status--info--default);
+  --pf-t--global--border--color--status--info--hover: var(--pf-t--global--color--status--info--hover);
+  --pf-t--global--color--brand--accent--clicked: var(--pf-t--global--color--brand--clicked);
+  --pf-t--global--color--brand--accent--default: var(--pf-t--global--color--brand--default);
+  --pf-t--global--color--brand--accent--hover: var(--pf-t--global--color--brand--hover);
+  --pf-t--global--color--status--read--on-primary: var(--pf-t--global--background--color--secondary--default);
+  --pf-t--global--color--status--unread--attention--clicked: var(--pf-t--global--color--status--danger--clicked);
+  --pf-t--global--color--status--unread--attention--default: var(--pf-t--global--color--status--danger--default);
+  --pf-t--global--color--status--unread--attention--hover: var(--pf-t--global--color--status--danger--hover);
+  --pf-t--global--color--status--unread--clicked: var(--pf-t--global--color--brand--clicked);
+  --pf-t--global--color--status--unread--default: var(--pf-t--global--color--brand--default);
+  --pf-t--global--color--status--unread--hover: var(--pf-t--global--color--brand--hover);
+  --pf-t--global--icon--color--favorite--clicked: var(--pf-t--global--color--favorite--clicked);
+  --pf-t--global--icon--color--favorite--default: var(--pf-t--global--color--favorite--default);
+  --pf-t--global--icon--color--favorite--hover: var(--pf-t--global--color--favorite--hover);
+  --pf-t--global--icon--color--nonstatus--on-blue--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-blue--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-blue--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-gray--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-gray--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-gray--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-green--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-green--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-green--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-orange--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-orange--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-orange--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-orangered--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-orangered--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-orangered--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-purple--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-purple--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-purple--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-red--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-red--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-red--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-teal--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-teal--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-teal--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-yellow--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-yellow--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-yellow--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--on-brand--accent--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--accent--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--accent--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--subtle--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--on-brand--subtle--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--on-brand--subtle--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--status--custom--clicked: var(--pf-t--global--color--status--custom--clicked);
+  --pf-t--global--icon--color--status--custom--default: var(--pf-t--global--color--status--custom--default);
+  --pf-t--global--icon--color--status--custom--hover: var(--pf-t--global--color--status--custom--hover);
+  --pf-t--global--icon--color--status--info--clicked: var(--pf-t--global--color--status--info--clicked);
+  --pf-t--global--icon--color--status--info--default: var(--pf-t--global--color--status--info--default);
+  --pf-t--global--icon--color--status--info--hover: var(--pf-t--global--color--status--info--hover);
+  --pf-t--global--icon--color--status--on-custom--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-custom--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-custom--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-danger--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-danger--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-danger--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-info--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-info--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-info--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-success--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-success--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-success--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-warning--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-warning--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-warning--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--success--clicked: var(--pf-t--global--color--status--success--clicked);
+  --pf-t--global--icon--color--status--success--default: var(--pf-t--global--color--status--success--default);
+  --pf-t--global--icon--color--status--success--hover: var(--pf-t--global--color--status--success--hover);
+  --pf-t--global--icon--color--status--unread--on-attention--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-attention--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-attention--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-default--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-default--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-default--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--size--font--body--default: var(--pf-t--global--font--size--body--default);
+  --pf-t--global--icon--size--font--body--lg: var(--pf-t--global--font--size--body--lg);
+  --pf-t--global--icon--size--font--body--sm: var(--pf-t--global--font--size--body--sm);
+  --pf-t--global--icon--size--font--heading--h1: var(--pf-t--global--font--size--heading--h1);
+  --pf-t--global--icon--size--font--heading--h2: var(--pf-t--global--font--size--heading--h2);
+  --pf-t--global--icon--size--font--heading--h3: var(--pf-t--global--font--size--heading--h3);
+  --pf-t--global--icon--size--font--heading--h4: var(--pf-t--global--font--size--heading--h4);
+  --pf-t--global--icon--size--font--heading--h5: var(--pf-t--global--font--size--heading--h5);
+  --pf-t--global--icon--size--font--heading--h6: var(--pf-t--global--font--size--heading--h6);
+  --pf-t--global--text--color--nonstatus--on-blue--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-blue--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-blue--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-gray--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-gray--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-gray--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-green--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-green--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-green--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-orange--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-orange--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-orange--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-orangered--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-orangered--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-orangered--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-purple--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-purple--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-purple--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-red--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-red--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-red--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-teal--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-teal--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-teal--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-yellow--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-yellow--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-yellow--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--on-brand--accent--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--accent--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--accent--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--subtle--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--on-brand--subtle--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--on-brand--subtle--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--placeholder: var(--pf-t--global--text--color--subtle);
+  --pf-t--global--text--color--status--custom--clicked: var(--pf-t--global--color--status--custom--clicked);
+  --pf-t--global--text--color--status--custom--default: var(--pf-t--global--color--status--custom--default);
+  --pf-t--global--text--color--status--custom--hover: var(--pf-t--global--color--status--custom--hover);
+  --pf-t--global--text--color--status--danger--clicked: var(--pf-t--global--color--status--danger--clicked);
+  --pf-t--global--text--color--status--danger--default: var(--pf-t--global--color--status--danger--default);
+  --pf-t--global--text--color--status--danger--hover: var(--pf-t--global--color--status--danger--hover);
+  --pf-t--global--text--color--status--info--clicked: var(--pf-t--global--color--status--info--clicked);
+  --pf-t--global--text--color--status--info--default: var(--pf-t--global--color--status--info--default);
+  --pf-t--global--text--color--status--info--hover: var(--pf-t--global--color--status--info--hover);
+  --pf-t--global--text--color--status--on-custom--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-custom--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-custom--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-danger--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--text--color--status--on-danger--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-danger--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-info--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-info--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-info--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-success--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-success--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-success--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-warning--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-warning--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-warning--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-attention--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-attention--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-attention--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-default--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-default--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-default--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text-decoration--color--hover: var(--pf-t--global--border--color--hover);
+  --pf-t--global--border--color--brand--accent--clicked: var(--pf-t--global--color--brand--accent--clicked);
+  --pf-t--global--border--color--brand--accent--default: var(--pf-t--global--color--brand--accent--default);
+  --pf-t--global--border--color--brand--accent--hover: var(--pf-t--global--color--brand--accent--hover);
+  --pf-t--global--color--status--read--on-secondary: var(--pf-t--global--background--color--control--default);
+  --pf-t--global--icon--color--brand--accent--clicked: var(--pf-t--global--color--brand--accent--clicked);
+  --pf-t--global--icon--color--brand--accent--default: var(--pf-t--global--color--brand--accent--default);
+  --pf-t--global--icon--color--brand--accent--hover: var(--pf-t--global--color--brand--accent--hover);
+}
+
+:root:where(.pf-v6-theme-glass) {
+  --pf-t--global--background--color--glass--primary--default: rgba(255, 255, 255, 0.5000);
+  --pf-t--global--background--color--primary--clicked: rgba(199, 199, 199, 0.3000);
+  --pf-t--global--background--color--primary--default: rgba(255, 255, 255, 0.6000);
+  --pf-t--global--background--color--primary--hover: rgba(199, 199, 199, 0.3000);
+  --pf-t--global--background--color--secondary--clicked: rgba(163, 163, 163, 0.3000);
+  --pf-t--global--background--color--secondary--default: rgba(199, 199, 199, 0.3000);
+  --pf-t--global--background--color--secondary--hover: rgba(163, 163, 163, 0.3000);
+  --pf-t--global--background--filter--glass--blur--primary: blur(16px);
+  --pf-t--global--border--width--main--default: var(--pf-t--global--border--width--100);
+  --pf-t--global--background--color--action--plain--alt--clicked: var(--pf-t--global--background--color--action--plain--clicked);
+  --pf-t--global--background--color--action--plain--alt--hover: var(--pf-t--global--background--color--action--plain--hover);
+  --pf-t--global--border--color--glass--default: var(--pf-t--global--border--color--alt);
+  --pf-t--global--border--radius--glass--default: var(--pf-t--global--border--radius--medium);
+  --pf-t--global--border--width--glass--default: var(--pf-t--global--border--width--regular);
+  --pf-t--global--background--color--floating--secondary--default: var(--pf-t--global--background--color--floating--default);
+  --pf-t--global--background--image--default: var(--pf-t--global--background--image--glass, url("./assets/images/PF-Bkg-Generic-Light.svg"));
+  --pf-t--global--box-shadow--glass--default: var(--pf-t--global--box-shadow--md);
+}
+
+:root:where(.pf-v6-theme-felt.pf-v6-theme-high-contrast) {
+  --pf-t--global--border--color--nonstatus--green--default: var(--pf-t--global--color--nonstatus--green--400);
+  --pf-t--global--border--color--status--success--default: var(--pf-t--global--color--status--success--150);
+  --pf-t--global--border--width--action--plain--clicked: var(--pf-t--global--border--width--200);
+  --pf-t--global--border--width--action--plain--hover: var(--pf-t--global--border--width--100);
+  --pf-t--global--border--width--control--hover: var(--pf-t--global--border--width--200);
+  --pf-t--global--border--width--main--default: var(--pf-t--global--border--width--200);
+  --pf-t--global--border--color--brand--accent--clicked: var(--pf-t--global--color--brand--accent--400);
+  --pf-t--global--border--color--brand--accent--default: var(--pf-t--global--color--brand--accent--400);
+  --pf-t--global--border--color--brand--accent--hover: var(--pf-t--global--color--brand--accent--400);
+  --pf-t--global--border--color--brand--subtle--clicked: var(--pf-t--global--color--brand--subtle--400);
+  --pf-t--global--border--color--brand--subtle--hover: var(--pf-t--global--color--brand--subtle--400);
+  --pf-t--global--border--color--clicked: var(--pf-t--global--color--brand--400);
+  --pf-t--global--border--color--control--default: var(--pf-t--global--border--color--400);
+  --pf-t--global--border--color--default: var(--pf-t--global--border--color--400);
+  --pf-t--global--border--color--hover: var(--pf-t--global--color--brand--300);
+  --pf-t--global--border--color--nonstatus--blue--clicked: var(--pf-t--global--color--nonstatus--blue--500);
+  --pf-t--global--border--color--nonstatus--blue--default: var(--pf-t--global--color--nonstatus--blue--400);
+  --pf-t--global--border--color--nonstatus--blue--hover: var(--pf-t--global--color--nonstatus--blue--500);
+  --pf-t--global--border--color--nonstatus--gray--clicked: var(--pf-t--global--color--nonstatus--gray--500);
+  --pf-t--global--border--color--nonstatus--gray--default: var(--pf-t--global--color--nonstatus--gray--400);
+  --pf-t--global--border--color--nonstatus--gray--hover: var(--pf-t--global--color--nonstatus--gray--500);
+  --pf-t--global--border--color--nonstatus--green--clicked: var(--pf-t--global--color--nonstatus--green--500);
+  --pf-t--global--border--color--nonstatus--green--hover: var(--pf-t--global--color--nonstatus--green--500);
+  --pf-t--global--border--color--nonstatus--orange--clicked: var(--pf-t--global--color--nonstatus--orange--500);
+  --pf-t--global--border--color--nonstatus--orange--default: var(--pf-t--global--color--nonstatus--orange--400);
+  --pf-t--global--border--color--nonstatus--orange--hover: var(--pf-t--global--color--nonstatus--orange--500);
+  --pf-t--global--border--color--nonstatus--orangered--clicked: var(--pf-t--global--color--nonstatus--orangered--500);
+  --pf-t--global--border--color--nonstatus--orangered--default: var(--pf-t--global--color--nonstatus--orangered--400);
+  --pf-t--global--border--color--nonstatus--orangered--hover: var(--pf-t--global--color--nonstatus--orangered--500);
+  --pf-t--global--border--color--nonstatus--purple--clicked: var(--pf-t--global--color--nonstatus--purple--500);
+  --pf-t--global--border--color--nonstatus--purple--default: var(--pf-t--global--color--nonstatus--purple--400);
+  --pf-t--global--border--color--nonstatus--purple--hover: var(--pf-t--global--color--nonstatus--purple--500);
+  --pf-t--global--border--color--nonstatus--red--clicked: var(--pf-t--global--color--nonstatus--red--500);
+  --pf-t--global--border--color--nonstatus--red--default: var(--pf-t--global--color--nonstatus--red--400);
+  --pf-t--global--border--color--nonstatus--red--hover: var(--pf-t--global--color--nonstatus--red--500);
+  --pf-t--global--border--color--nonstatus--teal--clicked: var(--pf-t--global--color--nonstatus--teal--500);
+  --pf-t--global--border--color--nonstatus--teal--default: var(--pf-t--global--color--nonstatus--teal--400);
+  --pf-t--global--border--color--nonstatus--teal--hover: var(--pf-t--global--color--nonstatus--teal--500);
+  --pf-t--global--border--color--nonstatus--yellow--clicked: var(--pf-t--global--color--nonstatus--yellow--500);
+  --pf-t--global--border--color--nonstatus--yellow--default: var(--pf-t--global--color--nonstatus--yellow--400);
+  --pf-t--global--border--color--nonstatus--yellow--hover: var(--pf-t--global--color--nonstatus--yellow--500);
+  --pf-t--global--border--color--on-secondary: var(--pf-t--global--border--color--400);
+  --pf-t--global--border--color--status--success--clicked: var(--pf-t--global--color--status--success--200);
+  --pf-t--global--border--color--status--success--hover: var(--pf-t--global--color--status--success--200);
+  --pf-t--global--border--color--status--warning--clicked: var(--pf-t--global--color--status--warning--600);
+  --pf-t--global--border--color--status--warning--default: var(--pf-t--global--color--status--warning--500);
+  --pf-t--global--border--color--status--warning--hover: var(--pf-t--global--color--status--warning--600);
+  --pf-t--global--border--color--subtle: var(--pf-t--global--border--color--400);
+  --pf-t--global--border--radius--action--plain--default: var(--pf-t--global--border--radius--pill);
+  --pf-t--global--border--radius--control--default: var(--pf-t--global--border--radius--pill);
+  --pf-t--global--border--width--high-contrast--extra-strong: var(--pf-t--global--border--width--extra-strong);
+  --pf-t--global--border--width--high-contrast--regular: var(--pf-t--global--border--width--regular);
+  --pf-t--global--border--width--high-contrast--strong: var(--pf-t--global--border--width--strong);
+  --pf-t--global--color--brand--accent--clicked: var(--pf-t--global--color--brand--accent--300);
+  --pf-t--global--color--brand--accent--default: var(--pf-t--global--color--brand--accent--400);
+  --pf-t--global--color--brand--accent--hover: var(--pf-t--global--color--brand--accent--300);
+  --pf-t--global--color--brand--clicked: var(--pf-t--global--color--brand--400);
+  --pf-t--global--color--brand--default: var(--pf-t--global--color--brand--300);
+  --pf-t--global--color--brand--hover: var(--pf-t--global--color--brand--400);
+  --pf-t--global--color--favorite--clicked: var(--pf-t--global--color--favorite--400);
+  --pf-t--global--color--favorite--default: var(--pf-t--global--color--favorite--300);
+  --pf-t--global--color--favorite--hover: var(--pf-t--global--color--favorite--400);
+  --pf-t--global--color--nonstatus--gray--clicked: var(--pf-t--global--color--nonstatus--gray--100);
+  --pf-t--global--color--nonstatus--gray--default: var(--pf-t--global--color--nonstatus--gray--50);
+  --pf-t--global--color--nonstatus--gray--hover: var(--pf-t--global--color--nonstatus--gray--100);
+  --pf-t--global--color--status--custom--clicked: var(--pf-t--global--color--status--custom--300);
+  --pf-t--global--color--status--custom--default: var(--pf-t--global--color--status--custom--200);
+  --pf-t--global--color--status--custom--hover: var(--pf-t--global--color--status--custom--300);
+  --pf-t--global--color--status--danger--clicked: var(--pf-t--global--color--status--danger--300);
+  --pf-t--global--color--status--danger--default: var(--pf-t--global--color--status--danger--200);
+  --pf-t--global--color--status--danger--hover: var(--pf-t--global--color--status--danger--300);
+  --pf-t--global--color--status--info--clicked: var(--pf-t--global--color--status--info--300);
+  --pf-t--global--color--status--info--default: var(--pf-t--global--color--status--info--200);
+  --pf-t--global--color--status--info--hover: var(--pf-t--global--color--status--info--300);
+  --pf-t--global--color--status--success--clicked: var(--pf-t--global--color--status--success--300);
+  --pf-t--global--color--status--success--default: var(--pf-t--global--color--status--success--200);
+  --pf-t--global--color--status--success--hover: var(--pf-t--global--color--status--success--300);
+  --pf-t--global--color--status--warning--clicked: var(--pf-t--global--color--status--warning--600);
+  --pf-t--global--color--status--warning--default: var(--pf-t--global--color--status--warning--500);
+  --pf-t--global--color--status--warning--hover: var(--pf-t--global--color--status--warning--600);
+  --pf-t--global--focus-ring--color--default: var(--pf-t--global--focus-ring--color--200);
+  --pf-t--global--icon--color--brand--clicked: var(--pf-t--global--color--brand--400);
+  --pf-t--global--icon--color--brand--default: var(--pf-t--global--color--brand--300);
+  --pf-t--global--icon--color--brand--hover: var(--pf-t--global--color--brand--400);
+  --pf-t--global--icon--color--severity--important--default: var(--pf-t--global--color--severity--important--200);
+  --pf-t--global--icon--color--severity--minor--default: var(--pf-t--global--color--severity--minor--200);
+  --pf-t--global--icon--color--severity--moderate--default: var(--pf-t--global--color--severity--moderate--200);
+  --pf-t--global--icon--color--severity--none--default: var(--pf-t--global--color--severity--none--200);
+  --pf-t--global--icon--color--severity--undefined--default: var(--pf-t--global--color--severity--undefined--200);
+  --pf-t--global--icon--color--status--danger--clicked: var(--pf-t--global--color--status--danger--200);
+  --pf-t--global--icon--color--status--danger--default: var(--pf-t--global--color--status--danger--100);
+  --pf-t--global--icon--color--status--danger--hover: var(--pf-t--global--color--status--danger--200);
+  --pf-t--global--icon--color--status--warning--clicked: var(--pf-t--global--color--status--warning--600);
+  --pf-t--global--icon--color--status--warning--default: var(--pf-t--global--color--status--warning--500);
+  --pf-t--global--icon--color--status--warning--hover: var(--pf-t--global--color--status--warning--600);
+  --pf-t--global--icon--color--subtle: var(--pf-t--global--icon--color--150);
+  --pf-t--global--text--color--brand--clicked: var(--pf-t--global--color--brand--500);
+  --pf-t--global--text--color--brand--default: var(--pf-t--global--color--brand--400);
+  --pf-t--global--text--color--brand--hover: var(--pf-t--global--color--brand--500);
+  --pf-t--global--text--color--link--default: var(--pf-t--global--text--color--link--200);
+  --pf-t--global--text--color--link--hover: var(--pf-t--global--text--color--link--250);
+  --pf-t--global--text--color--link--visited: var(--pf-t--global--text--color--link--350);
+  --pf-t--global--text--color--required: var(--pf-t--global--text--color--500);
+  --pf-t--global--text--color--status--success--clicked: var(--pf-t--global--color--status--success--300);
+  --pf-t--global--text--color--status--success--default: var(--pf-t--global--color--status--success--200);
+  --pf-t--global--text--color--status--success--hover: var(--pf-t--global--color--status--success--300);
+  --pf-t--global--text--color--status--warning--clicked: var(--pf-t--global--color--status--warning--600);
+  --pf-t--global--text--color--status--warning--default: var(--pf-t--global--color--status--warning--500);
+  --pf-t--global--text--color--status--warning--hover: var(--pf-t--global--color--status--warning--600);
+  --pf-t--global--text--color--subtle: var(--pf-t--global--text--color--250);
+  --pf-t--global--text-decoration--color--default: var(--pf-t--global--border--color--400);
+  --pf-t--global--text-decoration--width--hover: var(--pf-t--global--border--width--strong);
+  --pf-t--global--background--color--action--plain--alt--clicked: var(--pf-t--global--background--color--primary--default);
+  --pf-t--global--background--color--action--plain--alt--hover: var(--pf-t--global--background--color--primary--default);
+  --pf-t--global--border--color--high-contrast: var(--pf-t--global--border--color--default);
+  --pf-t--global--border--color--main--default: var(--pf-t--global--border--color--default);
+  --pf-t--global--icon--color--status--on-warning--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-warning--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-warning--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--text--color--status--on-warning--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-warning--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-warning--hover: var(--pf-t--global--text--color--inverse);
+}
+
+:root:where(.pf-v6-theme-felt.pf-v6-theme-glass) {
+  --pf-t--global--background--color--glass--primary--default: rgba(255, 255, 255, 0.5000);
+  --pf-t--global--background--color--primary--clicked: rgba(199, 199, 199, 0.3000);
+  --pf-t--global--background--color--primary--default: rgba(255, 255, 255, 0.6000);
+  --pf-t--global--background--color--primary--hover: rgba(199, 199, 199, 0.3000);
+  --pf-t--global--background--color--secondary--clicked: rgba(163, 163, 163, 0.3000);
+  --pf-t--global--background--color--secondary--default: rgba(199, 199, 199, 0.3000);
+  --pf-t--global--background--color--secondary--hover: rgba(163, 163, 163, 0.3000);
+  --pf-t--global--background--filter--glass--blur--primary: blur(16px);
+  --pf-t--global--border--width--main--default: var(--pf-t--global--border--width--100);
+  --pf-t--global--background--color--action--plain--alt--clicked: var(--pf-t--global--background--color--action--plain--clicked);
+  --pf-t--global--background--color--action--plain--alt--hover: var(--pf-t--global--background--color--action--plain--hover);
+  --pf-t--global--border--color--brand--accent--clicked: var(--pf-t--global--color--brand--accent--400);
+  --pf-t--global--border--color--brand--accent--default: var(--pf-t--global--color--brand--accent--400);
+  --pf-t--global--border--color--brand--accent--hover: var(--pf-t--global--color--brand--accent--400);
+  --pf-t--global--border--color--glass--default: var(--pf-t--global--border--color--alt);
+  --pf-t--global--border--radius--action--plain--default: var(--pf-t--global--border--radius--pill);
+  --pf-t--global--border--radius--control--default: var(--pf-t--global--border--radius--pill);
+  --pf-t--global--border--radius--glass--default: var(--pf-t--global--border--radius--medium);
+  --pf-t--global--border--width--glass--default: var(--pf-t--global--border--width--regular);
+  --pf-t--global--color--brand--accent--clicked: var(--pf-t--global--color--brand--accent--200);
+  --pf-t--global--color--brand--accent--default: var(--pf-t--global--color--brand--accent--100);
+  --pf-t--global--color--brand--accent--hover: var(--pf-t--global--color--brand--accent--200);
+  --pf-t--global--background--color--floating--secondary--default: var(--pf-t--global--background--color--floating--default);
+  --pf-t--global--background--image--default: var(--pf-t--global--background--image--felt--glass, url("./assets/images/Felt-Bkg-Generic-Light.svg"));
+}
+
+:root:where(.pf-v6-theme-dark) {
+  --pf-t--global--background--color--action--plain--default: rgba(0, 0, 0, 0.0000);
+  --pf-t--global--background--color--striped--row--default: rgba(21, 21, 21, 0.3000);
+  --pf-t--global--background--filter--glass--blur--primary: initial;
+  --pf-t--global--border--color--high-contrast: rgba(255, 255, 255, 0.0000);
+  --pf-t--global--dark--background--color--500: rgba(21, 21, 21, 0.8000);
+  --pf-t--global--dark--background--color--600: rgba(199, 199, 199, 0.1500);
+  --pf-t--global--dark--background--color--700: rgba(199, 199, 199, 0.2500);
+  --pf-t--global--dark--box-shadow--color--100: rgba(0, 0, 0, 0.5000);
+  --pf-t--global--dark--box-shadow--color--200: rgba(0, 0, 0, 0.6000);
+  --pf-t--global--background--color--action--plain--clicked: var(--pf-t--global--dark--background--color--600);
+  --pf-t--global--background--color--action--plain--hover: var(--pf-t--global--dark--background--color--600);
+  --pf-t--global--background--color--backdrop--default: var(--pf-t--global--dark--background--color--500);
+  --pf-t--global--background--color--loading--skeleton--default: var(--pf-t--global--dark--background--color--700);
+  --pf-t--global--background--color--loading--skeleton--subtle: var(--pf-t--global--dark--background--color--600);
+  --pf-t--global--background--color--tertiary--default: var(--pf-t--global--dark--background--color--600);
+  --pf-t--global--box-shadow--color--lg--default: var(--pf-t--global--dark--box-shadow--color--100);
+  --pf-t--global--box-shadow--color--lg--directional: var(--pf-t--global--dark--box-shadow--color--200);
+  --pf-t--global--box-shadow--color--md--default: var(--pf-t--global--dark--box-shadow--color--100);
+  --pf-t--global--box-shadow--color--md--directional: var(--pf-t--global--dark--box-shadow--color--100);
+  --pf-t--global--box-shadow--color--sm--default: var(--pf-t--global--dark--box-shadow--color--100);
+  --pf-t--global--box-shadow--color--sm--directional: var(--pf-t--global--dark--box-shadow--color--200);
+  --pf-t--global--dark--background--color--100: var(--pf-t--color--gray--95);
+  --pf-t--global--dark--background--color--200: var(--pf-t--color--gray--80);
+  --pf-t--global--dark--background--color--300: var(--pf-t--color--gray--70);
+  --pf-t--global--dark--background--color--400: var(--pf-t--color--gray--10);
+  --pf-t--global--dark--background--color--450: var(--pf-t--color--gray--20);
+  --pf-t--global--dark--background--color--highlight--100: var(--pf-t--color--yellow--20);
+  --pf-t--global--dark--background--color--highlight--200: var(--pf-t--color--yellow--30);
+  --pf-t--global--dark--border--color--100: var(--pf-t--color--gray--60);
+  --pf-t--global--dark--border--color--200: var(--pf-t--color--gray--40);
+  --pf-t--global--dark--border--color--300: var(--pf-t--color--gray--30);
+  --pf-t--global--dark--border--color--50: var(--pf-t--color--gray--70);
+  --pf-t--global--dark--color--brand--100: var(--pf-t--color--blue--30);
+  --pf-t--global--dark--color--brand--200: var(--pf-t--color--blue--20);
+  --pf-t--global--dark--color--brand--300: var(--pf-t--color--blue--10);
+  --pf-t--global--dark--color--brand--accent--100: var(--pf-t--color--red--50);
+  --pf-t--global--dark--color--brand--accent--200: var(--pf-t--color--red--60);
+  --pf-t--global--dark--color--brand--accent--300: var(--pf-t--color--red--40);
+  --pf-t--global--dark--color--brand--accent--350: var(--pf-t--color--gray--20);
+  --pf-t--global--dark--color--brand--accent--400: var(--pf-t--color--white);
+  --pf-t--global--dark--color--brand--subtle--100: var(--pf-t--color--blue--70);
+  --pf-t--global--dark--color--brand--subtle--200: var(--pf-t--color--blue--60);
+  --pf-t--global--dark--color--brand--subtle--300: var(--pf-t--color--blue--30);
+  --pf-t--global--dark--color--disabled--100: var(--pf-t--color--gray--40);
+  --pf-t--global--dark--color--disabled--200: var(--pf-t--color--gray--50);
+  --pf-t--global--dark--color--disabled--300: var(--pf-t--color--gray--70);
+  --pf-t--global--dark--color--disabled--400: var(--pf-t--color--gray--90);
+  --pf-t--global--dark--color--favorite--100: var(--pf-t--color--yellow--30);
+  --pf-t--global--dark--color--favorite--200: var(--pf-t--color--yellow--20);
+  --pf-t--global--dark--color--nonstatus--blue--100: var(--pf-t--color--blue--30);
+  --pf-t--global--dark--color--nonstatus--blue--200: var(--pf-t--color--blue--20);
+  --pf-t--global--dark--color--nonstatus--blue--300: var(--pf-t--color--blue--10);
+  --pf-t--global--dark--color--nonstatus--gray--100: var(--pf-t--color--gray--60);
+  --pf-t--global--dark--color--nonstatus--gray--200: var(--pf-t--color--gray--50);
+  --pf-t--global--dark--color--nonstatus--gray--300: var(--pf-t--color--gray--40);
+  --pf-t--global--dark--color--nonstatus--gray--50: var(--pf-t--color--gray--70);
+  --pf-t--global--dark--color--nonstatus--green--100: var(--pf-t--color--green--30);
+  --pf-t--global--dark--color--nonstatus--green--200: var(--pf-t--color--green--20);
+  --pf-t--global--dark--color--nonstatus--green--300: var(--pf-t--color--green--10);
+  --pf-t--global--dark--color--nonstatus--orange--100: var(--pf-t--color--orange--30);
+  --pf-t--global--dark--color--nonstatus--orange--200: var(--pf-t--color--orange--20);
+  --pf-t--global--dark--color--nonstatus--orange--300: var(--pf-t--color--orange--10);
+  --pf-t--global--dark--color--nonstatus--orangered--100: var(--pf-t--color--red-orange--30);
+  --pf-t--global--dark--color--nonstatus--orangered--200: var(--pf-t--color--red-orange--20);
+  --pf-t--global--dark--color--nonstatus--orangered--300: var(--pf-t--color--red-orange--10);
+  --pf-t--global--dark--color--nonstatus--purple--100: var(--pf-t--color--purple--30);
+  --pf-t--global--dark--color--nonstatus--purple--200: var(--pf-t--color--purple--20);
+  --pf-t--global--dark--color--nonstatus--purple--300: var(--pf-t--color--purple--10);
+  --pf-t--global--dark--color--nonstatus--red--100: var(--pf-t--color--red--30);
+  --pf-t--global--dark--color--nonstatus--red--200: var(--pf-t--color--red--20);
+  --pf-t--global--dark--color--nonstatus--red--300: var(--pf-t--color--red--10);
+  --pf-t--global--dark--color--nonstatus--teal--100: var(--pf-t--color--teal--30);
+  --pf-t--global--dark--color--nonstatus--teal--200: var(--pf-t--color--teal--20);
+  --pf-t--global--dark--color--nonstatus--teal--300: var(--pf-t--color--teal--10);
+  --pf-t--global--dark--color--nonstatus--yellow--100: var(--pf-t--color--yellow--30);
+  --pf-t--global--dark--color--nonstatus--yellow--200: var(--pf-t--color--yellow--20);
+  --pf-t--global--dark--color--nonstatus--yellow--300: var(--pf-t--color--yellow--10);
+  --pf-t--global--dark--color--severity--critical--100: var(--pf-t--color--red-orange--50);
+  --pf-t--global--dark--color--severity--critical--200: var(--pf-t--color--red-orange--40);
+  --pf-t--global--dark--color--severity--important--100: var(--pf-t--color--orange--40);
+  --pf-t--global--dark--color--severity--minor--100: var(--pf-t--color--gray--30);
+  --pf-t--global--dark--color--severity--moderate--100: var(--pf-t--color--yellow--30);
+  --pf-t--global--dark--color--severity--none--100: var(--pf-t--color--blue--30);
+  --pf-t--global--dark--color--severity--undefined--100: var(--pf-t--color--gray--40);
+  --pf-t--global--dark--color--status--custom--100: var(--pf-t--color--teal--40);
+  --pf-t--global--dark--color--status--custom--200: var(--pf-t--color--teal--30);
+  --pf-t--global--dark--color--status--custom--300: var(--pf-t--color--teal--20);
+  --pf-t--global--dark--color--status--danger--100: var(--pf-t--color--red-orange--50);
+  --pf-t--global--dark--color--status--danger--200: var(--pf-t--color--red-orange--40);
+  --pf-t--global--dark--color--status--danger--250: var(--pf-t--color--red-orange--30);
+  --pf-t--global--dark--color--status--danger--300: var(--pf-t--color--red-orange--20);
+  --pf-t--global--dark--color--status--info--100: var(--pf-t--color--purple--30);
+  --pf-t--global--dark--color--status--info--200: var(--pf-t--color--purple--20);
+  --pf-t--global--dark--color--status--info--300: var(--pf-t--color--purple--10);
+  --pf-t--global--dark--color--status--success--100: var(--pf-t--color--green--40);
+  --pf-t--global--dark--color--status--success--200: var(--pf-t--color--green--30);
+  --pf-t--global--dark--color--status--success--300: var(--pf-t--color--green--20);
+  --pf-t--global--dark--color--status--warning--100: var(--pf-t--color--yellow--30);
+  --pf-t--global--dark--color--status--warning--200: var(--pf-t--color--yellow--20);
+  --pf-t--global--dark--focus-ring--color--100: var(--pf-t--color--blue--30);
+  --pf-t--global--dark--icon--color--100: var(--pf-t--color--gray--10);
+  --pf-t--global--dark--icon--color--200: var(--pf-t--color--gray--40);
+  --pf-t--global--dark--icon--color--300: var(--pf-t--color--gray--90);
+  --pf-t--global--dark--text--color--100: var(--pf-t--color--white);
+  --pf-t--global--dark--text--color--200: var(--pf-t--color--gray--30);
+  --pf-t--global--dark--text--color--300: var(--pf-t--color--gray--90);
+  --pf-t--global--dark--text--color--400: var(--pf-t--color--red-orange--30);
+  --pf-t--global--dark--text--color--link--100: var(--pf-t--color--blue--20);
+  --pf-t--global--dark--text--color--link--200: var(--pf-t--color--blue--10);
+  --pf-t--global--dark--text--color--link--300: var(--pf-t--color--purple--30);
+  --pf-t--global--dark--text--color--link--400: var(--pf-t--color--purple--20);
+  --pf-t--global--background--color--action--plain--alt--clicked: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--action--plain--alt--hover: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--control--default: var(--pf-t--global--dark--background--color--300);
+  --pf-t--global--background--color--control--read-only: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--disabled--default: var(--pf-t--global--dark--color--disabled--100);
+  --pf-t--global--background--color--floating--clicked: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--floating--default: var(--pf-t--global--dark--background--color--300);
+  --pf-t--global--background--color--floating--hover: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--highlight--clicked: var(--pf-t--global--dark--background--color--highlight--200);
+  --pf-t--global--background--color--highlight--default: var(--pf-t--global--dark--background--color--highlight--100);
+  --pf-t--global--background--color--inverse--clicked: var(--pf-t--global--dark--background--color--450);
+  --pf-t--global--background--color--inverse--default: var(--pf-t--global--dark--background--color--400);
+  --pf-t--global--background--color--inverse--hover: var(--pf-t--global--dark--background--color--450);
+  --pf-t--global--background--color--primary--clicked: var(--pf-t--global--dark--background--color--300);
+  --pf-t--global--background--color--primary--default: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--primary--hover: var(--pf-t--global--dark--background--color--300);
+  --pf-t--global--background--color--secondary--clicked: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--secondary--default: var(--pf-t--global--dark--background--color--100);
+  --pf-t--global--background--color--secondary--hover: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--sticky--default: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--border--color--brand--subtle--clicked: var(--pf-t--global--dark--color--brand--subtle--300);
+  --pf-t--global--border--color--brand--subtle--default: var(--pf-t--global--dark--color--brand--subtle--200);
+  --pf-t--global--border--color--brand--subtle--hover: var(--pf-t--global--dark--color--brand--subtle--300);
+  --pf-t--global--border--color--clicked: var(--pf-t--global--dark--color--brand--200);
+  --pf-t--global--border--color--control--default: var(--pf-t--global--dark--border--color--200);
+  --pf-t--global--border--color--control--read-only: var(--pf-t--global--dark--border--color--100);
+  --pf-t--global--border--color--default: var(--pf-t--global--dark--border--color--100);
+  --pf-t--global--border--color--disabled: var(--pf-t--global--dark--color--disabled--200);
+  --pf-t--global--border--color--hover: var(--pf-t--global--dark--color--brand--100);
+  --pf-t--global--border--color--nonstatus--blue--clicked: var(--pf-t--global--dark--color--nonstatus--blue--200);
+  --pf-t--global--border--color--nonstatus--blue--default: var(--pf-t--global--dark--color--nonstatus--blue--100);
+  --pf-t--global--border--color--nonstatus--blue--hover: var(--pf-t--global--dark--color--nonstatus--blue--200);
+  --pf-t--global--border--color--nonstatus--gray--clicked: var(--pf-t--global--dark--color--nonstatus--gray--300);
+  --pf-t--global--border--color--nonstatus--gray--default: var(--pf-t--global--dark--color--nonstatus--gray--200);
+  --pf-t--global--border--color--nonstatus--gray--hover: var(--pf-t--global--dark--color--nonstatus--gray--300);
+  --pf-t--global--border--color--nonstatus--green--clicked: var(--pf-t--global--dark--color--nonstatus--green--200);
+  --pf-t--global--border--color--nonstatus--green--default: var(--pf-t--global--dark--color--nonstatus--green--100);
+  --pf-t--global--border--color--nonstatus--green--hover: var(--pf-t--global--dark--color--nonstatus--green--200);
+  --pf-t--global--border--color--nonstatus--orange--clicked: var(--pf-t--global--dark--color--nonstatus--orange--200);
+  --pf-t--global--border--color--nonstatus--orange--default: var(--pf-t--global--dark--color--nonstatus--orange--100);
+  --pf-t--global--border--color--nonstatus--orange--hover: var(--pf-t--global--dark--color--nonstatus--orange--200);
+  --pf-t--global--border--color--nonstatus--orangered--clicked: var(--pf-t--global--dark--color--nonstatus--orangered--200);
+  --pf-t--global--border--color--nonstatus--orangered--default: var(--pf-t--global--dark--color--nonstatus--orangered--100);
+  --pf-t--global--border--color--nonstatus--orangered--hover: var(--pf-t--global--dark--color--nonstatus--orangered--200);
+  --pf-t--global--border--color--nonstatus--purple--clicked: var(--pf-t--global--dark--color--nonstatus--purple--200);
+  --pf-t--global--border--color--nonstatus--purple--default: var(--pf-t--global--dark--color--nonstatus--purple--100);
+  --pf-t--global--border--color--nonstatus--purple--hover: var(--pf-t--global--dark--color--nonstatus--purple--200);
+  --pf-t--global--border--color--nonstatus--red--clicked: var(--pf-t--global--dark--color--nonstatus--red--200);
+  --pf-t--global--border--color--nonstatus--red--default: var(--pf-t--global--dark--color--nonstatus--red--100);
+  --pf-t--global--border--color--nonstatus--red--hover: var(--pf-t--global--dark--color--nonstatus--red--200);
+  --pf-t--global--border--color--nonstatus--teal--clicked: var(--pf-t--global--dark--color--nonstatus--teal--200);
+  --pf-t--global--border--color--nonstatus--teal--default: var(--pf-t--global--dark--color--nonstatus--teal--100);
+  --pf-t--global--border--color--nonstatus--teal--hover: var(--pf-t--global--dark--color--nonstatus--teal--200);
+  --pf-t--global--border--color--nonstatus--yellow--clicked: var(--pf-t--global--dark--color--nonstatus--yellow--200);
+  --pf-t--global--border--color--nonstatus--yellow--default: var(--pf-t--global--dark--color--nonstatus--yellow--100);
+  --pf-t--global--border--color--nonstatus--yellow--hover: var(--pf-t--global--dark--color--nonstatus--yellow--200);
+  --pf-t--global--border--color--on-secondary: var(--pf-t--global--dark--border--color--200);
+  --pf-t--global--border--color--subtle: var(--pf-t--global--dark--border--color--100);
+  --pf-t--global--color--brand--clicked: var(--pf-t--global--dark--color--brand--200);
+  --pf-t--global--color--brand--default: var(--pf-t--global--dark--color--brand--100);
+  --pf-t--global--color--brand--hover: var(--pf-t--global--dark--color--brand--200);
+  --pf-t--global--color--brand--subtle--clicked: var(--pf-t--global--dark--color--brand--subtle--200);
+  --pf-t--global--color--brand--subtle--default: var(--pf-t--global--dark--color--brand--subtle--100);
+  --pf-t--global--color--brand--subtle--hover: var(--pf-t--global--dark--color--brand--subtle--200);
+  --pf-t--global--color--favorite--clicked: var(--pf-t--global--dark--color--favorite--200);
+  --pf-t--global--color--favorite--default: var(--pf-t--global--dark--color--favorite--100);
+  --pf-t--global--color--favorite--hover: var(--pf-t--global--dark--color--favorite--200);
+  --pf-t--global--color--nonstatus--blue--clicked: var(--pf-t--global--dark--color--nonstatus--blue--200);
+  --pf-t--global--color--nonstatus--blue--default: var(--pf-t--global--dark--color--nonstatus--blue--100);
+  --pf-t--global--color--nonstatus--blue--hover: var(--pf-t--global--dark--color--nonstatus--blue--200);
+  --pf-t--global--color--nonstatus--gray--clicked: var(--pf-t--global--dark--color--nonstatus--gray--200);
+  --pf-t--global--color--nonstatus--gray--default: var(--pf-t--global--dark--color--nonstatus--gray--100);
+  --pf-t--global--color--nonstatus--gray--hover: var(--pf-t--global--dark--color--nonstatus--gray--200);
+  --pf-t--global--color--nonstatus--green--clicked: var(--pf-t--global--dark--color--nonstatus--green--200);
+  --pf-t--global--color--nonstatus--green--default: var(--pf-t--global--dark--color--nonstatus--green--100);
+  --pf-t--global--color--nonstatus--green--hover: var(--pf-t--global--dark--color--nonstatus--green--200);
+  --pf-t--global--color--nonstatus--orange--clicked: var(--pf-t--global--dark--color--nonstatus--orange--200);
+  --pf-t--global--color--nonstatus--orange--default: var(--pf-t--global--dark--color--nonstatus--orange--100);
+  --pf-t--global--color--nonstatus--orange--hover: var(--pf-t--global--dark--color--nonstatus--orange--200);
+  --pf-t--global--color--nonstatus--orangered--clicked: var(--pf-t--global--dark--color--nonstatus--orangered--200);
+  --pf-t--global--color--nonstatus--orangered--default: var(--pf-t--global--dark--color--nonstatus--orangered--100);
+  --pf-t--global--color--nonstatus--orangered--hover: var(--pf-t--global--dark--color--nonstatus--orangered--200);
+  --pf-t--global--color--nonstatus--purple--clicked: var(--pf-t--global--dark--color--nonstatus--purple--200);
+  --pf-t--global--color--nonstatus--purple--default: var(--pf-t--global--dark--color--nonstatus--purple--100);
+  --pf-t--global--color--nonstatus--purple--hover: var(--pf-t--global--dark--color--nonstatus--purple--200);
+  --pf-t--global--color--nonstatus--red--clicked: var(--pf-t--global--dark--color--nonstatus--red--200);
+  --pf-t--global--color--nonstatus--red--default: var(--pf-t--global--dark--color--nonstatus--red--100);
+  --pf-t--global--color--nonstatus--red--hover: var(--pf-t--global--dark--color--nonstatus--red--200);
+  --pf-t--global--color--nonstatus--teal--clicked: var(--pf-t--global--dark--color--nonstatus--teal--200);
+  --pf-t--global--color--nonstatus--teal--default: var(--pf-t--global--dark--color--nonstatus--teal--100);
+  --pf-t--global--color--nonstatus--teal--hover: var(--pf-t--global--dark--color--nonstatus--teal--200);
+  --pf-t--global--color--nonstatus--yellow--clicked: var(--pf-t--global--dark--color--nonstatus--yellow--200);
+  --pf-t--global--color--nonstatus--yellow--default: var(--pf-t--global--dark--color--nonstatus--yellow--100);
+  --pf-t--global--color--nonstatus--yellow--hover: var(--pf-t--global--dark--color--nonstatus--yellow--200);
+  --pf-t--global--color--status--custom--clicked: var(--pf-t--global--dark--color--status--custom--200);
+  --pf-t--global--color--status--custom--default: var(--pf-t--global--dark--color--status--custom--100);
+  --pf-t--global--color--status--custom--hover: var(--pf-t--global--dark--color--status--custom--200);
+  --pf-t--global--color--status--danger--clicked: var(--pf-t--global--dark--color--status--danger--200);
+  --pf-t--global--color--status--danger--default: var(--pf-t--global--dark--color--status--danger--100);
+  --pf-t--global--color--status--danger--hover: var(--pf-t--global--dark--color--status--danger--200);
+  --pf-t--global--color--status--info--clicked: var(--pf-t--global--dark--color--status--info--200);
+  --pf-t--global--color--status--info--default: var(--pf-t--global--dark--color--status--info--100);
+  --pf-t--global--color--status--info--hover: var(--pf-t--global--dark--color--status--info--200);
+  --pf-t--global--color--status--success--clicked: var(--pf-t--global--dark--color--status--success--200);
+  --pf-t--global--color--status--success--default: var(--pf-t--global--dark--color--status--success--100);
+  --pf-t--global--color--status--success--hover: var(--pf-t--global--dark--color--status--success--200);
+  --pf-t--global--color--status--warning--clicked: var(--pf-t--global--dark--color--status--warning--200);
+  --pf-t--global--color--status--warning--default: var(--pf-t--global--dark--color--status--warning--100);
+  --pf-t--global--color--status--warning--hover: var(--pf-t--global--dark--color--status--warning--200);
+  --pf-t--global--focus-ring--color--default: var(--pf-t--global--dark--focus-ring--color--100);
+  --pf-t--global--icon--color--brand--clicked: var(--pf-t--global--dark--color--brand--300);
+  --pf-t--global--icon--color--brand--default: var(--pf-t--global--dark--color--brand--200);
+  --pf-t--global--icon--color--brand--hover: var(--pf-t--global--dark--color--brand--300);
+  --pf-t--global--icon--color--disabled: var(--pf-t--global--dark--color--disabled--200);
+  --pf-t--global--icon--color--inverse: var(--pf-t--global--dark--icon--color--300);
+  --pf-t--global--icon--color--on-disabled: var(--pf-t--global--dark--color--disabled--300);
+  --pf-t--global--icon--color--regular: var(--pf-t--global--dark--icon--color--100);
+  --pf-t--global--icon--color--severity--critical--default: var(--pf-t--global--dark--color--severity--critical--100);
+  --pf-t--global--icon--color--severity--important--default: var(--pf-t--global--dark--color--severity--important--100);
+  --pf-t--global--icon--color--severity--minor--default: var(--pf-t--global--dark--color--severity--minor--100);
+  --pf-t--global--icon--color--severity--moderate--default: var(--pf-t--global--dark--color--severity--moderate--100);
+  --pf-t--global--icon--color--severity--none--default: var(--pf-t--global--dark--color--severity--none--100);
+  --pf-t--global--icon--color--severity--undefined--default: var(--pf-t--global--dark--color--severity--undefined--100);
+  --pf-t--global--icon--color--subtle: var(--pf-t--global--dark--icon--color--200);
+  --pf-t--global--text--color--brand--clicked: var(--pf-t--global--dark--color--brand--300);
+  --pf-t--global--text--color--brand--default: var(--pf-t--global--dark--color--brand--200);
+  --pf-t--global--text--color--brand--hover: var(--pf-t--global--dark--color--brand--300);
+  --pf-t--global--text--color--disabled: var(--pf-t--global--dark--color--disabled--200);
+  --pf-t--global--text--color--inverse: var(--pf-t--global--dark--text--color--300);
+  --pf-t--global--text--color--link--default: var(--pf-t--global--dark--text--color--link--100);
+  --pf-t--global--text--color--link--hover: var(--pf-t--global--dark--text--color--link--200);
+  --pf-t--global--text--color--link--visited: var(--pf-t--global--dark--text--color--link--300);
+  --pf-t--global--text--color--on-disabled: var(--pf-t--global--dark--color--disabled--300);
+  --pf-t--global--text--color--on-highlight: var(--pf-t--global--dark--text--color--300);
+  --pf-t--global--text--color--regular: var(--pf-t--global--dark--text--color--100);
+  --pf-t--global--text--color--required: var(--pf-t--global--dark--text--color--400);
+  --pf-t--global--text--color--status--danger--clicked: var(--pf-t--global--dark--color--status--danger--300);
+  --pf-t--global--text--color--status--danger--default: var(--pf-t--global--dark--color--status--danger--250);
+  --pf-t--global--text--color--status--danger--hover: var(--pf-t--global--dark--color--status--danger--300);
+  --pf-t--global--text--color--subtle: var(--pf-t--global--dark--text--color--200);
+  --pf-t--global--text-decoration--color--default: var(--pf-t--global--dark--border--color--200);
+  --pf-t--global--background--color--floating--secondary--default: var(--pf-t--global--background--color--secondary--default);
+  --pf-t--global--background--color--glass--primary--default: initial;
+  --pf-t--global--border--color--alt: var(--pf-t--global--background--color--primary--default);
+  --pf-t--global--border--color--brand--clicked: var(--pf-t--global--color--brand--clicked);
+  --pf-t--global--border--color--brand--default: var(--pf-t--global--color--brand--default);
+  --pf-t--global--border--color--brand--hover: var(--pf-t--global--color--brand--hover);
+  --pf-t--global--border--color--glass--default: initial;
+  --pf-t--global--border--color--main--default: var(--pf-t--global--background--color--primary--default);
+  --pf-t--global--border--color--status--custom--clicked: var(--pf-t--global--color--status--custom--clicked);
+  --pf-t--global--border--color--status--custom--default: var(--pf-t--global--color--status--custom--default);
+  --pf-t--global--border--color--status--custom--hover: var(--pf-t--global--color--status--custom--hover);
+  --pf-t--global--border--color--status--danger--clicked: var(--pf-t--global--color--status--danger--clicked);
+  --pf-t--global--border--color--status--danger--default: var(--pf-t--global--color--status--danger--default);
+  --pf-t--global--border--color--status--danger--hover: var(--pf-t--global--color--status--danger--hover);
+  --pf-t--global--border--color--status--info--clicked: var(--pf-t--global--color--status--info--clicked);
+  --pf-t--global--border--color--status--info--default: var(--pf-t--global--color--status--info--default);
+  --pf-t--global--border--color--status--info--hover: var(--pf-t--global--color--status--info--hover);
+  --pf-t--global--border--color--status--success--clicked: var(--pf-t--global--color--status--success--clicked);
+  --pf-t--global--border--color--status--success--default: var(--pf-t--global--color--status--success--default);
+  --pf-t--global--border--color--status--success--hover: var(--pf-t--global--color--status--success--hover);
+  --pf-t--global--border--color--status--warning--clicked: var(--pf-t--global--color--status--warning--clicked);
+  --pf-t--global--border--color--status--warning--default: var(--pf-t--global--color--status--warning--default);
+  --pf-t--global--border--color--status--warning--hover: var(--pf-t--global--color--status--warning--hover);
+  --pf-t--global--color--brand--accent--clicked: var(--pf-t--global--color--brand--clicked);
+  --pf-t--global--color--brand--accent--default: var(--pf-t--global--color--brand--default);
+  --pf-t--global--color--brand--accent--hover: var(--pf-t--global--color--brand--hover);
+  --pf-t--global--color--status--read--on-primary: var(--pf-t--global--background--color--secondary--default);
+  --pf-t--global--color--status--read--on-secondary: var(--pf-t--global--background--color--control--default);
+  --pf-t--global--color--status--unread--attention--clicked: var(--pf-t--global--color--status--danger--clicked);
+  --pf-t--global--color--status--unread--attention--default: var(--pf-t--global--color--status--danger--default);
+  --pf-t--global--color--status--unread--attention--hover: var(--pf-t--global--color--status--danger--hover);
+  --pf-t--global--color--status--unread--clicked: var(--pf-t--global--color--brand--clicked);
+  --pf-t--global--color--status--unread--default: var(--pf-t--global--color--brand--default);
+  --pf-t--global--color--status--unread--hover: var(--pf-t--global--color--brand--hover);
+  --pf-t--global--icon--color--favorite--clicked: var(--pf-t--global--color--favorite--clicked);
+  --pf-t--global--icon--color--favorite--default: var(--pf-t--global--color--favorite--default);
+  --pf-t--global--icon--color--favorite--hover: var(--pf-t--global--color--favorite--hover);
+  --pf-t--global--icon--color--nonstatus--on-blue--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-blue--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-blue--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-gray--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-gray--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-gray--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-green--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-green--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-green--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-orange--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-orange--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-orange--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-orangered--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-orangered--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-orangered--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-purple--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-purple--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-purple--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-red--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-red--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-red--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-teal--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-teal--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-teal--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-yellow--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-yellow--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-yellow--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--accent--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--accent--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--accent--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--subtle--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--on-brand--subtle--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--on-brand--subtle--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--status--custom--clicked: var(--pf-t--global--color--status--custom--clicked);
+  --pf-t--global--icon--color--status--custom--default: var(--pf-t--global--color--status--custom--default);
+  --pf-t--global--icon--color--status--custom--hover: var(--pf-t--global--color--status--custom--hover);
+  --pf-t--global--icon--color--status--danger--clicked: var(--pf-t--global--color--status--danger--clicked);
+  --pf-t--global--icon--color--status--danger--default: var(--pf-t--global--color--status--danger--default);
+  --pf-t--global--icon--color--status--danger--hover: var(--pf-t--global--color--status--danger--hover);
+  --pf-t--global--icon--color--status--info--clicked: var(--pf-t--global--color--status--info--clicked);
+  --pf-t--global--icon--color--status--info--default: var(--pf-t--global--color--status--info--default);
+  --pf-t--global--icon--color--status--info--hover: var(--pf-t--global--color--status--info--hover);
+  --pf-t--global--icon--color--status--on-custom--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-custom--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-custom--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-danger--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-danger--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-danger--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-info--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-info--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-info--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-success--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-success--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-success--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-warning--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-warning--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-warning--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--success--clicked: var(--pf-t--global--color--status--success--clicked);
+  --pf-t--global--icon--color--status--success--default: var(--pf-t--global--color--status--success--default);
+  --pf-t--global--icon--color--status--success--hover: var(--pf-t--global--color--status--success--hover);
+  --pf-t--global--icon--color--status--unread--on-attention--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-attention--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-attention--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-default--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-default--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-default--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--warning--clicked: var(--pf-t--global--color--status--warning--clicked);
+  --pf-t--global--icon--color--status--warning--default: var(--pf-t--global--color--status--warning--default);
+  --pf-t--global--icon--color--status--warning--hover: var(--pf-t--global--color--status--warning--hover);
+  --pf-t--global--text--color--nonstatus--on-blue--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-blue--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-blue--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-gray--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-gray--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-gray--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-green--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-green--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-green--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-orange--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-orange--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-orange--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-orangered--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-orangered--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-orangered--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-purple--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-purple--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-purple--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-red--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-red--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-red--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-teal--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-teal--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-teal--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-yellow--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-yellow--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-yellow--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--accent--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--accent--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--accent--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--subtle--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--on-brand--subtle--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--on-brand--subtle--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--placeholder: var(--pf-t--global--text--color--subtle);
+  --pf-t--global--text--color--status--custom--clicked: var(--pf-t--global--color--status--custom--clicked);
+  --pf-t--global--text--color--status--custom--default: var(--pf-t--global--color--status--custom--default);
+  --pf-t--global--text--color--status--custom--hover: var(--pf-t--global--color--status--custom--hover);
+  --pf-t--global--text--color--status--info--clicked: var(--pf-t--global--color--status--info--clicked);
+  --pf-t--global--text--color--status--info--default: var(--pf-t--global--color--status--info--default);
+  --pf-t--global--text--color--status--info--hover: var(--pf-t--global--color--status--info--hover);
+  --pf-t--global--text--color--status--on-custom--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-custom--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-custom--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-danger--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-danger--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-danger--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-info--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-info--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-info--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-success--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-success--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-success--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-warning--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-warning--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-warning--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--success--clicked: var(--pf-t--global--color--status--success--clicked);
+  --pf-t--global--text--color--status--success--default: var(--pf-t--global--color--status--success--default);
+  --pf-t--global--text--color--status--success--hover: var(--pf-t--global--color--status--success--hover);
+  --pf-t--global--text--color--status--unread--on-attention--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-attention--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-attention--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-default--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-default--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-default--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--warning--clicked: var(--pf-t--global--color--status--warning--clicked);
+  --pf-t--global--text--color--status--warning--default: var(--pf-t--global--color--status--warning--default);
+  --pf-t--global--text--color--status--warning--hover: var(--pf-t--global--color--status--warning--hover);
+  --pf-t--global--text-decoration--color--hover: var(--pf-t--global--border--color--hover);
+  --pf-t--global--border--color--brand--accent--clicked: var(--pf-t--global--color--brand--accent--clicked);
+  --pf-t--global--border--color--brand--accent--default: var(--pf-t--global--color--brand--accent--default);
+  --pf-t--global--border--color--brand--accent--hover: var(--pf-t--global--color--brand--accent--hover);
+  --pf-t--global--icon--color--brand--accent--clicked: var(--pf-t--global--color--brand--accent--clicked);
+  --pf-t--global--icon--color--brand--accent--default: var(--pf-t--global--color--brand--accent--default);
+  --pf-t--global--icon--color--brand--accent--hover: var(--pf-t--global--color--brand--accent--hover);
+}
+
+:root:where(.pf-v6-theme-dark.pf-v6-theme-felt) {
+  --pf-t--global--border--color--brand--accent--clicked: var(--pf-t--global--dark--color--brand--accent--400);
+  --pf-t--global--border--color--brand--accent--default: var(--pf-t--global--dark--color--brand--accent--400);
+  --pf-t--global--border--color--brand--accent--hover: var(--pf-t--global--dark--color--brand--accent--400);
+  --pf-t--global--color--brand--accent--clicked: var(--pf-t--global--dark--color--brand--accent--200);
+  --pf-t--global--color--brand--accent--default: var(--pf-t--global--dark--color--brand--accent--100);
+  --pf-t--global--color--brand--accent--hover: var(--pf-t--global--dark--color--brand--accent--200);
+  --pf-t--global--icon--color--brand--accent--clicked: var(--pf-t--global--dark--color--brand--accent--300);
+  --pf-t--global--icon--color--brand--accent--hover: var(--pf-t--global--dark--color--brand--accent--300);
+  --pf-t--global--icon--color--on-brand--accent--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--on-brand--accent--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--on-brand--accent--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--text--color--on-brand--accent--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--on-brand--accent--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--on-brand--accent--hover: var(--pf-t--global--text--color--regular);
+}
+
+:root:where(.pf-v6-theme-dark.pf-v6-theme-high-contrast) {
+  --pf-t--global--background--color--action--plain--default: rgba(0, 0, 0, 0.0000);
+  --pf-t--global--background--color--striped--row--default: rgba(21, 21, 21, 0.3000);
+  --pf-t--global--background--filter--glass--blur--primary: initial;
+  --pf-t--global--dark--background--color--500: rgba(21, 21, 21, 0.8000);
+  --pf-t--global--dark--background--color--600: rgba(199, 199, 199, 0.1500);
+  --pf-t--global--dark--background--color--700: rgba(199, 199, 199, 0.2500);
+  --pf-t--global--dark--box-shadow--color--100: rgba(0, 0, 0, 0.5000);
+  --pf-t--global--dark--box-shadow--color--200: rgba(0, 0, 0, 0.6000);
+  --pf-t--global--background--color--action--plain--clicked: var(--pf-t--global--dark--background--color--600);
+  --pf-t--global--background--color--action--plain--hover: var(--pf-t--global--dark--background--color--600);
+  --pf-t--global--background--color--backdrop--default: var(--pf-t--global--dark--background--color--500);
+  --pf-t--global--background--color--loading--skeleton--default: var(--pf-t--global--dark--background--color--700);
+  --pf-t--global--background--color--loading--skeleton--subtle: var(--pf-t--global--dark--background--color--600);
+  --pf-t--global--background--color--primary--default: var(--pf-t--color--black);
+  --pf-t--global--background--color--tertiary--default: var(--pf-t--global--dark--background--color--600);
+  --pf-t--global--box-shadow--color--lg--default: var(--pf-t--global--dark--box-shadow--color--100);
+  --pf-t--global--box-shadow--color--lg--directional: var(--pf-t--global--dark--box-shadow--color--200);
+  --pf-t--global--box-shadow--color--md--default: var(--pf-t--global--dark--box-shadow--color--100);
+  --pf-t--global--box-shadow--color--md--directional: var(--pf-t--global--dark--box-shadow--color--200);
+  --pf-t--global--box-shadow--color--sm--default: var(--pf-t--global--dark--box-shadow--color--100);
+  --pf-t--global--box-shadow--color--sm--directional: var(--pf-t--global--dark--box-shadow--color--200);
+  --pf-t--global--dark--background--color--100: var(--pf-t--color--gray--95);
+  --pf-t--global--dark--background--color--200: var(--pf-t--color--gray--80);
+  --pf-t--global--dark--background--color--300: var(--pf-t--color--gray--70);
+  --pf-t--global--dark--background--color--400: var(--pf-t--color--gray--10);
+  --pf-t--global--dark--background--color--450: var(--pf-t--color--gray--20);
+  --pf-t--global--dark--background--color--highlight--100: var(--pf-t--color--yellow--20);
+  --pf-t--global--dark--background--color--highlight--200: var(--pf-t--color--yellow--30);
+  --pf-t--global--dark--border--color--100: var(--pf-t--color--gray--60);
+  --pf-t--global--dark--border--color--200: var(--pf-t--color--gray--40);
+  --pf-t--global--dark--border--color--300: var(--pf-t--color--gray--30);
+  --pf-t--global--dark--border--color--50: var(--pf-t--color--gray--70);
+  --pf-t--global--dark--color--brand--100: var(--pf-t--color--blue--30);
+  --pf-t--global--dark--color--brand--200: var(--pf-t--color--blue--20);
+  --pf-t--global--dark--color--brand--300: var(--pf-t--color--blue--10);
+  --pf-t--global--dark--color--brand--accent--100: var(--pf-t--color--red--50);
+  --pf-t--global--dark--color--brand--accent--200: var(--pf-t--color--red--60);
+  --pf-t--global--dark--color--brand--accent--300: var(--pf-t--color--red--40);
+  --pf-t--global--dark--color--brand--accent--350: var(--pf-t--color--gray--20);
+  --pf-t--global--dark--color--brand--accent--400: var(--pf-t--color--white);
+  --pf-t--global--dark--color--brand--subtle--100: var(--pf-t--color--blue--70);
+  --pf-t--global--dark--color--brand--subtle--200: var(--pf-t--color--blue--60);
+  --pf-t--global--dark--color--brand--subtle--300: var(--pf-t--color--blue--30);
+  --pf-t--global--dark--color--disabled--100: var(--pf-t--color--gray--40);
+  --pf-t--global--dark--color--disabled--200: var(--pf-t--color--gray--50);
+  --pf-t--global--dark--color--disabled--300: var(--pf-t--color--gray--70);
+  --pf-t--global--dark--color--disabled--400: var(--pf-t--color--gray--90);
+  --pf-t--global--dark--color--favorite--100: var(--pf-t--color--yellow--30);
+  --pf-t--global--dark--color--favorite--200: var(--pf-t--color--yellow--20);
+  --pf-t--global--dark--color--nonstatus--blue--100: var(--pf-t--color--blue--30);
+  --pf-t--global--dark--color--nonstatus--blue--200: var(--pf-t--color--blue--20);
+  --pf-t--global--dark--color--nonstatus--blue--300: var(--pf-t--color--blue--10);
+  --pf-t--global--dark--color--nonstatus--gray--100: var(--pf-t--color--gray--60);
+  --pf-t--global--dark--color--nonstatus--gray--200: var(--pf-t--color--gray--50);
+  --pf-t--global--dark--color--nonstatus--gray--300: var(--pf-t--color--gray--40);
+  --pf-t--global--dark--color--nonstatus--gray--50: var(--pf-t--color--gray--70);
+  --pf-t--global--dark--color--nonstatus--green--100: var(--pf-t--color--green--30);
+  --pf-t--global--dark--color--nonstatus--green--200: var(--pf-t--color--green--20);
+  --pf-t--global--dark--color--nonstatus--green--300: var(--pf-t--color--green--10);
+  --pf-t--global--dark--color--nonstatus--orange--100: var(--pf-t--color--orange--30);
+  --pf-t--global--dark--color--nonstatus--orange--200: var(--pf-t--color--orange--20);
+  --pf-t--global--dark--color--nonstatus--orange--300: var(--pf-t--color--orange--10);
+  --pf-t--global--dark--color--nonstatus--orangered--100: var(--pf-t--color--red-orange--30);
+  --pf-t--global--dark--color--nonstatus--orangered--200: var(--pf-t--color--red-orange--20);
+  --pf-t--global--dark--color--nonstatus--orangered--300: var(--pf-t--color--red-orange--10);
+  --pf-t--global--dark--color--nonstatus--purple--100: var(--pf-t--color--purple--30);
+  --pf-t--global--dark--color--nonstatus--purple--200: var(--pf-t--color--purple--20);
+  --pf-t--global--dark--color--nonstatus--purple--300: var(--pf-t--color--purple--10);
+  --pf-t--global--dark--color--nonstatus--red--100: var(--pf-t--color--red--30);
+  --pf-t--global--dark--color--nonstatus--red--200: var(--pf-t--color--red--20);
+  --pf-t--global--dark--color--nonstatus--red--300: var(--pf-t--color--red--10);
+  --pf-t--global--dark--color--nonstatus--teal--100: var(--pf-t--color--teal--30);
+  --pf-t--global--dark--color--nonstatus--teal--200: var(--pf-t--color--teal--20);
+  --pf-t--global--dark--color--nonstatus--teal--300: var(--pf-t--color--teal--10);
+  --pf-t--global--dark--color--nonstatus--yellow--100: var(--pf-t--color--yellow--30);
+  --pf-t--global--dark--color--nonstatus--yellow--200: var(--pf-t--color--yellow--20);
+  --pf-t--global--dark--color--nonstatus--yellow--300: var(--pf-t--color--yellow--10);
+  --pf-t--global--dark--color--severity--critical--100: var(--pf-t--color--red-orange--50);
+  --pf-t--global--dark--color--severity--critical--200: var(--pf-t--color--red-orange--40);
+  --pf-t--global--dark--color--severity--important--100: var(--pf-t--color--orange--40);
+  --pf-t--global--dark--color--severity--minor--100: var(--pf-t--color--gray--30);
+  --pf-t--global--dark--color--severity--moderate--100: var(--pf-t--color--yellow--30);
+  --pf-t--global--dark--color--severity--none--100: var(--pf-t--color--blue--30);
+  --pf-t--global--dark--color--severity--undefined--100: var(--pf-t--color--gray--40);
+  --pf-t--global--dark--color--status--custom--100: var(--pf-t--color--teal--40);
+  --pf-t--global--dark--color--status--custom--200: var(--pf-t--color--teal--30);
+  --pf-t--global--dark--color--status--custom--300: var(--pf-t--color--teal--20);
+  --pf-t--global--dark--color--status--danger--100: var(--pf-t--color--red-orange--50);
+  --pf-t--global--dark--color--status--danger--200: var(--pf-t--color--red-orange--40);
+  --pf-t--global--dark--color--status--danger--250: var(--pf-t--color--red-orange--30);
+  --pf-t--global--dark--color--status--danger--300: var(--pf-t--color--red-orange--20);
+  --pf-t--global--dark--color--status--info--100: var(--pf-t--color--purple--30);
+  --pf-t--global--dark--color--status--info--200: var(--pf-t--color--purple--20);
+  --pf-t--global--dark--color--status--info--300: var(--pf-t--color--purple--10);
+  --pf-t--global--dark--color--status--success--100: var(--pf-t--color--green--40);
+  --pf-t--global--dark--color--status--success--200: var(--pf-t--color--green--30);
+  --pf-t--global--dark--color--status--success--300: var(--pf-t--color--green--20);
+  --pf-t--global--dark--color--status--warning--100: var(--pf-t--color--yellow--30);
+  --pf-t--global--dark--color--status--warning--200: var(--pf-t--color--yellow--20);
+  --pf-t--global--dark--focus-ring--color--100: var(--pf-t--color--blue--30);
+  --pf-t--global--dark--icon--color--100: var(--pf-t--color--gray--10);
+  --pf-t--global--dark--icon--color--200: var(--pf-t--color--gray--40);
+  --pf-t--global--dark--icon--color--300: var(--pf-t--color--gray--90);
+  --pf-t--global--dark--text--color--100: var(--pf-t--color--white);
+  --pf-t--global--dark--text--color--200: var(--pf-t--color--gray--30);
+  --pf-t--global--dark--text--color--300: var(--pf-t--color--gray--90);
+  --pf-t--global--dark--text--color--400: var(--pf-t--color--red-orange--30);
+  --pf-t--global--dark--text--color--link--100: var(--pf-t--color--blue--20);
+  --pf-t--global--dark--text--color--link--200: var(--pf-t--color--blue--10);
+  --pf-t--global--dark--text--color--link--300: var(--pf-t--color--purple--30);
+  --pf-t--global--dark--text--color--link--400: var(--pf-t--color--purple--20);
+  --pf-t--global--background--color--action--plain--alt--clicked: var(--pf-t--global--background--color--primary--default);
+  --pf-t--global--background--color--action--plain--alt--hover: var(--pf-t--global--background--color--primary--default);
+  --pf-t--global--background--color--control--default: var(--pf-t--global--dark--background--color--100);
+  --pf-t--global--background--color--control--read-only: var(--pf-t--global--dark--background--color--100);
+  --pf-t--global--background--color--disabled--default: var(--pf-t--global--dark--color--disabled--200);
+  --pf-t--global--background--color--floating--clicked: var(--pf-t--global--dark--background--color--300);
+  --pf-t--global--background--color--floating--default: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--floating--hover: var(--pf-t--global--dark--background--color--300);
+  --pf-t--global--background--color--glass--primary--default: initial;
+  --pf-t--global--background--color--highlight--clicked: var(--pf-t--global--dark--background--color--highlight--200);
+  --pf-t--global--background--color--highlight--default: var(--pf-t--global--dark--background--color--highlight--100);
+  --pf-t--global--background--color--inverse--clicked: var(--pf-t--global--dark--background--color--450);
+  --pf-t--global--background--color--inverse--default: var(--pf-t--global--dark--background--color--400);
+  --pf-t--global--background--color--inverse--hover: var(--pf-t--global--dark--background--color--450);
+  --pf-t--global--background--color--primary--clicked: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--primary--hover: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--secondary--clicked: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--secondary--default: var(--pf-t--global--dark--background--color--100);
+  --pf-t--global--background--color--secondary--hover: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--sticky--default: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--border--color--alt: var(--pf-t--global--background--color--primary--default);
+  --pf-t--global--border--color--brand--subtle--clicked: var(--pf-t--global--dark--color--brand--subtle--300);
+  --pf-t--global--border--color--brand--subtle--default: var(--pf-t--global--dark--color--brand--subtle--200);
+  --pf-t--global--border--color--brand--subtle--hover: var(--pf-t--global--dark--color--brand--subtle--300);
+  --pf-t--global--border--color--clicked: var(--pf-t--global--dark--color--brand--200);
+  --pf-t--global--border--color--control--default: var(--pf-t--global--dark--border--color--300);
+  --pf-t--global--border--color--control--read-only: var(--pf-t--global--dark--border--color--50);
+  --pf-t--global--border--color--default: var(--pf-t--global--dark--border--color--300);
+  --pf-t--global--border--color--disabled: var(--pf-t--global--dark--color--disabled--100);
+  --pf-t--global--border--color--hover: var(--pf-t--global--dark--color--brand--100);
+  --pf-t--global--border--color--nonstatus--blue--clicked: var(--pf-t--global--dark--color--nonstatus--blue--200);
+  --pf-t--global--border--color--nonstatus--blue--default: var(--pf-t--global--dark--color--nonstatus--blue--100);
+  --pf-t--global--border--color--nonstatus--blue--hover: var(--pf-t--global--dark--color--nonstatus--blue--200);
+  --pf-t--global--border--color--nonstatus--gray--clicked: var(--pf-t--global--dark--color--nonstatus--gray--300);
+  --pf-t--global--border--color--nonstatus--gray--default: var(--pf-t--global--dark--color--nonstatus--gray--200);
+  --pf-t--global--border--color--nonstatus--gray--hover: var(--pf-t--global--dark--color--nonstatus--gray--300);
+  --pf-t--global--border--color--nonstatus--green--clicked: var(--pf-t--global--dark--color--nonstatus--green--200);
+  --pf-t--global--border--color--nonstatus--green--default: var(--pf-t--global--dark--color--nonstatus--green--100);
+  --pf-t--global--border--color--nonstatus--green--hover: var(--pf-t--global--dark--color--nonstatus--green--200);
+  --pf-t--global--border--color--nonstatus--orange--clicked: var(--pf-t--global--dark--color--nonstatus--orange--200);
+  --pf-t--global--border--color--nonstatus--orange--default: var(--pf-t--global--dark--color--nonstatus--orange--100);
+  --pf-t--global--border--color--nonstatus--orange--hover: var(--pf-t--global--dark--color--nonstatus--orange--200);
+  --pf-t--global--border--color--nonstatus--orangered--clicked: var(--pf-t--global--dark--color--nonstatus--orangered--200);
+  --pf-t--global--border--color--nonstatus--orangered--default: var(--pf-t--global--dark--color--nonstatus--orangered--100);
+  --pf-t--global--border--color--nonstatus--orangered--hover: var(--pf-t--global--dark--color--nonstatus--orangered--200);
+  --pf-t--global--border--color--nonstatus--purple--clicked: var(--pf-t--global--dark--color--nonstatus--purple--200);
+  --pf-t--global--border--color--nonstatus--purple--default: var(--pf-t--global--dark--color--nonstatus--purple--100);
+  --pf-t--global--border--color--nonstatus--purple--hover: var(--pf-t--global--dark--color--nonstatus--purple--200);
+  --pf-t--global--border--color--nonstatus--red--clicked: var(--pf-t--global--dark--color--nonstatus--red--200);
+  --pf-t--global--border--color--nonstatus--red--default: var(--pf-t--global--dark--color--nonstatus--red--100);
+  --pf-t--global--border--color--nonstatus--red--hover: var(--pf-t--global--dark--color--nonstatus--red--200);
+  --pf-t--global--border--color--nonstatus--teal--clicked: var(--pf-t--global--dark--color--nonstatus--teal--200);
+  --pf-t--global--border--color--nonstatus--teal--default: var(--pf-t--global--dark--color--nonstatus--teal--100);
+  --pf-t--global--border--color--nonstatus--teal--hover: var(--pf-t--global--dark--color--nonstatus--teal--200);
+  --pf-t--global--border--color--nonstatus--yellow--clicked: var(--pf-t--global--dark--color--nonstatus--yellow--200);
+  --pf-t--global--border--color--nonstatus--yellow--default: var(--pf-t--global--dark--color--nonstatus--yellow--100);
+  --pf-t--global--border--color--nonstatus--yellow--hover: var(--pf-t--global--dark--color--nonstatus--yellow--200);
+  --pf-t--global--border--color--on-secondary: var(--pf-t--global--dark--border--color--300);
+  --pf-t--global--border--color--subtle: var(--pf-t--global--dark--border--color--300);
+  --pf-t--global--color--brand--clicked: var(--pf-t--global--dark--color--brand--200);
+  --pf-t--global--color--brand--default: var(--pf-t--global--dark--color--brand--100);
+  --pf-t--global--color--brand--hover: var(--pf-t--global--dark--color--brand--200);
+  --pf-t--global--color--brand--subtle--clicked: var(--pf-t--global--dark--color--brand--subtle--200);
+  --pf-t--global--color--brand--subtle--default: var(--pf-t--global--dark--color--brand--subtle--100);
+  --pf-t--global--color--brand--subtle--hover: var(--pf-t--global--dark--color--brand--subtle--200);
+  --pf-t--global--color--favorite--clicked: var(--pf-t--global--dark--color--favorite--200);
+  --pf-t--global--color--favorite--default: var(--pf-t--global--dark--color--favorite--100);
+  --pf-t--global--color--favorite--hover: var(--pf-t--global--dark--color--favorite--200);
+  --pf-t--global--color--nonstatus--blue--clicked: var(--pf-t--global--dark--color--nonstatus--blue--200);
+  --pf-t--global--color--nonstatus--blue--default: var(--pf-t--global--dark--color--nonstatus--blue--100);
+  --pf-t--global--color--nonstatus--blue--hover: var(--pf-t--global--dark--color--nonstatus--blue--200);
+  --pf-t--global--color--nonstatus--gray--clicked: var(--pf-t--global--dark--color--nonstatus--gray--100);
+  --pf-t--global--color--nonstatus--gray--default: var(--pf-t--global--dark--color--nonstatus--gray--50);
+  --pf-t--global--color--nonstatus--gray--hover: var(--pf-t--global--dark--color--nonstatus--gray--100);
+  --pf-t--global--color--nonstatus--green--clicked: var(--pf-t--global--dark--color--nonstatus--green--200);
+  --pf-t--global--color--nonstatus--green--default: var(--pf-t--global--dark--color--nonstatus--green--100);
+  --pf-t--global--color--nonstatus--green--hover: var(--pf-t--global--dark--color--nonstatus--green--200);
+  --pf-t--global--color--nonstatus--orange--clicked: var(--pf-t--global--dark--color--nonstatus--orange--200);
+  --pf-t--global--color--nonstatus--orange--default: var(--pf-t--global--dark--color--nonstatus--orange--100);
+  --pf-t--global--color--nonstatus--orange--hover: var(--pf-t--global--dark--color--nonstatus--orange--200);
+  --pf-t--global--color--nonstatus--orangered--clicked: var(--pf-t--global--dark--color--nonstatus--orangered--200);
+  --pf-t--global--color--nonstatus--orangered--default: var(--pf-t--global--dark--color--nonstatus--orangered--100);
+  --pf-t--global--color--nonstatus--orangered--hover: var(--pf-t--global--dark--color--nonstatus--orangered--200);
+  --pf-t--global--color--nonstatus--purple--clicked: var(--pf-t--global--dark--color--nonstatus--purple--200);
+  --pf-t--global--color--nonstatus--purple--default: var(--pf-t--global--dark--color--nonstatus--purple--100);
+  --pf-t--global--color--nonstatus--purple--hover: var(--pf-t--global--dark--color--nonstatus--purple--200);
+  --pf-t--global--color--nonstatus--red--clicked: var(--pf-t--global--dark--color--nonstatus--red--200);
+  --pf-t--global--color--nonstatus--red--default: var(--pf-t--global--dark--color--nonstatus--red--100);
+  --pf-t--global--color--nonstatus--red--hover: var(--pf-t--global--dark--color--nonstatus--red--200);
+  --pf-t--global--color--nonstatus--teal--clicked: var(--pf-t--global--dark--color--nonstatus--teal--200);
+  --pf-t--global--color--nonstatus--teal--default: var(--pf-t--global--dark--color--nonstatus--teal--100);
+  --pf-t--global--color--nonstatus--teal--hover: var(--pf-t--global--dark--color--nonstatus--teal--200);
+  --pf-t--global--color--nonstatus--yellow--clicked: var(--pf-t--global--dark--color--nonstatus--yellow--200);
+  --pf-t--global--color--nonstatus--yellow--default: var(--pf-t--global--dark--color--nonstatus--yellow--100);
+  --pf-t--global--color--nonstatus--yellow--hover: var(--pf-t--global--dark--color--nonstatus--yellow--200);
+  --pf-t--global--color--status--custom--clicked: var(--pf-t--global--dark--color--status--custom--300);
+  --pf-t--global--color--status--custom--default: var(--pf-t--global--dark--color--status--custom--200);
+  --pf-t--global--color--status--custom--hover: var(--pf-t--global--dark--color--status--custom--300);
+  --pf-t--global--color--status--danger--clicked: var(--pf-t--global--dark--color--status--danger--250);
+  --pf-t--global--color--status--danger--default: var(--pf-t--global--dark--color--status--danger--200);
+  --pf-t--global--color--status--danger--hover: var(--pf-t--global--dark--color--status--danger--250);
+  --pf-t--global--color--status--info--clicked: var(--pf-t--global--dark--color--status--info--200);
+  --pf-t--global--color--status--info--default: var(--pf-t--global--dark--color--status--info--100);
+  --pf-t--global--color--status--info--hover: var(--pf-t--global--dark--color--status--info--200);
+  --pf-t--global--color--status--success--clicked: var(--pf-t--global--dark--color--status--success--300);
+  --pf-t--global--color--status--success--default: var(--pf-t--global--dark--color--status--success--200);
+  --pf-t--global--color--status--success--hover: var(--pf-t--global--dark--color--status--success--300);
+  --pf-t--global--color--status--warning--clicked: var(--pf-t--global--dark--color--status--warning--200);
+  --pf-t--global--color--status--warning--default: var(--pf-t--global--dark--color--status--warning--100);
+  --pf-t--global--color--status--warning--hover: var(--pf-t--global--dark--color--status--warning--200);
+  --pf-t--global--focus-ring--color--default: var(--pf-t--global--dark--focus-ring--color--100);
+  --pf-t--global--icon--color--brand--clicked: var(--pf-t--global--dark--color--brand--300);
+  --pf-t--global--icon--color--brand--default: var(--pf-t--global--dark--color--brand--200);
+  --pf-t--global--icon--color--brand--hover: var(--pf-t--global--dark--color--brand--300);
+  --pf-t--global--icon--color--disabled: var(--pf-t--global--dark--color--disabled--200);
+  --pf-t--global--icon--color--inverse: var(--pf-t--global--dark--icon--color--300);
+  --pf-t--global--icon--color--on-disabled: var(--pf-t--global--dark--color--disabled--300);
+  --pf-t--global--icon--color--regular: var(--pf-t--global--dark--icon--color--100);
+  --pf-t--global--icon--color--severity--critical--default: var(--pf-t--global--dark--color--severity--critical--200);
+  --pf-t--global--icon--color--severity--important--default: var(--pf-t--global--dark--color--severity--important--100);
+  --pf-t--global--icon--color--severity--minor--default: var(--pf-t--global--dark--color--severity--minor--100);
+  --pf-t--global--icon--color--severity--moderate--default: var(--pf-t--global--dark--color--severity--moderate--100);
+  --pf-t--global--icon--color--severity--none--default: var(--pf-t--global--dark--color--severity--none--100);
+  --pf-t--global--icon--color--severity--undefined--default: var(--pf-t--global--dark--color--severity--undefined--100);
+  --pf-t--global--icon--color--subtle: var(--pf-t--global--dark--icon--color--200);
+  --pf-t--global--text--color--brand--clicked: var(--pf-t--global--dark--color--brand--300);
+  --pf-t--global--text--color--brand--default: var(--pf-t--global--dark--color--brand--200);
+  --pf-t--global--text--color--brand--hover: var(--pf-t--global--dark--color--brand--300);
+  --pf-t--global--text--color--disabled: var(--pf-t--global--dark--color--disabled--200);
+  --pf-t--global--text--color--inverse: var(--pf-t--global--dark--text--color--300);
+  --pf-t--global--text--color--link--default: var(--pf-t--global--dark--text--color--link--100);
+  --pf-t--global--text--color--link--hover: var(--pf-t--global--dark--text--color--link--200);
+  --pf-t--global--text--color--link--visited: var(--pf-t--global--dark--text--color--link--400);
+  --pf-t--global--text--color--on-disabled: var(--pf-t--global--dark--color--disabled--400);
+  --pf-t--global--text--color--on-highlight: var(--pf-t--global--dark--text--color--300);
+  --pf-t--global--text--color--regular: var(--pf-t--global--dark--text--color--100);
+  --pf-t--global--text--color--required: var(--pf-t--global--dark--text--color--400);
+  --pf-t--global--text--color--status--danger--clicked: var(--pf-t--global--dark--color--status--danger--300);
+  --pf-t--global--text--color--status--danger--default: var(--pf-t--global--dark--color--status--danger--300);
+  --pf-t--global--text--color--status--danger--hover: var(--pf-t--global--dark--color--status--danger--300);
+  --pf-t--global--text--color--subtle: var(--pf-t--global--dark--text--color--200);
+  --pf-t--global--text-decoration--color--default: var(--pf-t--global--dark--border--color--300);
+  --pf-t--global--background--color--floating--secondary--default: var(--pf-t--global--background--color--secondary--default);
+  --pf-t--global--border--color--brand--clicked: var(--pf-t--global--color--brand--clicked);
+  --pf-t--global--border--color--brand--default: var(--pf-t--global--color--brand--default);
+  --pf-t--global--border--color--brand--hover: var(--pf-t--global--color--brand--hover);
+  --pf-t--global--border--color--glass--default: initial;
+  --pf-t--global--border--color--high-contrast: var(--pf-t--global--border--color--default);
+  --pf-t--global--border--color--main--default: var(--pf-t--global--border--color--default);
+  --pf-t--global--border--color--status--custom--clicked: var(--pf-t--global--color--status--custom--clicked);
+  --pf-t--global--border--color--status--custom--default: var(--pf-t--global--color--status--custom--default);
+  --pf-t--global--border--color--status--custom--hover: var(--pf-t--global--color--status--custom--hover);
+  --pf-t--global--border--color--status--danger--clicked: var(--pf-t--global--color--status--danger--clicked);
+  --pf-t--global--border--color--status--danger--default: var(--pf-t--global--color--status--danger--default);
+  --pf-t--global--border--color--status--danger--hover: var(--pf-t--global--color--status--danger--hover);
+  --pf-t--global--border--color--status--info--clicked: var(--pf-t--global--color--status--info--clicked);
+  --pf-t--global--border--color--status--info--default: var(--pf-t--global--color--status--info--default);
+  --pf-t--global--border--color--status--info--hover: var(--pf-t--global--color--status--info--hover);
+  --pf-t--global--border--color--status--success--clicked: var(--pf-t--global--color--status--success--clicked);
+  --pf-t--global--border--color--status--success--default: var(--pf-t--global--color--status--success--default);
+  --pf-t--global--border--color--status--success--hover: var(--pf-t--global--color--status--success--hover);
+  --pf-t--global--border--color--status--warning--clicked: var(--pf-t--global--color--status--warning--clicked);
+  --pf-t--global--border--color--status--warning--default: var(--pf-t--global--color--status--warning--default);
+  --pf-t--global--border--color--status--warning--hover: var(--pf-t--global--color--status--warning--hover);
+  --pf-t--global--color--brand--accent--clicked: var(--pf-t--global--color--brand--clicked);
+  --pf-t--global--color--brand--accent--default: var(--pf-t--global--color--brand--default);
+  --pf-t--global--color--brand--accent--hover: var(--pf-t--global--color--brand--hover);
+  --pf-t--global--color--status--read--on-primary: var(--pf-t--global--background--color--secondary--default);
+  --pf-t--global--color--status--read--on-secondary: var(--pf-t--global--background--color--control--default);
+  --pf-t--global--color--status--unread--attention--clicked: var(--pf-t--global--color--status--danger--clicked);
+  --pf-t--global--color--status--unread--attention--default: var(--pf-t--global--color--status--danger--default);
+  --pf-t--global--color--status--unread--attention--hover: var(--pf-t--global--color--status--danger--hover);
+  --pf-t--global--color--status--unread--clicked: var(--pf-t--global--color--brand--clicked);
+  --pf-t--global--color--status--unread--default: var(--pf-t--global--color--brand--default);
+  --pf-t--global--color--status--unread--hover: var(--pf-t--global--color--brand--hover);
+  --pf-t--global--icon--color--favorite--clicked: var(--pf-t--global--color--favorite--clicked);
+  --pf-t--global--icon--color--favorite--default: var(--pf-t--global--color--favorite--default);
+  --pf-t--global--icon--color--favorite--hover: var(--pf-t--global--color--favorite--hover);
+  --pf-t--global--icon--color--nonstatus--on-blue--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-blue--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-blue--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-gray--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-gray--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-gray--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--nonstatus--on-green--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-green--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-green--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-orange--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-orange--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-orange--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-orangered--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-orangered--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-orangered--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-purple--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-purple--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-purple--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-red--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-red--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-red--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-teal--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-teal--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-teal--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-yellow--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-yellow--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--nonstatus--on-yellow--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--accent--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--accent--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--accent--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--on-brand--subtle--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--on-brand--subtle--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--on-brand--subtle--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--status--custom--clicked: var(--pf-t--global--color--status--custom--clicked);
+  --pf-t--global--icon--color--status--custom--default: var(--pf-t--global--color--status--custom--default);
+  --pf-t--global--icon--color--status--custom--hover: var(--pf-t--global--color--status--custom--hover);
+  --pf-t--global--icon--color--status--danger--clicked: var(--pf-t--global--color--status--danger--clicked);
+  --pf-t--global--icon--color--status--danger--default: var(--pf-t--global--color--status--danger--default);
+  --pf-t--global--icon--color--status--danger--hover: var(--pf-t--global--color--status--danger--hover);
+  --pf-t--global--icon--color--status--info--clicked: var(--pf-t--global--color--status--info--clicked);
+  --pf-t--global--icon--color--status--info--default: var(--pf-t--global--color--status--info--default);
+  --pf-t--global--icon--color--status--info--hover: var(--pf-t--global--color--status--info--hover);
+  --pf-t--global--icon--color--status--on-custom--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-custom--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-custom--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-danger--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-danger--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-danger--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-info--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-info--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-info--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-success--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-success--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-success--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-warning--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-warning--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--on-warning--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--success--clicked: var(--pf-t--global--color--status--success--clicked);
+  --pf-t--global--icon--color--status--success--default: var(--pf-t--global--color--status--success--default);
+  --pf-t--global--icon--color--status--success--hover: var(--pf-t--global--color--status--success--hover);
+  --pf-t--global--icon--color--status--unread--on-attention--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-attention--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-attention--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-default--clicked: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-default--default: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--unread--on-default--hover: var(--pf-t--global--icon--color--inverse);
+  --pf-t--global--icon--color--status--warning--clicked: var(--pf-t--global--color--status--warning--clicked);
+  --pf-t--global--icon--color--status--warning--default: var(--pf-t--global--color--status--warning--default);
+  --pf-t--global--icon--color--status--warning--hover: var(--pf-t--global--color--status--warning--hover);
+  --pf-t--global--text--color--nonstatus--on-blue--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-blue--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-blue--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-gray--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-gray--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-gray--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--nonstatus--on-green--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-green--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-green--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-orange--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-orange--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-orange--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-orangered--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-orangered--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-orangered--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-purple--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-purple--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-purple--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-red--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-red--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-red--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-teal--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-teal--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-teal--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-yellow--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-yellow--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--nonstatus--on-yellow--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--accent--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--accent--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--accent--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--on-brand--subtle--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--on-brand--subtle--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--on-brand--subtle--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--placeholder: var(--pf-t--global--text--color--subtle);
+  --pf-t--global--text--color--status--custom--clicked: var(--pf-t--global--color--status--custom--clicked);
+  --pf-t--global--text--color--status--custom--default: var(--pf-t--global--color--status--custom--default);
+  --pf-t--global--text--color--status--custom--hover: var(--pf-t--global--color--status--custom--hover);
+  --pf-t--global--text--color--status--info--clicked: var(--pf-t--global--color--status--info--clicked);
+  --pf-t--global--text--color--status--info--default: var(--pf-t--global--color--status--info--default);
+  --pf-t--global--text--color--status--info--hover: var(--pf-t--global--color--status--info--hover);
+  --pf-t--global--text--color--status--on-custom--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-custom--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-custom--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-danger--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-danger--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-danger--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-info--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-info--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-info--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-success--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-success--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-success--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-warning--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-warning--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--on-warning--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--success--clicked: var(--pf-t--global--color--status--success--clicked);
+  --pf-t--global--text--color--status--success--default: var(--pf-t--global--color--status--success--default);
+  --pf-t--global--text--color--status--success--hover: var(--pf-t--global--color--status--success--hover);
+  --pf-t--global--text--color--status--unread--on-attention--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-attention--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-attention--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-default--clicked: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-default--default: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--unread--on-default--hover: var(--pf-t--global--text--color--inverse);
+  --pf-t--global--text--color--status--warning--clicked: var(--pf-t--global--color--status--warning--clicked);
+  --pf-t--global--text--color--status--warning--default: var(--pf-t--global--color--status--warning--default);
+  --pf-t--global--text--color--status--warning--hover: var(--pf-t--global--color--status--warning--hover);
+  --pf-t--global--text-decoration--color--hover: var(--pf-t--global--border--color--hover);
+  --pf-t--global--border--color--brand--accent--clicked: var(--pf-t--global--color--brand--accent--clicked);
+  --pf-t--global--border--color--brand--accent--default: var(--pf-t--global--color--brand--accent--default);
+  --pf-t--global--border--color--brand--accent--hover: var(--pf-t--global--color--brand--accent--hover);
+  --pf-t--global--icon--color--brand--accent--clicked: var(--pf-t--global--color--brand--accent--clicked);
+  --pf-t--global--icon--color--brand--accent--default: var(--pf-t--global--color--brand--accent--default);
+  --pf-t--global--icon--color--brand--accent--hover: var(--pf-t--global--color--brand--accent--hover);
+}
+
+:root:where(.pf-v6-theme-dark.pf-v6-theme-glass) {
+  --pf-t--global--background--color--glass--primary--default: rgba(41, 41, 41, 0.5000);
+  --pf-t--global--background--color--primary--clicked: rgba(56, 56, 56, 0.5000);
+  --pf-t--global--background--color--primary--default: rgba(41, 41, 41, 0.5000);
+  --pf-t--global--background--color--primary--hover: rgba(56, 56, 56, 0.5000);
+  --pf-t--global--background--color--secondary--clicked: rgba(41, 41, 41, 0.6000);
+  --pf-t--global--background--color--secondary--default: rgba(21, 21, 21, 0.6000);
+  --pf-t--global--background--color--secondary--hover: rgba(41, 41, 41, 0.6000);
+  --pf-t--global--background--filter--glass--blur--primary: blur(16px);
+  --pf-t--global--background--color--control--default: var(--pf-t--global--dark--background--color--500);
+  --pf-t--global--background--color--control--read-only: var(--pf-t--global--dark--background--color--500);
+  --pf-t--global--background--color--action--plain--alt--clicked: var(--pf-t--global--background--color--action--plain--clicked);
+  --pf-t--global--background--color--action--plain--alt--hover: var(--pf-t--global--background--color--action--plain--hover);
+  --pf-t--global--background--color--floating--clicked: var(--pf-t--global--dark--background--color--300);
+  --pf-t--global--background--color--floating--default: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--floating--hover: var(--pf-t--global--dark--background--color--300);
+  --pf-t--global--border--color--control--read-only: var(--pf-t--global--dark--border--color--50);
+  --pf-t--global--border--color--glass--default: var(--pf-t--global--border--color--alt);
+  --pf-t--global--border--color--subtle: var(--pf-t--global--dark--border--color--50);
+  --pf-t--global--background--color--floating--secondary--default: var(--pf-t--global--background--color--floating--default);
+  --pf-t--global--background--image--default: var(--pf-t--global--background--image--glass--dark, url("./assets/images/PF-Bkg-Generic-Dark.svg"));
+}
+
+:root:where(.pf-v6-theme-dark.pf-v6-theme-felt.pf-v6-theme-high-contrast) {
+  --pf-t--global--background--color--primary--default: var(--pf-t--color--black);
+  --pf-t--global--box-shadow--color--md--directional: var(--pf-t--global--dark--box-shadow--color--200);
+  --pf-t--global--background--color--action--plain--alt--clicked: var(--pf-t--global--background--color--primary--default);
+  --pf-t--global--background--color--action--plain--alt--hover: var(--pf-t--global--background--color--primary--default);
+  --pf-t--global--background--color--control--default: var(--pf-t--global--dark--background--color--100);
+  --pf-t--global--background--color--control--read-only: var(--pf-t--global--dark--background--color--100);
+  --pf-t--global--background--color--disabled--default: var(--pf-t--global--dark--color--disabled--200);
+  --pf-t--global--background--color--floating--clicked: var(--pf-t--global--dark--background--color--300);
+  --pf-t--global--background--color--floating--default: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--floating--hover: var(--pf-t--global--dark--background--color--300);
+  --pf-t--global--background--color--primary--clicked: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--primary--hover: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--border--color--brand--accent--clicked: var(--pf-t--global--dark--color--brand--accent--400);
+  --pf-t--global--border--color--brand--accent--default: var(--pf-t--global--dark--color--brand--accent--400);
+  --pf-t--global--border--color--brand--accent--hover: var(--pf-t--global--dark--color--brand--accent--400);
+  --pf-t--global--border--color--control--default: var(--pf-t--global--dark--border--color--300);
+  --pf-t--global--border--color--control--read-only: var(--pf-t--global--dark--border--color--50);
+  --pf-t--global--border--color--default: var(--pf-t--global--dark--border--color--300);
+  --pf-t--global--border--color--disabled: var(--pf-t--global--dark--color--disabled--100);
+  --pf-t--global--border--color--on-secondary: var(--pf-t--global--dark--border--color--300);
+  --pf-t--global--border--color--subtle: var(--pf-t--global--dark--border--color--300);
+  --pf-t--global--color--brand--accent--clicked: var(--pf-t--global--dark--color--brand--accent--350);
+  --pf-t--global--color--brand--accent--default: var(--pf-t--global--dark--color--brand--accent--400);
+  --pf-t--global--color--brand--accent--hover: var(--pf-t--global--dark--color--brand--accent--350);
+  --pf-t--global--color--nonstatus--gray--clicked: var(--pf-t--global--dark--color--nonstatus--gray--100);
+  --pf-t--global--color--nonstatus--gray--default: var(--pf-t--global--dark--color--nonstatus--gray--50);
+  --pf-t--global--color--nonstatus--gray--hover: var(--pf-t--global--dark--color--nonstatus--gray--100);
+  --pf-t--global--color--status--custom--clicked: var(--pf-t--global--dark--color--status--custom--300);
+  --pf-t--global--color--status--custom--default: var(--pf-t--global--dark--color--status--custom--200);
+  --pf-t--global--color--status--custom--hover: var(--pf-t--global--dark--color--status--custom--300);
+  --pf-t--global--color--status--danger--clicked: var(--pf-t--global--dark--color--status--danger--250);
+  --pf-t--global--color--status--danger--default: var(--pf-t--global--dark--color--status--danger--200);
+  --pf-t--global--color--status--danger--hover: var(--pf-t--global--dark--color--status--danger--250);
+  --pf-t--global--color--status--success--clicked: var(--pf-t--global--dark--color--status--success--300);
+  --pf-t--global--color--status--success--default: var(--pf-t--global--dark--color--status--success--200);
+  --pf-t--global--color--status--success--hover: var(--pf-t--global--dark--color--status--success--300);
+  --pf-t--global--icon--color--severity--critical--default: var(--pf-t--global--dark--color--severity--critical--200);
+  --pf-t--global--text--color--link--visited: var(--pf-t--global--dark--text--color--link--400);
+  --pf-t--global--text--color--on-disabled: var(--pf-t--global--dark--color--disabled--400);
+  --pf-t--global--text--color--status--danger--default: var(--pf-t--global--dark--color--status--danger--300);
+  --pf-t--global--text-decoration--color--default: var(--pf-t--global--dark--border--color--300);
+  --pf-t--global--border--color--high-contrast: var(--pf-t--global--border--color--default);
+  --pf-t--global--border--color--main--default: var(--pf-t--global--border--color--default);
+}
+
+:root:where(.pf-v6-theme-dark.pf-v6-theme-felt.pf-v6-theme-glass) {
+  --pf-t--global--background--color--glass--primary--default: rgba(41, 41, 41, 0.5000);
+  --pf-t--global--background--color--primary--clicked: rgba(56, 56, 56, 0.5000);
+  --pf-t--global--background--color--primary--default: rgba(41, 41, 41, 0.5000);
+  --pf-t--global--background--color--primary--hover: rgba(56, 56, 56, 0.5000);
+  --pf-t--global--background--color--secondary--clicked: rgba(41, 41, 41, 0.6000);
+  --pf-t--global--background--color--secondary--default: rgba(21, 21, 21, 0.6000);
+  --pf-t--global--background--color--secondary--hover: rgba(41, 41, 41, 0.6000);
+  --pf-t--global--background--filter--glass--blur--primary: blur(16px);
+  --pf-t--global--background--color--control--default: var(--pf-t--global--dark--background--color--500);
+  --pf-t--global--background--color--control--read-only: var(--pf-t--global--dark--background--color--500);
+  --pf-t--global--background--color--action--plain--alt--clicked: var(--pf-t--global--background--color--action--plain--clicked);
+  --pf-t--global--background--color--action--plain--alt--hover: var(--pf-t--global--background--color--action--plain--hover);
+  --pf-t--global--background--color--floating--clicked: var(--pf-t--global--dark--background--color--300);
+  --pf-t--global--background--color--floating--default: var(--pf-t--global--dark--background--color--200);
+  --pf-t--global--background--color--floating--hover: var(--pf-t--global--dark--background--color--300);
+  --pf-t--global--border--color--brand--accent--clicked: var(--pf-t--global--dark--color--brand--accent--400);
+  --pf-t--global--border--color--brand--accent--default: var(--pf-t--global--dark--color--brand--accent--400);
+  --pf-t--global--border--color--brand--accent--hover: var(--pf-t--global--dark--color--brand--accent--400);
+  --pf-t--global--border--color--control--read-only: var(--pf-t--global--dark--border--color--50);
+  --pf-t--global--border--color--glass--default: var(--pf-t--global--border--color--alt);
+  --pf-t--global--border--color--subtle: var(--pf-t--global--dark--border--color--50);
+  --pf-t--global--color--brand--accent--clicked: var(--pf-t--global--dark--color--brand--accent--200);
+  --pf-t--global--color--brand--accent--default: var(--pf-t--global--dark--color--brand--accent--100);
+  --pf-t--global--color--brand--accent--hover: var(--pf-t--global--dark--color--brand--accent--200);
+  --pf-t--global--icon--color--brand--accent--clicked: var(--pf-t--global--dark--color--brand--accent--300);
+  --pf-t--global--icon--color--brand--accent--hover: var(--pf-t--global--dark--color--brand--accent--300);
+  --pf-t--global--background--color--floating--secondary--default: var(--pf-t--global--background--color--floating--default);
+  --pf-t--global--icon--color--on-brand--accent--clicked: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--on-brand--accent--default: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--icon--color--on-brand--accent--hover: var(--pf-t--global--icon--color--regular);
+  --pf-t--global--text--color--on-brand--accent--clicked: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--on-brand--accent--default: var(--pf-t--global--text--color--regular);
+  --pf-t--global--text--color--on-brand--accent--hover: var(--pf-t--global--text--color--regular);
+  --pf-t--global--background--image--default: var(--pf-t--global--background--image--felt--glass--dark, url("./assets/images/Felt-Bkg-Generic-Dark.svg"));
+}
+
+:is(.pf-v6-m-dir-rtl, [dir=rtl]) {
+  --pf-v6-global--inverse--multiplier: -1;
+}

--- a/docs/stylesheets/patternfly-base.css
+++ b/docs/stylesheets/patternfly-base.css
@@ -296,48 +296,6 @@ button) {
     opacity: 0;
   }
 }
-@font-face {
-  font-family: "Red Hat Text";
-  font-style: normal;
-  font-weight: 400 500;
-  src: url("./assets/fonts/RedHatText/RedHatTextVF.woff2") format("woff2-variations");
-  font-display: fallback;
-}
-@font-face {
-  font-family: "Red Hat Text";
-  font-style: italic;
-  font-weight: 400 500;
-  src: url("./assets/fonts/RedHatText/RedHatTextVF-Italic.woff2") format("woff2-variations");
-  font-display: fallback;
-}
-@font-face {
-  font-family: "Red Hat Display";
-  font-style: normal;
-  font-weight: 400 700;
-  src: url("./assets/fonts/RedHatDisplay/RedHatDisplayVF.woff2") format("woff2-variations");
-  font-display: fallback;
-}
-@font-face {
-  font-family: "Red Hat Display";
-  font-style: italic;
-  font-weight: 400 700;
-  src: url("./assets/fonts/RedHatDisplay/RedHatDisplayVF-Italic.woff2") format("woff2-variations");
-  font-display: fallback;
-}
-@font-face {
-  font-family: "Red Hat Mono";
-  font-style: normal;
-  font-weight: 400;
-  src: url("./assets/fonts/RedHatMono/RedHatMonoVF.woff2") format("woff2-variations");
-  font-display: fallback;
-}
-@font-face {
-  font-family: "Red Hat Mono";
-  font-style: italic;
-  font-weight: 400;
-  src: url("./assets/fonts/RedHatMono/RedHatMonoVF-Italic.woff2") format("woff2-variations");
-  font-display: fallback;
-}
 .fa-lg {
   font-size: 1.3333333333em;
   line-height: 0.75em;
@@ -546,12 +504,6 @@ button) {
   width: auto;
 }
 
-@font-face {
-  font-family: "Font Awesome 5 Free";
-  font-style: normal;
-  font-weight: 900;
-  src: url("./assets/fonts/webfonts/fa-solid-900.woff2") format("woff2");
-}
 .fa,
 .fas {
   font-family: "Font Awesome 5 Free";
@@ -5893,10 +5845,6 @@ button) {
   line-height: 1;
 }
 
-@font-face {
-  font-family: "pf-v6-pficon";
-  src: url("./assets/pficon/pf-v6-pficon.woff2") format("woff2");
-}
 .pf-v6-pficon-zone:before, .pf-v6-pficon-warning-triangle:before, .pf-v6-pficon-volume:before, .pf-v6-pficon-virtual-machine:before, .pf-v6-pficon-users:before, .pf-v6-pficon-user:before, .pf-v6-pficon-unplugged:before, .pf-v6-pficon-unlocked:before, .pf-v6-pficon-unknown:before, .pf-v6-pficon-trend-up:before, .pf-v6-pficon-trend-down:before, .pf-v6-pficon-treeview:before, .pf-v6-pficon-topology:before, .pf-v6-pficon-thumb-tack:before, .pf-v6-pficon-tenant:before, .pf-v6-pficon-task:before, .pf-v6-pficon-storage-domain:before, .pf-v6-pficon-spinner2:before, .pf-v6-pficon-spinner:before, .pf-v6-pficon-severity-undefined:before, .pf-v6-pficon-severity-none:before, .pf-v6-pficon-severity-moderate:before, .pf-v6-pficon-severity-minor:before, .pf-v6-pficon-severity-important:before, .pf-v6-pficon-severity-critical:before, .pf-v6-pficon-services:before, .pf-v6-pficon-service:before, .pf-v6-pficon-service-catalog:before, .pf-v6-pficon-server:before, .pf-v6-pficon-server-group:before, .pf-v6-pficon-security:before, .pf-v6-pficon-screen:before, .pf-v6-pficon-save:before, .pf-v6-pficon-running:before, .pf-v6-pficon-resources-full:before, .pf-v6-pficon-resources-empty:before, .pf-v6-pficon-resources-almost-full:before, .pf-v6-pficon-resources-almost-empty:before, .pf-v6-pficon-resource-pool:before, .pf-v6-pficon-repository:before, .pf-v6-pficon-replicator:before, .pf-v6-pficon-remove2:before, .pf-v6-pficon-registry:before, .pf-v6-pficon-regions:before, .pf-v6-pficon-rebooting:before, .pf-v6-pficon-rebalance:before, .pf-v6-pficon-project:before, .pf-v6-pficon-process-automation:before, .pf-v6-pficon-private:before, .pf-v6-pficon-print:before, .pf-v6-pficon-port:before, .pf-v6-pficon-plugged:before, .pf-v6-pficon-pficon-vcenter:before, .pf-v6-pficon-pficon-template:before, .pf-v6-pficon-pficon-sort-common-desc:before, .pf-v6-pficon-pficon-sort-common-asc:before, .pf-v6-pficon-pficon-satellite:before, .pf-v6-pficon-pficon-network-range:before, .pf-v6-pficon-pficon-history:before, .pf-v6-pficon-pficon-dragdrop:before, .pf-v6-pficon-pending:before, .pf-v6-pficon-paused:before, .pf-v6-pficon-panel-open:before, .pf-v6-pficon-panel-close:before, .pf-v6-pficon-package:before, .pf-v6-pficon-os-image:before, .pf-v6-pficon-orders:before, .pf-v6-pficon-optimize:before, .pf-v6-pficon-openstack:before, .pf-v6-pficon-openshift:before, .pf-v6-pficon-open-drawer-right:before, .pf-v6-pficon-on:before, .pf-v6-pficon-on-running:before, .pf-v6-pficon-ok:before, .pf-v6-pficon-off:before, .pf-v6-pficon-not-started:before, .pf-v6-pficon-new-process:before, .pf-v6-pficon-network:before, .pf-v6-pficon-namespaces:before, .pf-v6-pficon-multicluster:before, .pf-v6-pficon-monitoring:before, .pf-v6-pficon-module:before, .pf-v6-pficon-migration:before, .pf-v6-pficon-middleware:before, .pf-v6-pficon-messages:before, .pf-v6-pficon-memory:before, .pf-v6-pficon-maintenance:before, .pf-v6-pficon-locked:before, .pf-v6-pficon-key:before, .pf-v6-pficon-integration:before, .pf-v6-pficon-infrastructure:before, .pf-v6-pficon-info:before, .pf-v6-pficon-in-progress:before, .pf-v6-pficon-import:before, .pf-v6-pficon-home:before, .pf-v6-pficon-history:before, .pf-v6-pficon-help:before, .pf-v6-pficon-globe-route:before, .pf-v6-pficon-folder-open:before, .pf-v6-pficon-folder-close:before, .pf-v6-pficon-flavor:before, .pf-v6-pficon-filter:before, .pf-v6-pficon-export:before, .pf-v6-pficon-error-circle-o:before, .pf-v6-pficon-equalizer:before, .pf-v6-pficon-enterprise:before, .pf-v6-pficon-enhancement:before, .pf-v6-pficon-edit:before, .pf-v6-pficon-domain:before, .pf-v6-pficon-disconnected:before, .pf-v6-pficon-degraded:before, .pf-v6-pficon-data-source:before, .pf-v6-pficon-data-sink:before, .pf-v6-pficon-data-processor:before, .pf-v6-pficon-critical-risk:before, .pf-v6-pficon-cpu:before, .pf-v6-pficon-container-node:before, .pf-v6-pficon-connected:before, .pf-v6-pficon-cluster:before, .pf-v6-pficon-cloud-tenant:before, .pf-v6-pficon-cloud-security:before, .pf-v6-pficon-close:before, .pf-v6-pficon-chat:before, .pf-v6-pficon-catalog:before, .pf-v6-pficon-bundle:before, .pf-v6-pficon-builder-image:before, .pf-v6-pficon-build:before, .pf-v6-pficon-blueprint:before, .pf-v6-pficon-bell:before, .pf-v6-pficon-automation:before, .pf-v6-pficon-attention-bell:before, .pf-v6-pficon-asleep:before, .pf-v6-pficon-arrow:before, .pf-v6-pficon-applications:before, .pf-v6-pficon-ansible-tower:before, .pf-v6-pficon-add-circle-o:before {
   font-family: "pf-v6-pficon";
   -webkit-font-smoothing: antialiased;

--- a/docs/stylesheets/site.css
+++ b/docs/stylesheets/site.css
@@ -1,0 +1,299 @@
+/* OGO docs — PatternFly 6 dark theme */
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background-color: #1b1d21;
+  color: #e0e0e0;
+  font-family: "RedHatText", "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
+}
+
+/* ── Header ── */
+.site-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 52px;
+  background-color: #151515;
+  border-bottom: 1px solid #3c3f42;
+  display: flex;
+  align-items: center;
+  padding: 0 1.5rem;
+  z-index: 300;
+}
+
+.site-header__brand {
+  color: #73bcf7;
+  font-size: 1.25rem;
+  font-weight: 700;
+  text-decoration: none;
+  letter-spacing: 0.5px;
+}
+
+.site-header__brand:hover {
+  color: #2b9af3;
+}
+
+.site-header__tagline {
+  margin-left: 1rem;
+  color: #6a6e73;
+  font-size: 0.85rem;
+  font-weight: 400;
+}
+
+/* ── Layout ── */
+.site-layout {
+  display: flex;
+  margin-top: 52px;
+  height: calc(100vh - 52px);
+  overflow: hidden;
+}
+
+/* ── Sidebar ── */
+.site-sidebar {
+  width: 280px;
+  min-width: 280px;
+  height: 100%;
+  overflow-y: auto;
+  background-color: #1b1d21;
+  border-right: 1px solid #3c3f42;
+  padding: 1rem 0.75rem;
+}
+
+/* ── Main content ── */
+.site-main {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  justify-content: center;
+  padding: 2rem 3rem;
+}
+
+.site-content {
+  max-width: 900px;
+  width: 100%;
+}
+
+/* ── PF6 Nav (expandable) ── */
+.pf-v6-c-nav__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.pf-v6-c-nav__item {
+  margin: 0;
+}
+
+.pf-v6-c-nav__item > details {
+  border: none;
+}
+
+.pf-v6-c-nav__item > details > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  color: #e0e0e0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.6rem 0.75rem;
+  border-radius: 6px;
+  list-style: none;
+  user-select: none;
+  transition: background-color 0.15s;
+}
+
+.pf-v6-c-nav__item > details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.pf-v6-c-nav__toggle-icon {
+  font-size: 0.65rem;
+  color: #6a6e73;
+  transition: transform 0.15s;
+}
+
+details[open] > summary .pf-v6-c-nav__toggle-icon {
+  transform: rotate(90deg);
+}
+
+.pf-v6-c-nav__item > details > summary:hover {
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+/* Subnav */
+.pf-v6-c-nav__subnav {
+  list-style: none;
+  padding: 0.15rem 0 0.35rem 0;
+  margin: 0;
+}
+
+.pf-v6-c-nav__subnav .pf-v6-c-nav__link {
+  display: block;
+  color: #d2d2d2;
+  text-decoration: none;
+  padding: 0.3rem 0.75rem 0.3rem 1.75rem;
+  font-size: 0.85rem;
+  border-radius: 6px;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.pf-v6-c-nav__subnav .pf-v6-c-nav__link:hover {
+  color: #73bcf7;
+  background-color: rgba(115, 188, 247, 0.08);
+}
+
+.pf-v6-c-nav__subnav .pf-v6-c-nav__link.pf-m-current {
+  color: #73bcf7;
+  background-color: rgba(115, 188, 247, 0.12);
+  font-weight: 600;
+  border-left: 3px solid #0066cc;
+  padding-left: calc(1.75rem - 3px);
+}
+
+/* ── Content typography ── */
+.pf-v6-c-content h1 {
+  color: #e0e0e0;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid #3c3f42;
+  padding-bottom: 0.5rem;
+}
+
+.pf-v6-c-content h2 {
+  color: #e0e0e0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+}
+
+.pf-v6-c-content h3 {
+  color: #d2d2d2;
+  font-size: 1.15rem;
+  font-weight: 600;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.pf-v6-c-content p { margin-bottom: 1rem; }
+
+.pf-v6-c-content ul,
+.pf-v6-c-content ol {
+  margin-bottom: 1rem;
+  padding-left: 1.5rem;
+}
+
+.pf-v6-c-content li { margin-bottom: 0.35rem; }
+
+/* Links */
+.pf-v6-c-content a { color: #73bcf7; text-decoration: none; }
+.pf-v6-c-content a:hover { color: #2b9af3; text-decoration: underline; }
+
+/* Code */
+.pf-v6-c-content code {
+  background-color: #292e34;
+  color: #73bcf7;
+  padding: 0.15em 0.4em;
+  border-radius: 3px;
+  font-size: 0.875em;
+  font-family: "RedHatMono", "Fira Code", "Consolas", monospace;
+}
+
+.pf-v6-c-content pre {
+  background-color: #292e34 !important;
+  border: 1px solid #3c3f42;
+  border-radius: 6px;
+  padding: 1rem;
+  overflow-x: auto;
+  margin-bottom: 1rem;
+}
+
+.pf-v6-c-content pre code {
+  background: none;
+  color: #e0e0e0;
+  padding: 0;
+  font-size: 0.85em;
+}
+
+/* Copy button on code blocks */
+.copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background-color: #3c3f42;
+  color: #d2d2d2;
+  border: 1px solid #6a6e73;
+  border-radius: 4px;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+pre:hover .copy-btn { opacity: 1; }
+.copy-btn:hover { background-color: #4f5255; }
+
+/* Tables */
+.pf-v6-c-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+
+.pf-v6-c-content th {
+  background-color: #292e34;
+  color: #e0e0e0;
+  font-weight: 600;
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 2px solid #3c3f42;
+}
+
+.pf-v6-c-content td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid #3c3f42;
+}
+
+.pf-v6-c-content tr:hover {
+  background-color: rgba(115, 188, 247, 0.04);
+}
+
+/* Blockquotes */
+.pf-v6-c-content blockquote {
+  border-left: 3px solid #73bcf7;
+  padding: 0.5rem 1rem;
+  margin: 1rem 0;
+  color: #a0a0a0;
+  background-color: rgba(115, 188, 247, 0.05);
+  border-radius: 0 6px 6px 0;
+}
+
+.pf-v6-c-content hr {
+  border: none;
+  border-top: 1px solid #3c3f42;
+  margin: 2rem 0;
+}
+
+/* ── Responsive ── */
+@media (max-width: 768px) {
+  .site-sidebar {
+    position: static;
+    width: 100%;
+    height: auto;
+    border-right: none;
+    border-bottom: 1px solid #3c3f42;
+  }
+
+  .site-main {
+    margin-left: 0;
+    padding: 1.5rem 1rem;
+  }
+}

--- a/docs/stylesheets/site.css
+++ b/docs/stylesheets/site.css
@@ -5,7 +5,7 @@
 body {
   background-color: #1b1d21;
   color: #e0e0e0;
-  font-family: "RedHatText", "Helvetica Neue", Arial, sans-serif;
+  font-family: "Red Hat Text", "Helvetica Neue", Arial, sans-serif;
   line-height: 1.6;
 }
 
@@ -203,7 +203,7 @@ details[open] > summary .pf-v6-c-nav__toggle-icon {
   padding: 0.15em 0.4em;
   border-radius: 3px;
   font-size: 0.875em;
-  font-family: "RedHatMono", "Fira Code", "Consolas", monospace;
+  font-family: "Red Hat Mono", "Fira Code", "Consolas", monospace;
 }
 
 .pf-v6-c-content pre {

--- a/scripts/ogo-docs.py
+++ b/scripts/ogo-docs.py
@@ -2,14 +2,15 @@
 """OGO docs toolchain — build, serve, lint, search.
 
 Usage:
-    python3 includes/ogo-docs.py              # build site
-    python3 includes/ogo-docs.py serve [port] # build and serve locally
-    python3 includes/ogo-docs.py lint         # validate frontmatter, nav, links
-    python3 includes/ogo-docs.py search QUERY # search docs by tags and descriptions
-    python3 includes/ogo-docs.py init PATH    # scaffold a new doc with frontmatter
+    python3 scripts/ogo-docs.py              # build site
+    python3 scripts/ogo-docs.py serve [port] # build and serve locally
+    python3 scripts/ogo-docs.py lint         # validate frontmatter, nav, links
+    python3 scripts/ogo-docs.py search QUERY # search docs by tags and descriptions
+    python3 scripts/ogo-docs.py init PATH    # scaffold a new doc with frontmatter
 """
 
 import datetime
+import html as html_module
 import os
 import posixpath
 import re
@@ -22,7 +23,10 @@ import tomli
 DOCS_DIR = "docs"
 OUT_DIR = "public"
 CONFIG_FILE = "docs.toml"
-BASE_PATH = os.environ.get("DOCS_BASE_PATH", "/ogo")
+_raw_base = os.environ.get("DOCS_BASE_PATH", "/ogo")
+if not re.match(r'^(/[A-Za-z0-9._~:/?#@!$&()*+,;=\-]*)?$', _raw_base):
+    sys.exit(f"Invalid DOCS_BASE_PATH: {_raw_base!r}")
+BASE_PATH = _raw_base.rstrip("/")
 
 
 def parse_frontmatter(text):
@@ -124,6 +128,9 @@ TEMPLATE = """\
   <title>{tab_title}</title>
   <meta name="description" content="{description}">
   <link rel="icon" href="{base_path}/favicon.svg" type="image/svg+xml">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Red+Hat+Text:ital,wght@0,300..700;1,300..700&family=Red+Hat+Mono:wght@300..700&display=swap">
   <link rel="stylesheet" href="{base_path}/stylesheets/patternfly-base.css">
   <link rel="stylesheet" href="{base_path}/stylesheets/site.css">
 </head>
@@ -206,12 +213,12 @@ def build_page(md_rel, nav, md_converter):
     sidebar = build_sidebar(nav, md_rel)
 
     slug = md_to_slug(md_rel)
-    tab_title = "OGO" if not slug else f"{title} · OGO"
+    tab_title = "OGO" if not slug else f"{html_module.escape(title)} · OGO"
 
     html = TEMPLATE.format(
         base_path=BASE_PATH,
         tab_title=tab_title,
-        description=description,
+        description=html_module.escape(description),
         sidebar=sidebar,
         content=content,
         copy_script=COPY_SCRIPT,

--- a/scripts/ogo-docs.py
+++ b/scripts/ogo-docs.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""OGO docs toolchain — build, serve, lint, search.
+
+Usage:
+    python3 includes/ogo-docs.py              # build site
+    python3 includes/ogo-docs.py serve [port] # build and serve locally
+    python3 includes/ogo-docs.py lint         # validate frontmatter, nav, links
+    python3 includes/ogo-docs.py search QUERY # search docs by tags and descriptions
+    python3 includes/ogo-docs.py init PATH    # scaffold a new doc with frontmatter
+"""
+
+import datetime
+import os
+import posixpath
+import re
+import shutil
+import sys
+
+import markdown
+import tomli
+
+DOCS_DIR = "docs"
+OUT_DIR = "public"
+CONFIG_FILE = "docs.toml"
+BASE_PATH = os.environ.get("DOCS_BASE_PATH", "/ogo")
+
+
+def parse_frontmatter(text):
+    if text.startswith("---"):
+        end = text.find("---", 3)
+        if end != -1:
+            fm_text = text[3:end].strip()
+            body = text[end + 3:].strip()
+            meta = {}
+            for line in fm_text.split("\n"):
+                if ":" in line:
+                    key, val = line.split(":", 1)
+                    meta[key.strip()] = val.strip().strip('"').strip("'")
+            return meta, body
+    return {}, text
+
+
+def extract_title(meta, body):
+    if "title" in meta:
+        return meta["title"]
+    match = re.match(r"^#\s+(.+)", body, re.MULTILINE)
+    if match:
+        return match.group(1)
+    return "OGO"
+
+
+def md_to_slug(md_rel):
+    """Convert a docs-relative .md path to its URL slug (no leading/trailing slash).
+
+    Examples:
+        index.md            -> ""
+        concepts/index.md   -> "concepts"
+        concepts/gateway.md -> "concepts/gateway"
+    """
+    parts = md_rel.replace("\\", "/").split("/")
+    if parts[-1] == "index.md":
+        parts = parts[:-1]
+    else:
+        parts[-1] = parts[-1][:-3]  # strip .md
+    return "/".join(parts)
+
+
+def slug_to_href(slug):
+    """Convert a slug to its full site href."""
+    if not slug:
+        return f"{BASE_PATH}/"
+    return f"{BASE_PATH}/{slug}/"
+
+
+def load_nav(config_path):
+    with open(config_path, "rb") as f:
+        config = tomli.load(f)
+    nav_raw = config.get("project", {}).get("nav", [])
+    nav = []
+    for section in nav_raw:
+        for section_title, items in section.items():
+            entries = []
+            for item in items:
+                for label, path in item.items():
+                    slug = md_to_slug(path)
+                    entries.append({"label": label, "path": slug, "file": path})
+            nav.append({"title": section_title, "entries": entries})
+    return nav
+
+
+def build_sidebar(nav, current_file):
+    html = '<nav class="pf-v6-c-nav" aria-label="Documentation">\n'
+    html += '  <ul class="pf-v6-c-nav__list">\n'
+    for section in nav:
+        has_active = any(e["file"] == current_file for e in section["entries"])
+        expanded = " pf-m-expanded" if has_active else ""
+        open_attr = " open" if has_active else ""
+        html += f'    <li class="pf-v6-c-nav__item pf-m-expandable{expanded}">\n'
+        html += f'      <details{open_attr}>\n'
+        html += f'        <summary class="pf-v6-c-nav__link">{section["title"]}\n'
+        html += f'          <span class="pf-v6-c-nav__toggle-icon">▸</span>\n'
+        html += f'        </summary>\n'
+        html += f'        <ul class="pf-v6-c-nav__subnav">\n'
+        for entry in section["entries"]:
+            href = slug_to_href(entry["path"])
+            active = " pf-m-current" if entry["file"] == current_file else ""
+            html += f'          <li class="pf-v6-c-nav__item">\n'
+            html += f'            <a class="pf-v6-c-nav__link{active}" href="{href}">{entry["label"]}</a>\n'
+            html += f'          </li>\n'
+        html += f'        </ul>\n'
+        html += f'      </details>\n'
+        html += f'    </li>\n'
+    html += '  </ul>\n'
+    html += '</nav>\n'
+    return html
+
+
+TEMPLATE = """\
+<!DOCTYPE html>
+<html lang="en" class="pf-v6-theme-dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{tab_title}</title>
+  <meta name="description" content="{description}">
+  <link rel="icon" href="{base_path}/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="{base_path}/stylesheets/patternfly-base.css">
+  <link rel="stylesheet" href="{base_path}/stylesheets/site.css">
+</head>
+<body>
+  <header class="site-header">
+    <a href="{base_path}/" class="site-header__brand">OGO</a>
+    <span class="site-header__tagline">OpenShell Gateway Operator</span>
+  </header>
+
+  <div class="site-layout">
+    <aside class="site-sidebar">
+      {sidebar}
+    </aside>
+
+    <main class="site-main">
+      <div class="site-content pf-v6-c-content">
+        {content}
+      </div>
+    </main>
+  </div>
+{copy_script}
+</body>
+</html>
+"""
+
+
+COPY_SCRIPT = """<script>
+document.querySelectorAll('pre').forEach(function(pre) {
+  var btn = document.createElement('button');
+  btn.className = 'copy-btn';
+  btn.textContent = 'Copy';
+  btn.addEventListener('click', function() {
+    var code = pre.querySelector('code');
+    var text = (code ? code.textContent : pre.textContent).trimEnd();
+    navigator.clipboard.writeText(text).then(function() {
+      btn.textContent = 'Copied!';
+      setTimeout(function() { btn.textContent = 'Copy'; }, 2000);
+    }).catch(function() {
+      btn.textContent = 'Failed';
+      setTimeout(function() { btn.textContent = 'Copy'; }, 2000);
+    });
+  });
+  pre.style.position = 'relative';
+  pre.appendChild(btn);
+});
+</script>"""
+
+
+def rewrite_links(html, md_rel):
+    """Rewrite .md hrefs to absolute site paths."""
+    current_dir = posixpath.dirname(md_rel.replace("\\", "/"))
+
+    def replace(m):
+        href = m.group(1)
+        frag = m.group(2) or ""
+        # Resolve the href relative to the current file's directory in docs/
+        if current_dir:
+            resolved = posixpath.normpath(posixpath.join(current_dir, href))
+        else:
+            resolved = posixpath.normpath(href)
+        resolved = resolved.lstrip("/")
+        resolved_md = resolved + ".md"
+        slug = md_to_slug(resolved_md)
+        return f'href="{slug_to_href(slug)}{frag}"'
+
+    return re.sub(r'href="([^"#:]+)\.md(#[^"]*)?"', replace, html)
+
+
+def build_page(md_rel, nav, md_converter):
+    """Build a single page. md_rel is path relative to DOCS_DIR."""
+    with open(os.path.join(DOCS_DIR, md_rel)) as f:
+        raw = f.read()
+
+    meta, body = parse_frontmatter(raw)
+    title = extract_title(meta, body)
+    description = meta.get("description", "OpenShell Gateway Operator documentation")
+    content = md_converter.convert(body)
+    md_converter.reset()
+    content = rewrite_links(content, md_rel)
+    sidebar = build_sidebar(nav, md_rel)
+
+    slug = md_to_slug(md_rel)
+    tab_title = "OGO" if not slug else f"{title} · OGO"
+
+    html = TEMPLATE.format(
+        base_path=BASE_PATH,
+        tab_title=tab_title,
+        description=description,
+        sidebar=sidebar,
+        content=content,
+        copy_script=COPY_SCRIPT,
+    )
+
+    if not slug:
+        out_path = os.path.join(OUT_DIR, "index.html")
+    else:
+        out_dir = os.path.join(OUT_DIR, slug)
+        os.makedirs(out_dir, exist_ok=True)
+        out_path = os.path.join(out_dir, "index.html")
+
+    with open(out_path, "w") as f:
+        f.write(html)
+
+    display = "/" if not slug else f"/{slug}/"
+    print(f"  + {display}")
+
+
+def collect_md_files():
+    """Walk docs/ and return sorted list of .md paths relative to DOCS_DIR."""
+    md_files = []
+    for root, dirs, files in os.walk(DOCS_DIR):
+        dirs.sort()
+        for fname in sorted(files):
+            if fname.endswith(".md"):
+                rel = os.path.relpath(os.path.join(root, fname), DOCS_DIR)
+                md_files.append(rel.replace("\\", "/"))
+    return md_files
+
+
+def main():
+    os.makedirs(OUT_DIR, exist_ok=True)
+
+    nav = load_nav(CONFIG_FILE)
+
+    md = markdown.Markdown(
+        extensions=["tables", "fenced_code", "codehilite", "toc"],
+        extension_configs={
+            "codehilite": {"css_class": "highlight", "guess_lang": False},
+        },
+    )
+
+    print("Build started")
+
+    md_files = collect_md_files()
+    for md_rel in md_files:
+        build_page(md_rel, nav, md)
+
+    favicon_src = os.path.join(DOCS_DIR, "favicon.svg")
+    if os.path.exists(favicon_src):
+        shutil.copy2(favicon_src, os.path.join(OUT_DIR, "favicon.svg"))
+
+    styles_src = os.path.join(DOCS_DIR, "stylesheets")
+    styles_dst = os.path.join(OUT_DIR, "stylesheets")
+    if os.path.exists(styles_src):
+        if os.path.exists(styles_dst):
+            shutil.rmtree(styles_dst)
+        shutil.copytree(styles_src, styles_dst)
+
+    print(f"Build finished ({len(md_files)} pages)")
+
+
+def serve(port=8000):
+    import http.server
+    import functools
+
+    global BASE_PATH
+    BASE_PATH = ""
+    main()
+
+    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=OUT_DIR)
+    server = http.server.HTTPServer(("", port), handler)
+    print(f"\nServing at http://localhost:{port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped")
+
+
+VALID_TYPES = {"Guide", "Reference", "CRD Reference", "Concept", "Example", "Index"}
+SKIP_FRONTMATTER = set()
+
+
+def lint():
+    errors = []
+    warnings = []
+
+    nav = load_nav(CONFIG_FILE)
+    nav_files = set()
+    for section in nav:
+        for entry in section["entries"]:
+            nav_files.add(entry["file"])
+
+    md_files = collect_md_files()
+
+    for md_rel in md_files:
+        if md_rel in SKIP_FRONTMATTER:
+            continue
+
+        with open(os.path.join(DOCS_DIR, md_rel)) as f:
+            raw = f.read()
+
+        meta, body = parse_frontmatter(raw)
+
+        if not meta:
+            errors.append(f"{md_rel}: missing frontmatter")
+            continue
+
+        if not meta.get("type"):
+            errors.append(f"{md_rel}: missing required field 'type'")
+        elif meta["type"] not in VALID_TYPES:
+            warnings.append(f"{md_rel}: type '{meta['type']}' not in {VALID_TYPES}")
+
+        for field in ("title", "description"):
+            if not meta.get(field):
+                errors.append(f"{md_rel}: missing field '{field}'")
+
+        if md_rel not in nav_files:
+            warnings.append(f"{md_rel}: not in docs.toml nav")
+
+        current_dir = posixpath.dirname(md_rel)
+        for match in re.finditer(r'\[([^\]]+)\]\(([^)#]+)\.md(?:#[^)]*)?\)', body):
+            href = match.group(2)
+            if href.startswith("http"):
+                continue
+            if current_dir:
+                resolved = posixpath.normpath(posixpath.join(current_dir, href))
+            else:
+                resolved = posixpath.normpath(href)
+            resolved = resolved.lstrip("/") + ".md"
+            if not os.path.exists(os.path.join(DOCS_DIR, resolved)):
+                errors.append(f"{md_rel}: broken link to '{resolved}'")
+
+    for nav_file in nav_files:
+        if not os.path.exists(os.path.join(DOCS_DIR, nav_file)):
+            errors.append(f"nav: '{nav_file}' in docs.toml but file missing")
+
+    if warnings:
+        for w in warnings:
+            print(f"  WARN  {w}")
+    if errors:
+        for e in errors:
+            print(f"  FAIL  {e}")
+        print(f"\nLint failed: {len(errors)} error(s), {len(warnings)} warning(s)")
+        sys.exit(1)
+    else:
+        print(f"Lint passed: {len(md_files)} docs checked, {len(warnings)} warning(s)")
+
+
+def search(query):
+    query_lower = query.lower()
+    results = []
+
+    for md_rel in collect_md_files():
+        with open(os.path.join(DOCS_DIR, md_rel)) as f:
+            raw = f.read()
+
+        meta, _ = parse_frontmatter(raw)
+        if not meta:
+            continue
+
+        title = meta.get("title", "")
+        description = meta.get("description", "")
+        tags = meta.get("tags", "")
+        score = 0
+
+        if query_lower in title.lower():
+            score += 3
+        if query_lower in description.lower():
+            score += 2
+        if query_lower in tags.lower():
+            score += 1
+
+        if score > 0:
+            results.append((score, md_rel, meta))
+
+    results.sort(key=lambda x: -x[0])
+
+    if not results:
+        print(f"No docs matching '{query}'")
+        return
+
+    print(f"Found {len(results)} doc(s) matching '{query}':\n")
+    for score, md_rel, meta in results:
+        doc_type = meta.get("type", "?")
+        title = meta.get("title", md_rel)
+        desc = meta.get("description", "")
+        tags = meta.get("tags", "")
+        print(f"  [{doc_type}] {title}")
+        print(f"    {desc}")
+        print(f"    tags: {tags}")
+        print(f"    path: docs/{md_rel}")
+        print()
+
+
+def init(path):
+    if os.path.exists(path):
+        print(f"Error: {path} already exists")
+        sys.exit(1)
+
+    if not path.startswith("docs/"):
+        print(f"Warning: {path} is outside docs/ — are you sure?")
+
+    name = os.path.basename(path).replace(".md", "").replace("-", " ").title()
+
+    content = f"""---
+type: Guide
+title: {name}
+description: TODO
+tags: []
+---
+
+# {name}
+
+TODO: Write documentation.
+"""
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w") as f:
+        f.write(content)
+    print(f"Created {path} — update frontmatter and add to docs.toml nav")
+
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "build"
+
+    if cmd in ("serve", "--serve"):
+        port = 8000
+        for arg in sys.argv[2:]:
+            if arg.isdigit():
+                port = int(arg)
+        serve(port)
+    elif cmd == "lint":
+        lint()
+    elif cmd == "search":
+        if len(sys.argv) < 3:
+            print("Usage: ogo-docs.py search QUERY")
+            sys.exit(1)
+        search(" ".join(sys.argv[2:]))
+    elif cmd == "init":
+        if len(sys.argv) < 3:
+            print("Usage: ogo-docs.py init docs/my-page.md")
+            sys.exit(1)
+        init(sys.argv[2])
+    elif cmd == "build":
+        main()
+    else:
+        print(f"Unknown command: {cmd}")
+        print("Commands: build, serve, lint, search, init")
+        sys.exit(1)


### PR DESCRIPTION
## Summary

- Adds a PatternFly 6 dark-themed static documentation site built from the existing `docs/` content
- Introduces `scripts/ogo-docs.py` — a lightweight docs toolchain (build, serve, lint, search, init) that handles OGO's subdirectory doc structure
- GitHub Actions workflow deploys to GitHub Pages automatically on every push to `main` that touches docs content or the toolchain

## What's included

| File | Purpose |
|------|---------|
| `scripts/ogo-docs.py` | Docs toolchain — Markdown → PatternFly HTML with sidebar nav, copy buttons, and relative link rewriting |
| `docs.toml` | Navigation config — five sections covering all 20 docs pages |
| `docs/stylesheets/` | PatternFly 6 dark theme CSS |
| `docs/favicon.svg` | Gateway arch icon |
| `.github/workflows/pages.yml` | Build and deploy to GitHub Pages; Actions pinned to commit SHAs |
| `Makefile` | `make docs`, `make docs-serve`, `make docs-lint` targets |

## Test plan

- [ ] Enable GitHub Pages in repo Settings → Pages → Source → "GitHub Actions"
- [ ] Verify the workflow triggers on merge and deploys successfully
- [ ] Confirm site is live at https://aknochow.github.io/ogo/
- [ ] Spot-check a few pages for correct nav highlighting and link routing
- [ ] Run `make docs-lint` locally — should pass with 0 warnings

Generated with Claude Code