### PR TITLE
docs: add badge bar to docs site header and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ description: OpenShell Gateway Operator - deploy and manage OpenShell on OpenShi
 
 # OGO - OpenShell Gateway Operator
 
+[![Docs](https://img.shields.io/badge/docs-online-blue?logo=readthedocs&logoColor=white)](https://aknochow.github.io/ogo/) [![CI](https://github.com/aknochow/ogo/actions/workflows/ci.yml/badge.svg)](https://github.com/aknochow/ogo/actions/workflows/ci.yml) [![License](https://img.shields.io/badge/license-Apache%202.0-green)](https://github.com/aknochow/ogo/blob/main/LICENSE) [![Go](https://img.shields.io/badge/go-1.24-00ADD8?logo=go&logoColor=white)](https://go.dev/doc/go1.24)
+
 > **Alpha software.** OGO and [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell)
 > are both in active development. APIs, CRDs, and behavior may change without
 > notice. This project is not intended for production use.

--- a/docs.toml
+++ b/docs.toml
@@ -7,6 +7,28 @@ site_dir = "public"
 [project.theme]
 name = "patternfly-6-dark"
 
+# Badges — rendered in the docs site header and available as README markdown
+# via: python3 scripts/ogo-docs.py badges
+[[project.badges]]
+label = "Docs"
+url   = "https://aknochow.github.io/ogo/"
+img   = "https://img.shields.io/badge/docs-online-blue?logo=readthedocs&logoColor=white"
+
+[[project.badges]]
+label = "CI"
+url   = "https://github.com/aknochow/ogo/actions/workflows/ci.yml"
+img   = "https://github.com/aknochow/ogo/actions/workflows/ci.yml/badge.svg"
+
+[[project.badges]]
+label = "License"
+url   = "https://github.com/aknochow/ogo/blob/main/LICENSE"
+img   = "https://img.shields.io/badge/license-Apache%202.0-green"
+
+[[project.badges]]
+label = "Go"
+url   = "https://go.dev/doc/go1.24"
+img   = "https://img.shields.io/badge/go-1.24-00ADD8?logo=go&logoColor=white"
+
 # Navigation
 [[project.nav]]
 "Overview" = [

--- a/docs/stylesheets/site.css
+++ b/docs/stylesheets/site.css
@@ -43,6 +43,18 @@ body {
   font-weight: 400;
 }
 
+.site-header__badges {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.site-header__badge img {
+  display: block;
+  height: 20px;
+}
+
 /* ── Layout ── */
 .site-layout {
   display: flex;

--- a/scripts/ogo-docs.py
+++ b/scripts/ogo-docs.py
@@ -94,23 +94,27 @@ def load_nav(config_path):
 
 
 def load_badges(config_path):
+    """Load badge configuration from docs.toml."""
     with open(config_path, "rb") as f:
         config = tomli.load(f)
     return config.get("project", {}).get("badges", [])
 
 
 def build_badge_html(badges):
+    """Generate HTML for the badge bar in the site header. Returns empty string if no badges."""
     if not badges:
         return ""
     html = '<span class="site-header__badges">'
     for b in badges:
-        label = html_module.escape(b.get("label", ""))
-        img = html_module.escape(b.get("img", ""))
-        url = html_module.escape(b.get("url", ""))
+        label = b.get("label", "")
+        img = b.get("img", "")
+        url = b.get("url", "")
+        if not (label and img and url):
+            continue
         html += (
-            f'<a href="{url}" class="site-header__badge" '
-            f'target="_blank" rel="noopener noreferrer" aria-label="{label}">'
-            f'<img src="{img}" alt="{label}"></a>'
+            f'<a href="{html_module.escape(url)}" class="site-header__badge" '
+            f'target="_blank" rel="noopener noreferrer" aria-label="{html_module.escape(label)}">'
+            f'<img src="{html_module.escape(img)}" alt="{html_module.escape(label)}"></a>'
         )
     html += "</span>"
     return html
@@ -470,7 +474,7 @@ TODO: Write documentation.
 
 
 def badges_markdown():
-    """Print badge markdown for pasting into README."""
+    """Print badge markdown for README — one line, space-separated, sourced from docs.toml."""
     badge_list = load_badges(CONFIG_FILE)
     if not badge_list:
         print("No badges configured in docs.toml")
@@ -480,6 +484,12 @@ def badges_markdown():
         label = b.get("label", "")
         img = b.get("img", "")
         url = b.get("url", "")
+        if not (label and img and url):
+            print(f"Warning: skipping incomplete badge: {b}", file=sys.stderr)
+            continue
+        label = label.replace("[", "\\[").replace("]", "\\]")
+        img = img.replace("(", "\\(").replace(")", "\\)")
+        url = url.replace("(", "\\(").replace(")", "\\)")
         parts.append(f"[![{label}]({img})]({url})")
     print(" ".join(parts))
 

--- a/scripts/ogo-docs.py
+++ b/scripts/ogo-docs.py
@@ -7,6 +7,7 @@ Usage:
     python3 scripts/ogo-docs.py lint         # validate frontmatter, nav, links
     python3 scripts/ogo-docs.py search QUERY # search docs by tags and descriptions
     python3 scripts/ogo-docs.py init PATH    # scaffold a new doc with frontmatter
+    python3 scripts/ogo-docs.py badges       # print badge markdown for README
 """
 
 import datetime
@@ -92,6 +93,29 @@ def load_nav(config_path):
     return nav
 
 
+def load_badges(config_path):
+    with open(config_path, "rb") as f:
+        config = tomli.load(f)
+    return config.get("project", {}).get("badges", [])
+
+
+def build_badge_html(badges):
+    if not badges:
+        return ""
+    html = '<span class="site-header__badges">'
+    for b in badges:
+        label = html_module.escape(b.get("label", ""))
+        img = html_module.escape(b.get("img", ""))
+        url = html_module.escape(b.get("url", ""))
+        html += (
+            f'<a href="{url}" class="site-header__badge" '
+            f'target="_blank" rel="noopener noreferrer" aria-label="{label}">'
+            f'<img src="{img}" alt="{label}"></a>'
+        )
+    html += "</span>"
+    return html
+
+
 def build_sidebar(nav, current_file):
     html = '<nav class="pf-v6-c-nav" aria-label="Documentation">\n'
     html += '  <ul class="pf-v6-c-nav__list">\n'
@@ -138,6 +162,7 @@ TEMPLATE = """\
   <header class="site-header">
     <a href="{base_path}/" class="site-header__brand">OGO</a>
     <span class="site-header__tagline">OpenShell Gateway Operator</span>
+    {badges}
   </header>
 
   <div class="site-layout">
@@ -199,7 +224,7 @@ def rewrite_links(html, md_rel):
     return re.sub(r'href="([^"#:]+)\.md(#[^"]*)?"', replace, html)
 
 
-def build_page(md_rel, nav, md_converter):
+def build_page(md_rel, nav, badges_html, md_converter):
     """Build a single page. md_rel is path relative to DOCS_DIR."""
     with open(os.path.join(DOCS_DIR, md_rel)) as f:
         raw = f.read()
@@ -220,6 +245,7 @@ def build_page(md_rel, nav, md_converter):
         tab_title=tab_title,
         description=html_module.escape(description),
         sidebar=sidebar,
+        badges=badges_html,
         content=content,
         copy_script=COPY_SCRIPT,
     )
@@ -254,6 +280,7 @@ def main():
     os.makedirs(OUT_DIR, exist_ok=True)
 
     nav = load_nav(CONFIG_FILE)
+    badges_html = build_badge_html(load_badges(CONFIG_FILE))
 
     md = markdown.Markdown(
         extensions=["tables", "fenced_code", "codehilite", "toc"],
@@ -266,7 +293,7 @@ def main():
 
     md_files = collect_md_files()
     for md_rel in md_files:
-        build_page(md_rel, nav, md)
+        build_page(md_rel, nav, badges_html, md)
 
     favicon_src = os.path.join(DOCS_DIR, "favicon.svg")
     if os.path.exists(favicon_src):
@@ -442,6 +469,21 @@ TODO: Write documentation.
     print(f"Created {path} — update frontmatter and add to docs.toml nav")
 
 
+def badges_markdown():
+    """Print badge markdown for pasting into README."""
+    badge_list = load_badges(CONFIG_FILE)
+    if not badge_list:
+        print("No badges configured in docs.toml")
+        return
+    parts = []
+    for b in badge_list:
+        label = b.get("label", "")
+        img = b.get("img", "")
+        url = b.get("url", "")
+        parts.append(f"[![{label}]({img})]({url})")
+    print(" ".join(parts))
+
+
 if __name__ == "__main__":
     cmd = sys.argv[1] if len(sys.argv) > 1 else "build"
 
@@ -453,6 +495,8 @@ if __name__ == "__main__":
         serve(port)
     elif cmd == "lint":
         lint()
+    elif cmd == "badges":
+        badges_markdown()
     elif cmd == "search":
         if len(sys.argv) < 3:
             print("Usage: ogo-docs.py search QUERY")


### PR DESCRIPTION
## Summary

- Adds a badge bar to the docs site header (right-aligned, defined in `docs.toml`)
- Adds the same badges to `README.md` (single source of truth in `docs.toml`)
- Adds `python3 scripts/ogo-docs.py badges` subcommand to regenerate README markdown whenever badges change

## Badges

| Badge | Links to |
|-------|---------|
| Docs | https://aknochow.github.io/ogo/ |
| CI | Build workflow status |
| License | Apache 2.0 |
| Go | 1.24 |

## How to update badges

Edit `[[project.badges]]` entries in `docs.toml`, then run `python3 scripts/ogo-docs.py badges` to regenerate the README line.

Generated with Claude Code