### PR TITLE
feat: add /token/exchange endpoint for headless auth from DevSpaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Step-by-step walkthroughs.
 - [Quickstart](docs/guides/quickstart.md) - deploy OGO on OpenShift in 10 minutes
 - [Envoy Gateway](docs/guides/envoy-gateway.md) - gRPC ingress with Let's Encrypt TLS
 - [OpenShift SSO](docs/guides/openshift-sso.md) - "Log in with OpenShift" for the CLI
+- [DevSpaces](docs/guides/devspaces.md) - create sandboxes from DevSpaces workspaces
 
 ## Reference
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -79,6 +79,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - gateway.envoyproxy.io
+  resources:
+  - backendtrafficpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - gateway.networking.k8s.io
   resources:
   - gateways

--- a/docs/guides/devspaces.md
+++ b/docs/guides/devspaces.md
@@ -1,0 +1,224 @@
+---
+type: Guide
+title: DevSpaces Integration
+description: Create OpenShell sandboxes from Red Hat OpenShift DevSpaces workspaces using headless token exchange.
+tags: [devspaces, authentication, headless]
+---
+
+# DevSpaces integration
+
+Create OpenShell sandboxes from a DevSpaces workspace without a browser.
+Works on the same cluster or across clusters.
+
+## How it works
+
+```
+DevSpaces workspace
+  │
+  ├─ oc whoami -t              → OpenShift token (already authenticated)
+  │
+  ├─ POST /token/exchange      → auth-bridge exchanges for OpenShell JWT
+  │   Authorization: Bearer <ocp-token>
+  │
+  └─ openshell sandbox create  → authenticated sandbox creation
+```
+
+The auth-bridge's `/token/exchange` endpoint accepts an OpenShift bearer
+token and returns an OpenShell JWT. No browser redirect needed — the user
+is already authenticated to OpenShift in DevSpaces.
+
+## Prerequisites
+
+- OGO deployed with OpenShift SSO enabled ([Quickstart](quickstart.md))
+- User in the `openshell-users` group ([OpenShift SSO](openshift-sso.md))
+- `openshell` CLI installed in the DevSpaces workspace
+- `jq` available in the workspace
+
+## Install the OpenShell CLI
+
+From a DevSpaces terminal:
+
+```bash
+curl -LsSf https://github.com/NVIDIA/OpenShell/releases/latest/download/openshell-x86_64-unknown-linux-musl.tar.gz \
+  | tar xz -C ~/.local/bin/
+openshell --version
+```
+
+## Same-cluster setup
+
+When DevSpaces and OGO are on the same OpenShift cluster.
+
+### One-time setup
+
+```bash
+# Trust the system CA bundle (required for Let's Encrypt YR1 intermediate)
+export SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
+
+# Exchange your OpenShift token for an OpenShell JWT
+RESPONSE=$(curl -s -X POST \
+  -H "Authorization: Bearer $(oc whoami -t)" \
+  https://openshell-auth.apps.YOUR-CLUSTER.example.com/token/exchange)
+
+# Verify the exchange succeeded
+echo $RESPONSE | jq .
+
+# Write the gateway config
+GATEWAY_HOST="openshell.apps.YOUR-CLUSTER.example.com"
+AUTH_HOST="openshell-auth.apps.YOUR-CLUSTER.example.com"
+
+mkdir -p ~/.config/openshell/gateways/my-cluster
+cat > ~/.config/openshell/gateways/my-cluster/metadata.json <<EOF
+{
+  "name": "my-cluster",
+  "gateway_endpoint": "https://${GATEWAY_HOST}",
+  "is_remote": true,
+  "gateway_port": 0,
+  "auth_mode": "oidc",
+  "oidc_issuer": "https://${AUTH_HOST}",
+  "oidc_client_id": "openshell-cli"
+}
+EOF
+cat > ~/.config/openshell/gateways/my-cluster/oidc_token.json <<EOF
+{
+  "access_token": "$(echo $RESPONSE | jq -r .access_token)",
+  "expires_at": $(echo $RESPONSE | jq -r .expires_at),
+  "issuer": "https://${AUTH_HOST}",
+  "client_id": "openshell-cli"
+}
+EOF
+echo my-cluster > ~/.config/openshell/active_gateway
+```
+
+### Create a sandbox
+
+```bash
+openshell sandbox create
+```
+
+## Cross-cluster setup
+
+When DevSpaces and OGO are on different OpenShift clusters. The gateway
+cluster's Routes must be network-reachable from the DevSpaces pod.
+
+### Prerequisites
+
+- Network connectivity from DevSpaces to the gateway cluster's Routes
+- An OpenShift account on the gateway cluster with `openshell-users` group
+  membership
+
+### Setup
+
+```bash
+export SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
+
+# Login to the gateway cluster (separate kubeconfig)
+KUBECONFIG=~/.kube/remote-cluster oc login https://api.REMOTE-CLUSTER.example.com:6443
+
+# Exchange the remote cluster's token
+REMOTE_TOKEN=$(KUBECONFIG=~/.kube/remote-cluster oc whoami -t)
+RESPONSE=$(curl -s -X POST \
+  -H "Authorization: Bearer $REMOTE_TOKEN" \
+  https://openshell-auth.apps.REMOTE-CLUSTER.example.com/token/exchange)
+
+# Write the gateway config (same as above, with the remote cluster's hostnames)
+GATEWAY_HOST="openshell.apps.REMOTE-CLUSTER.example.com"
+AUTH_HOST="openshell-auth.apps.REMOTE-CLUSTER.example.com"
+
+mkdir -p ~/.config/openshell/gateways/remote
+cat > ~/.config/openshell/gateways/remote/metadata.json <<EOF
+{
+  "name": "remote",
+  "gateway_endpoint": "https://${GATEWAY_HOST}",
+  "is_remote": true,
+  "gateway_port": 0,
+  "auth_mode": "oidc",
+  "oidc_issuer": "https://${AUTH_HOST}",
+  "oidc_client_id": "openshell-cli"
+}
+EOF
+cat > ~/.config/openshell/gateways/remote/oidc_token.json <<EOF
+{
+  "access_token": "$(echo $RESPONSE | jq -r .access_token)",
+  "expires_at": $(echo $RESPONSE | jq -r .expires_at),
+  "issuer": "https://${AUTH_HOST}",
+  "client_id": "openshell-cli"
+}
+EOF
+
+# Create a sandbox on the remote cluster
+openshell sandbox create --gateway remote
+```
+
+## Token refresh
+
+The OpenShell JWT expires after the configured `tokenTTL` (default 8 hours).
+To refresh, re-run the token exchange:
+
+```bash
+RESPONSE=$(curl -s -X POST \
+  -H "Authorization: Bearer $(oc whoami -t)" \
+  https://openshell-auth.apps.YOUR-CLUSTER.example.com/token/exchange)
+
+cat > ~/.config/openshell/gateways/my-cluster/oidc_token.json <<EOF
+{
+  "access_token": "$(echo $RESPONSE | jq -r .access_token)",
+  "expires_at": $(echo $RESPONSE | jq -r .expires_at),
+  "issuer": "https://openshell-auth.apps.YOUR-CLUSTER.example.com",
+  "client_id": "openshell-cli"
+}
+EOF
+```
+
+## Troubleshooting
+
+### "missing Bearer token"
+
+The `Authorization` header is missing or not using the `Bearer` scheme.
+Check that `oc whoami -t` returns a token:
+
+```bash
+oc whoami -t
+# If empty, re-login:
+oc login --web
+```
+
+### "user is not a member of group"
+
+Your OpenShift user is not in the `openshell-users` group. Ask your
+cluster admin:
+
+```bash
+oc adm groups add-users openshell-users your-username
+```
+
+### "invalid OpenShift token"
+
+The token is expired or from a different cluster than the auth-bridge.
+For cross-cluster, make sure you use a token from the **gateway cluster**,
+not the DevSpaces cluster.
+
+### TLS certificate errors
+
+Set `SSL_CERT_FILE` to use the system CA bundle instead of the CLI's
+built-in bundle:
+
+```bash
+export SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
+```
+
+Add this to your `~/.bashrc` in the DevSpaces workspace for persistence.
+
+### curl hangs on token exchange
+
+The auth-bridge Route is not reachable from the DevSpaces pod. For
+cross-cluster, verify network connectivity:
+
+```bash
+curl --connect-timeout 5 https://openshell-auth.apps.REMOTE-CLUSTER.example.com/healthz
+```
+
+## See also
+
+- [Quickstart](quickstart.md) - deploy OGO
+- [OpenShift SSO](openshift-sso.md) - user groups and token management
+- [OpenShellGateway CRD](../reference/openshellgateway.md) - CR reference

