### PR TITLE
docs: rewrite quickstart with deployment paths and teardown

### DIFF
--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -7,8 +7,7 @@ tags: [getting-started]
 
 # Quickstart
 
-Deploy OGO on an OpenShift cluster with PostgreSQL, OpenShift SSO, and the
-OpenShell gateway.
+Deploy OGO on an OpenShift cluster with PostgreSQL and the OpenShell gateway.
 
 ## Prerequisites
 
@@ -65,7 +64,8 @@ EOF
 ### 2. Install Envoy Gateway
 
 On OpenShift 4.22+, Gateway API CRDs are managed by the Ingress Operator.
-Use `--skip-crds` to avoid conflicts:
+Use `--skip-crds` to avoid conflicts. On 4.16-4.21, omit `--skip-crds`
+to let the Helm chart install the CRDs:
 
 ```bash
 helm install eg oci://docker.io/envoyproxy/gateway-helm \
@@ -144,7 +144,6 @@ spec:
   tls:
     enabled: false
     certManager:
-      enabled: true
       issuerName: letsencrypt
       issuerKind: ClusterIssuer
   route:
@@ -238,6 +237,8 @@ spec:
     enabled: true
   route:
     hostname: openshell.apps.your-cluster.example.com
+    gatewayAPI:
+      enabled: false
   auth:
     openshift:
       enabled: false
@@ -305,6 +306,7 @@ oc delete gatewayclass eg
 
 ## Next steps
 
+- [DevSpaces](devspaces.md) - create sandboxes from DevSpaces workspaces
 - [Envoy Gateway](envoy-gateway.md) - gRPC ingress architecture details
 - [OpenShift SSO](openshift-sso.md) - authentication and user groups
 - [Provider](../concepts/provider.md) - inject API keys into sandboxes

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -7,65 +7,305 @@ tags: [getting-started]
 
 # Quickstart
 
-Deploy OGO on an OpenShift cluster with PostgreSQL, auth-bridge, and the
+Deploy OGO on an OpenShift cluster with PostgreSQL, OpenShift SSO, and the
 OpenShell gateway.
 
 ## Prerequisites
 
 - OpenShift 4.16+ cluster with `oc` CLI configured
-- cert-manager operator installed (for TLS certificates)
 - `openshell` CLI installed (`brew install nvidia/tap/openshell`)
 
-## 1. Install CRDs
+## Choose a deployment path
+
+| Path | Auth | TLS | Prerequisites |
+|------|------|-----|---------------|
+| **[With Envoy Gateway](#with-envoy-gateway)** | OpenShift SSO (browser login) | Let's Encrypt via cert-manager | cert-manager, Envoy Gateway, Helm |
+| **[Without Envoy Gateway](#without-envoy-gateway)** | mTLS (client certificates) | Self-signed (operator-managed) | None |
+
+Envoy Gateway is required for OpenShift SSO because the OpenShell gateway
+needs the OIDC issuer on the same hostname as the gateway endpoint. Without
+Envoy, use mTLS client certificates or `port-forward` for access.
+
+---
+
+## With Envoy Gateway
+
+This path gives you browser-based SSO login and Let's Encrypt TLS.
+
+### 1. Install cert-manager
+
+If not already installed:
 
 ```bash
-KUBECONFIG=~/.kube/your-cluster make install
+oc apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml
+oc wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
 ```
 
-## 2. Deploy the operator
+Create a ClusterIssuer for Let's Encrypt (requires DNS challenge for wildcard
+certs, or HTTP challenge for single-host certs):
 
 ```bash
