### PR TITLE
feat: add devfile for DevSpaces with ODI image

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -1,0 +1,12 @@
+schemaVersion: 2.2.2
+metadata:
+  generateName: ogo
+components:
+  - name: odi
+    container:
+      image: quay.io/aknochow/odi:latest
+      memoryLimit: 8Gi
+      cpuLimit: 4000m
+      env:
+        - name: SSL_CERT_FILE
+          value: /etc/pki/tls/certs/ca-bundle.crt


### PR DESCRIPTION
## Summary

Add a devfile for DevSpaces workspaces using the ODI (OpenShell Developer Image).

- Image: `quay.io/aknochow/odi:latest` ([source](https://github.com/aknochow/odi))
- UBI 10 based with Go 1.24.5, OpenShell CLI, golangci-lint, k9s, gh
- Contributors can open OGO in DevSpaces and immediately build, test, and create sandboxes

## Test plan

- [ ] Build the ODI image and push to quay.io
- [ ] Open OGO in DevSpaces using the devfile
- [ ] Verify: `go version`, `openshell --version`, `make build`, `make test`

Assisted-by: Claude