--- a/docs/guides/devspaces.md
+++ b/docs/guides/devspaces.md
@@ -34,14 +34,22 @@ is already authenticated to OpenShift in DevSpaces.
 - `openshell` CLI installed in the DevSpaces workspace
 - `jq` available in the workspace
 
-## Install the OpenShell CLI
+## Install the OpenShell CLI (if not in your workspace image)
 
-From a DevSpaces terminal:
+If your DevSpaces workspace image does not include the `openshell` CLI,
+install it manually:
 
 ```bash
 curl -LsSf https://github.com/NVIDIA/OpenShell/releases/latest/download/openshell-x86_64-unknown-linux-musl.tar.gz \
   | tar xz -C ~/.local/bin/
 openshell --version
+```
+
+To bake it into a custom workspace image, add to your Containerfile:
+
+```dockerfile
+RUN curl -LsSf https://github.com/NVIDIA/OpenShell/releases/latest/download/openshell-x86_64-unknown-linux-musl.tar.gz \
+  | tar xz -C /usr/local/bin/
 ```
 
 ## Same-cluster setup

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -9,3 +9,4 @@ description: Step-by-step walkthroughs for deploying and configuring OGO.
 - [Quickstart](quickstart.md) - deploy OGO on OpenShift in 10 minutes
 - [Envoy Gateway](envoy-gateway.md) - gRPC ingress with Let's Encrypt TLS
 - [OpenShift SSO](openshift-sso.md) - "Log in with OpenShift" for the CLI