-TAG="0.1.0-$(date +%Y%m%d%H%M%S)"
-podman build -f Containerfile -t quay.io/yourorg/ogo:$TAG .
-podman push quay.io/yourorg/ogo:$TAG
-KUBECONFIG=~/.kube/your-cluster make deploy IMG=quay.io/yourorg/ogo:$TAG
+cat <<EOF | oc apply -f -
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com
+    privateKeySecretRef:
+      name: letsencrypt-key
+    solvers:
+    - http01:
+        ingress: {}
+EOF
 ```
 
-## 3. Set up PostgreSQL
+### 2. Install Envoy Gateway
+
+On OpenShift 4.22+, Gateway API CRDs are managed by the Ingress Operator.
+Use `--skip-crds` to avoid conflicts:
+
+```bash
+helm install eg oci://docker.io/envoyproxy/gateway-helm \
+  --version v1.3.2 -n envoy-gateway-system --create-namespace --skip-crds
+```
+
+Grant the required SCCs and create the GatewayClass:
+
+```bash
+oc adm policy add-scc-to-user privileged -z envoy-gateway -n envoy-gateway-system
+
+cat <<EOF | oc apply -f -
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: eg
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+EOF
+```
+
+Verify Envoy Gateway is ready:
+
+```bash
+oc get gatewayclasses
+# Should show: eg   ACCEPTED   True
+```
+
+### 3. Deploy the operator
+
+```bash
+make deploy IMG=quay.io/aknochow/ogo:main
+oc wait --for=condition=Available deployment/ogo-controller-manager -n ogo --timeout=120s
+```
+
+### 4. Set up PostgreSQL
 
 ```bash
 oc create deployment ogo-pg -n ogo --image=docker.io/library/postgres:16
 oc set env deployment/ogo-pg -n ogo \
   POSTGRES_USER=openshell POSTGRES_PASSWORD=openshell POSTGRES_DB=openshell
 oc expose deployment/ogo-pg -n ogo --port=5432
+oc adm policy add-scc-to-user anyuid -z default -n ogo
 oc create secret generic ogo-pg -n ogo \
   --from-literal=uri='postgresql://openshell:openshell@ogo-pg.ogo.svc:5432/openshell'
 ```
 
-On OpenShift, grant the `anyuid` SCC:
+### 5. Create user groups
 
 ```bash
-oc adm policy add-scc-to-user anyuid -z default -n ogo
+oc adm groups new openshell-users
+oc adm groups add-users openshell-users your-username
+oc adm groups new openshell-admins
+oc adm groups add-users openshell-admins your-username
 ```
 
-## 4. Create the Gateway
+### 6. Create the Gateway
 
-```bash
-oc apply -f config/samples/ogo_v1alpha1_openshellgateway.yaml
+Replace `your-cluster.example.com` with your cluster's apps domain:
+
+```yaml
+# ogo-gateway.yaml
+apiVersion: gateway.ogo.aknochow.io/v1alpha1
+kind: OpenShellGateway
+metadata:
+  name: openshell
+spec:
+  namespace: ogo
+  replicas: 1
+  database:
+    secretName: ogo-pg
+  sandbox:
+    defaultImage: ghcr.io/nvidia/openshell-community/sandboxes/base:latest
+    workspaceStorageSize: "2Gi"
+    appArmorProfile: "Unconfined"
+  tls:
+    enabled: false
+    certManager:
+      enabled: true
+      issuerName: letsencrypt
+      issuerKind: ClusterIssuer
+  route:
+    hostname: openshell.apps.your-cluster.example.com
+    gatewayAPI:
+      gatewayClassName: eg
+  auth:
+    openshift:
+      userGroup: openshell-users
+      adminGroup: openshell-admins
+      tokenTTL: "8h"
+  logLevel: info
+  networkPolicy:
+    enabled: true
 ```
 
-Edit the sample to set your `route.hostname` before applying.
+```bash
+oc apply -f ogo-gateway.yaml
+```
 