+- [DevSpaces](devspaces.md) - create sandboxes from DevSpaces workspaces

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ Step-by-step walkthroughs.
 - [Quickstart](guides/quickstart.md) - deploy OGO on OpenShift in 10 minutes
 - [Envoy Gateway](guides/envoy-gateway.md) - gRPC ingress with Let's Encrypt TLS
 - [OpenShift SSO](guides/openshift-sso.md) - "Log in with OpenShift" for the CLI
+- [DevSpaces](guides/devspaces.md) - create sandboxes from DevSpaces workspaces
 
 ## Reference
 

--- a/internal/authbridge/server.go
+++ b/internal/authbridge/server.go
@@ -93,6 +93,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/authorize", s.handleAuthorize)
 	mux.HandleFunc("/callback", s.handleCallback)
 	mux.HandleFunc("/token", s.handleToken)
+	mux.HandleFunc("/token/exchange", s.handleTokenExchange)
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = fmt.Fprint(w, "ok")
@@ -117,7 +118,7 @@ func (s *Server) handleDiscovery(w http.ResponseWriter, r *http.Request) {
 		"token_endpoint":                        s.config.ExternalIssuer + "/token",
 		"jwks_uri":                              base + "/jwks",
 		"response_types_supported":              []string{"code"},
-		"grant_types_supported":                 []string{"authorization_code"},
+		"grant_types_supported":                 []string{"authorization_code", "urn:ietf:params:oauth:grant-type:token-exchange"},
 		"subject_types_supported":               []string{"public"},
 		"token_endpoint_auth_methods_supported": []string{"client_secret_basic"},
 		"scopes_supported":                      []string{"openid", "profile", "email"},
@@ -317,6 +318,62 @@ func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
 		"access_token": pending.jwt,
 		"token_type":   "Bearer",
 		"expires_in":   int(s.config.TokenTTL.Seconds()),
+	})
+}
+
+func (s *Server) handleTokenExchange(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	auth := r.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "Bearer ") {
+		http.Error(w, `{"error":"missing Bearer token"}`, http.StatusUnauthorized)
+		return
+	}
+	ocpToken := strings.TrimPrefix(auth, "Bearer ")
+
+	userInfo, err := s.osc.GetUserInfo(r.Context(), ocpToken)
+	if err != nil {
+		log.Printf("token exchange: user info failed: %v", err)
+		http.Error(w, `{"error":"invalid OpenShift token"}`, http.StatusUnauthorized)
+		return
+	}
+
+	if !s.isAuthorized(userInfo.Name, userInfo.Groups) {
+		log.Printf("token exchange: user %s not in required group %q", userInfo.Name, s.config.UserGroup)
+		http.Error(w, fmt.Sprintf(`{"error":"user %q is not a member of group %q"}`, userInfo.Name, s.config.UserGroup), http.StatusForbidden)
+		return
+	}
+
+	roles := s.mapRoles(userInfo.Groups)
+
+	jwt, err := s.signer.MintToken(
+		s.config.Issuer,
+		s.config.Audience,
+		userInfo.UID,
+		userInfo.Name,
+		"",
+		roles,
+		s.config.TokenTTL,
+	)
+	if err != nil {
+		log.Printf("token exchange: JWT minting failed: %v", err)
+		http.Error(w, `{"error":"token generation failed"}`, http.StatusInternalServerError)
+		return
+	}
+
+	expiresAt := time.Now().Add(s.config.TokenTTL).Unix()
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"access_token": jwt,
+		"token_type":   "Bearer",
+		"expires_in":   int(s.config.TokenTTL.Seconds()),
+		"expires_at":   expiresAt,
+		"issuer":       s.config.ExternalIssuer,
+		"client_id":    s.config.Audience,
 	})
 }
 

--- a/internal/authbridge/server.go
+++ b/internal/authbridge/server.go
@@ -118,7 +118,7 @@ func (s *Server) handleDiscovery(w http.ResponseWriter, r *http.Request) {
 		"token_endpoint":                        s.config.ExternalIssuer + "/token",
 		"jwks_uri":                              base + "/jwks",
 		"response_types_supported":              []string{"code"},
-		"grant_types_supported":                 []string{"authorization_code", "urn:ietf:params:oauth:grant-type:token-exchange"},
+		"grant_types_supported":                 []string{"authorization_code"},
 		"subject_types_supported":               []string{"public"},
 		"token_endpoint_auth_methods_supported": []string{"client_secret_basic"},
 		"scopes_supported":                      []string{"openid", "profile", "email"},
@@ -343,7 +343,7 @@ func (s *Server) handleTokenExchange(w http.ResponseWriter, r *http.Request) {
 
 	if !s.isAuthorized(userInfo.Name, userInfo.Groups) {
 		log.Printf("token exchange: user %s not in required group %q", userInfo.Name, s.config.UserGroup)
-		http.Error(w, fmt.Sprintf(`{"error":"user %q is not a member of group %q"}`, userInfo.Name, s.config.UserGroup), http.StatusForbidden)
+		http.Error(w, `{"error":"user is not a member of the required group"}`, http.StatusForbidden)
 		return
 	}
 

--- a/internal/authbridge/server_test.go
+++ b/internal/authbridge/server_test.go
@@ -390,6 +390,162 @@ func TestTokenExchangeRejectsNonMember(t *testing.T) {
 	}
 }
 
+func TestTokenExchangeRejectsInvalidToken(t *testing.T) {
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer mock.Close()
+
+	t.Setenv("KUBERNETES_API_URL", mock.URL)
+
+	s := testServer(t)
+	handler := s.Handler()
+
+	req := httptest.NewRequest("POST", "/token/exchange", nil)
+	req.Header.Set("Authorization", "Bearer invalid-token")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 for invalid token", w.Code)
+	}
+}
+
+func TestMapRoles(t *testing.T) {
+	s := testServer(t)
+	s.config.AdminGroup = "openshell-admins"
+
+	tests := []struct {
+		name      string
+		groups    []string
+		wantAdmin bool
+	}{
+		{"user only", []string{"openshell-users"}, false},
+		{"user and admin", []string{"openshell-users", "openshell-admins"}, true},
+		{"admin only", []string{"openshell-admins"}, true},
+		{"no relevant groups", []string{"other"}, false},
+		{"empty", []string{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			roles := s.mapRoles(tt.groups)
+			hasUser := false
+			hasAdmin := false
+			for _, r := range roles {
+				if r == "openshell-user" {
+					hasUser = true
+				}
+				if r == "openshell-admin" {
+					hasAdmin = true
+				}
+			}
+			if !hasUser {
+				t.Error("should always have openshell-user role")
+			}
+			if hasAdmin != tt.wantAdmin {
+				t.Errorf("admin = %v, want %v", hasAdmin, tt.wantAdmin)
+			}
+		})
+	}
+}
+
+func TestMapRolesNoAdminGroup(t *testing.T) {
+	s := testServer(t)
+	s.config.AdminGroup = ""
+
+	roles := s.mapRoles([]string{"openshell-admins"})
+	for _, r := range roles {
+		if r == "openshell-admin" {
+			t.Error("should not assign admin role when adminGroup is empty")
+		}
+	}
+}
+
+func TestSplitState(t *testing.T) {
+	tests := []struct {
+		input string
+		want  [2]string
+	}{
+		{"bridge:client", [2]string{"bridge", "client"}},
+		{"nodelimiter", [2]string{"nodelimiter", ""}},
+		{"a:b:c", [2]string{"a", "b:c"}},
+		{":", [2]string{"", ""}},
+		{"", [2]string{"", ""}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := splitState(tt.input)
+			if got != tt.want {
+				t.Errorf("splitState(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTokenEndpointHappyPath(t *testing.T) {
+	s := testServer(t)
+	handler := s.Handler()
+
+	jwt, err := s.signer.MintToken("http://localhost:8085", "openshell-cli", "uid-1", "alice", "", []string{"openshell-user"}, 8*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	code := generateCode()
+	s.codesMu.Lock()
+	s.codes[code] = &pendingCode{jwt: jwt, expiresAt: time.Now().Add(60 * time.Second)}
+	s.codesMu.Unlock()
+
+	form := url.Values{"grant_type": {"authorization_code"}, "code": {code}}
+	req := httptest.NewRequest("POST", "/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["access_token"] == nil || resp["access_token"] == "" {
+		t.Error("access_token is empty")
+	}
+	if resp["token_type"] != "Bearer" {
+		t.Errorf("token_type = %v, want Bearer", resp["token_type"])
+	}
+}
+
+func TestSweepExpiredCodes(t *testing.T) {
+	s := testServer(t)
+
+	s.codesMu.Lock()
+	s.codes["expired"] = &pendingCode{expiresAt: time.Now().Add(-1 * time.Minute)}
+	s.codes["valid"] = &pendingCode{expiresAt: time.Now().Add(5 * time.Minute)}
+	s.codesMu.Unlock()
+
+	// Trigger a manual sweep
+	now := time.Now()
+	s.codesMu.Lock()
+	for k, v := range s.codes {
+		if now.After(v.expiresAt) {
+			delete(s.codes, k)
+		}
+	}
+	s.codesMu.Unlock()
+
+	s.codesMu.Lock()
+	defer s.codesMu.Unlock()
+	if _, ok := s.codes["expired"]; ok {
+		t.Error("expired code should have been swept")
+	}
+	if _, ok := s.codes["valid"]; !ok {
+		t.Error("valid code should still exist")
+	}
+}
+
 func TestAuthorizeRejectsInvalidRedirectURI(t *testing.T) {
 	s := testServer(t)
 	handler := s.Handler()

--- a/internal/authbridge/server_test.go
+++ b/internal/authbridge/server_test.go
@@ -319,6 +319,77 @@ func TestTokenExchangeRejectsEmptyBearer(t *testing.T) {
 	}
 }
 
+func TestTokenExchangeWithMockOpenShift(t *testing.T) {
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/apis/user.openshift.io/v1/users/~" {
+			auth := r.Header.Get("Authorization")
+			if auth != "Bearer valid-ocp-token" {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"metadata":{"name":"alice","uid":"uid-alice"},"groups":["openshell-users"]}`))
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer mock.Close()
+
+	t.Setenv("KUBERNETES_API_URL", mock.URL)
+
+	s := testServer(t)
+	handler := s.Handler()
+
+	req := httptest.NewRequest("POST", "/token/exchange", nil)
+	req.Header.Set("Authorization", "Bearer valid-ocp-token")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["access_token"] == nil || resp["access_token"] == "" {
+		t.Error("access_token is empty")
+	}
+	if resp["token_type"] != "Bearer" {
+		t.Errorf("token_type = %v, want Bearer", resp["token_type"])
+	}
+	if resp["expires_at"] == nil {
+		t.Error("expires_at is missing")
+	}
+}
+
+func TestTokenExchangeRejectsNonMember(t *testing.T) {
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/apis/user.openshift.io/v1/users/~" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"metadata":{"name":"bob","uid":"uid-bob"},"groups":["other-group"]}`))
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer mock.Close()
+
+	t.Setenv("KUBERNETES_API_URL", mock.URL)
+
+	s := testServer(t)
+	handler := s.Handler()
+
+	req := httptest.NewRequest("POST", "/token/exchange", nil)
+	req.Header.Set("Authorization", "Bearer some-token")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for non-member", w.Code)
+	}
+}
+
 func TestAuthorizeRejectsInvalidRedirectURI(t *testing.T) {
 	s := testServer(t)
 	handler := s.Handler()

--- a/internal/authbridge/server_test.go
+++ b/internal/authbridge/server_test.go
@@ -305,7 +305,7 @@ func TestTokenExchangeRejectsMissingBearer(t *testing.T) {
 	}
 }
 
-func TestTokenExchangeRejectsEmptyBearer(t *testing.T) {
+func TestTokenExchangeRejectsNonBearerAuth(t *testing.T) {
 	s := testServer(t)
 	handler := s.Handler()
 

--- a/internal/authbridge/server_test.go
+++ b/internal/authbridge/server_test.go
@@ -280,6 +280,45 @@ func TestIsAuthorizedEmptyConfig(t *testing.T) {
 	}
 }
 
+func TestTokenExchangeRejectsGet(t *testing.T) {
+	s := testServer(t)
+	handler := s.Handler()
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest("GET", "/token/exchange", nil))
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestTokenExchangeRejectsMissingBearer(t *testing.T) {
+	s := testServer(t)
+	handler := s.Handler()
+
+	req := httptest.NewRequest("POST", "/token/exchange", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestTokenExchangeRejectsEmptyBearer(t *testing.T) {
+	s := testServer(t)
+	handler := s.Handler()
+
+	req := httptest.NewRequest("POST", "/token/exchange", nil)
+	req.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 for non-Bearer auth", w.Code)
+	}
+}
+
 func TestAuthorizeRejectsInvalidRedirectURI(t *testing.T) {
 	s := testServer(t)
 	handler := s.Handler()

--- a/internal/controller/openshellgateway_controller.go
+++ b/internal/controller/openshellgateway_controller.go
@@ -89,6 +89,7 @@ type OpenShellGatewayReconciler struct {
 // +kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=oauth.openshift.io,resources=oauthclients,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways;grpcroutes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=gateway.envoyproxy.io,resources=backendtrafficpolicies,verbs=get;list;watch;create;update;patch;delete
 
 func (r *OpenShellGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
@@ -247,6 +248,13 @@ func (r *OpenShellGatewayReconciler) reconcileDelete(ctx context.Context, gw *og
 			if err := r.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
 				log.Error(err, "Failed to delete Gateway API resource", "kind", gvk.Kind)
 			}
+		}
+		btpObj := &unstructured.Unstructured{}
+		btpObj.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.envoyproxy.io", Version: "v1alpha1", Kind: "BackendTrafficPolicy"})
+		btpObj.SetName(gw.Name + "-timeout")
+		btpObj.SetNamespace(ns)
+		if err := r.Delete(ctx, btpObj); err != nil && !apierrors.IsNotFound(err) {
+			log.Error(err, "Failed to delete BackendTrafficPolicy")
 		}
 		svcList := &corev1.ServiceList{}
 		if err := r.List(ctx, svcList, client.MatchingLabels{
@@ -1082,6 +1090,37 @@ func (r *OpenShellGatewayReconciler) reconcileGatewayAPI(ctx context.Context, gw
 		}
 	} else if err != nil {
 		return fmt.Errorf("getting GRPCRoute: %w", err)
+	}
+
+	// Disable Envoy's default 15-second stream timeout for long-lived gRPC
+	// streams (SSH relay, WatchSandbox). Without this, Envoy kills the
+	// connection and the CLI reports "missing grpc-status trailer".
+	btpGVK := schema.GroupVersionKind{Group: "gateway.envoyproxy.io", Version: "v1alpha1", Kind: "BackendTrafficPolicy"}
+	existingBTP := &unstructured.Unstructured{}
+	existingBTP.SetGroupVersionKind(btpGVK)
+	if err := r.Get(ctx, types.NamespacedName{Name: gw.Name + "-timeout", Namespace: ns}, existingBTP); apierrors.IsNotFound(err) {
+		btp := &unstructured.Unstructured{}
+		btp.SetGroupVersionKind(btpGVK)
+		btp.SetName(gw.Name + "-timeout")
+		btp.SetNamespace(ns)
+		btp.SetLabels(gatewayLabels(gw))
+		btp.Object["spec"] = map[string]interface{}{
+			"targetRefs": []interface{}{
+				map[string]interface{}{
+					"group": "gateway.networking.k8s.io",
+					"kind":  "GRPCRoute",
+					"name":  gw.Name,
+				},
+			},
+			"timeout": map[string]interface{}{
+				"http": map[string]interface{}{
+					"requestTimeout": "0s",
+				},
+			},
+		}
+		if createErr := r.Create(ctx, btp); createErr != nil {
+			logf.FromContext(ctx).Error(createErr, "Failed to create BackendTrafficPolicy (Envoy Gateway may not be installed)")
+		}
 	}
 
 	oldRoute := &unstructured.Unstructured{}

--- a/internal/controller/openshellgateway_controller.go
+++ b/internal/controller/openshellgateway_controller.go
@@ -1098,7 +1098,9 @@ func (r *OpenShellGatewayReconciler) reconcileGatewayAPI(ctx context.Context, gw
 	btpGVK := schema.GroupVersionKind{Group: "gateway.envoyproxy.io", Version: "v1alpha1", Kind: "BackendTrafficPolicy"}
 	existingBTP := &unstructured.Unstructured{}
 	existingBTP.SetGroupVersionKind(btpGVK)
-	if err := r.Get(ctx, types.NamespacedName{Name: gw.Name + "-timeout", Namespace: ns}, existingBTP); apierrors.IsNotFound(err) {
+	if err := r.Get(ctx, types.NamespacedName{Name: gw.Name + "-timeout", Namespace: ns}, existingBTP); err != nil && !apierrors.IsNotFound(err) {
+		logf.FromContext(ctx).Error(err, "Failed to check BackendTrafficPolicy")
+	} else if apierrors.IsNotFound(err) {
 		btp := &unstructured.Unstructured{}
 		btp.SetGroupVersionKind(btpGVK)
 		btp.SetName(gw.Name + "-timeout")


### PR DESCRIPTION
## Summary

Add a `/token/exchange` endpoint to the auth-bridge for headless authentication from environments where browser-based OIDC login is not possible.

### How it works

```
POST /token/exchange
Authorization: Bearer <openshift-token>
→ {"access_token": "<openshell-jwt>", "expires_at": ..., ...}
```

Accepts an OpenShift bearer token, validates it via the UserInfo API, checks group membership, and returns an OpenShell JWT with the same claims as the browser SSO flow.

### Use cases

- DevSpaces → OpenShell gateway (same or cross-cluster)
- CI/CD pipelines creating sandboxes
- SSH sessions and headless environments

### Tested

- Token exchange from DevSpaces pod on RDU cluster
- JWT accepted by gateway for sandbox creation
- Group membership enforced (non-members rejected with 403)
- No browser, no `--gateway-insecure`, no `allowUnauthenticated`

## Test plan

- [x] Unit tests for endpoint (rejects GET, rejects missing Bearer, rejects non-Bearer)
- [x] End-to-end: DevSpaces → token exchange → sandbox create (RDU)
- [x] Cross-cluster: DevSpaces on RDU → token exchange on SNO
- [ ] Token expiry honored

Assisted-by: Claude