-## 5. Connect
+Wait for the Envoy proxy to start. When Gateway API detects Envoy, it
+creates a dynamic ServiceAccount for the proxy. Grant it the privileged SCC:
 
 ```bash
-openshell gateway add https://openshell.apps.your-cluster.example.com my-cluster
-openshell gateway login my-cluster
+# Find the Envoy proxy SA (created after the Gateway resource is reconciled)
+oc get sa -n envoy-gateway-system | grep envoy-ogo
+# Grant it privileged SCC
+oc adm policy add-scc-to-user privileged -z <envoy-sa-name> -n envoy-gateway-system
+```
+
+Verify the gateway is running:
+
+```bash
+oc get openshellgateway
+# Should show: openshell   Running   https://openshell.apps.your-cluster.example.com:443
+```
+
+### 7. Connect
+
+```bash
+openshell gateway add https://openshell.apps.your-cluster.example.com \
+  --name my-cluster \
+  --oidc-issuer https://openshell-auth.apps.your-cluster.example.com
+
 openshell sandbox create --gateway my-cluster
+```
+
+---
+
+## Without Envoy Gateway
+
+This path uses self-signed TLS with a passthrough OpenShift Route. No
+external prerequisites. Authentication uses mTLS client certificates.
+
+### 1. Deploy the operator
+
+```bash
+make deploy IMG=quay.io/aknochow/ogo:main
+oc wait --for=condition=Available deployment/ogo-controller-manager -n ogo --timeout=120s
+```
+
+### 2. Set up PostgreSQL
+
+```bash
+oc create deployment ogo-pg -n ogo --image=docker.io/library/postgres:16
+oc set env deployment/ogo-pg -n ogo \
+  POSTGRES_USER=openshell POSTGRES_PASSWORD=openshell POSTGRES_DB=openshell
+oc expose deployment/ogo-pg -n ogo --port=5432
+oc adm policy add-scc-to-user anyuid -z default -n ogo
+oc create secret generic ogo-pg -n ogo \
+  --from-literal=uri='postgresql://openshell:openshell@ogo-pg.ogo.svc:5432/openshell'
+```
+
+### 3. Create the Gateway
+
+```yaml
+# ogo-gateway.yaml
+apiVersion: gateway.ogo.aknochow.io/v1alpha1
+kind: OpenShellGateway
+metadata:
+  name: openshell
+spec:
+  namespace: ogo
+  replicas: 1
+  database:
+    secretName: ogo-pg
+  sandbox:
+    defaultImage: ghcr.io/nvidia/openshell-community/sandboxes/base:latest
+    workspaceStorageSize: "2Gi"
+  tls:
+    enabled: true
+  route:
+    hostname: openshell.apps.your-cluster.example.com
+  auth:
+    openshift:
+      enabled: false
+      userGroup: openshell-users
+  logLevel: info
+  networkPolicy:
+    enabled: false
+```
+
+```bash
+oc apply -f ogo-gateway.yaml
+```
+
+Verify:
+
+```bash
+oc get openshellgateway
+oc get route -n ogo
+# Should show a passthrough Route
+```
+
+### 4. Connect
+
+```bash
+openshell gateway add https://openshell.apps.your-cluster.example.com \
+  --name my-cluster --gateway-insecure
+
+openshell sandbox create --gateway my-cluster
+```
+
+The `--gateway-insecure` flag is needed because the self-signed TLS
+certificate is not trusted by the CLI. For production, use the Envoy
+Gateway path with Let's Encrypt certificates.
+
+---
+
+## Teardown
+
+To completely remove OGO from the cluster:
+
+```bash
+# 1. Delete the gateway CR (triggers finalizer cleanup of all resources)
+oc delete openshellgateway openshell
+
+# 2. Delete the database
+oc delete deployment ogo-pg -n ogo
+oc delete svc ogo-pg -n ogo
+oc delete secret ogo-pg -n ogo
+
+# 3. Undeploy the operator, CRDs, and RBAC
+make undeploy
+
+# 4. Clean up cluster-scoped resources
+oc delete oauthclient openshell 2>/dev/null
+oc delete groups openshell-users openshell-admins 2>/dev/null
+
+# 5. Delete the namespace
+oc delete ns ogo
+
+# 6. (If using Envoy Gateway) Remove Envoy Gateway
+helm uninstall eg -n envoy-gateway-system
+oc delete ns envoy-gateway-system
+oc delete gatewayclass eg
 ```
 
 ## Next steps
 
-- [Envoy Gateway](envoy-gateway.md) - eliminate `--gateway-insecure` with proper TLS
-- [OpenShift SSO](openshift-sso.md) - understand the auth-bridge
+- [Envoy Gateway](envoy-gateway.md) - gRPC ingress architecture details
+- [OpenShift SSO](openshift-sso.md) - authentication and user groups
 - [Provider](../concepts/provider.md) - inject API keys into sandboxes
+- [Policy](../concepts/policy.md) - control sandbox network and filesystem access


### PR DESCRIPTION
## Summary

- Rewrite quickstart with two clear deployment paths and proper install ordering
- Add complete teardown section

### Two paths

| Path | Auth | TLS | Prerequisites |
|------|------|-----|---------------|
| With Envoy Gateway | OpenShift SSO | Let's Encrypt | cert-manager, Envoy Gateway |
| Without Envoy Gateway | mTLS | Self-signed | None |

### Install ordering (Envoy path)

cert-manager → Envoy Gateway + GatewayClass → operator → PostgreSQL → user groups → gateway CR → Envoy proxy SCC

### Teardown

Complete cleanup instructions covering gateway CR, database, operator, cluster-scoped resources, and optional Envoy Gateway removal.

## Test plan

- [ ] Follow the "Without Envoy Gateway" path on a fresh cluster
- [ ] Follow the "With Envoy Gateway" path on a fresh cluster
- [ ] Verify teardown removes all resources cleanly

Assisted-by: Claude