### PR TITLE
docs: Update Envoy Gateway installation docs

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: controller
   newName: quay.io/aknochow/ogo
-  newTag: 0.1.0-20260630094427
+  newTag: main

--- a/docs/guides/envoy-gateway.md
+++ b/docs/guides/envoy-gateway.md
@@ -33,14 +33,25 @@ Client ──HTTPS──▶ OpenShift Router ──passthrough──▶ Envoy Pr
 
 ### Install Envoy Gateway on OpenShift
 
+The certgen pre-install hook runs as uid 65534, which is outside OpenShift's
+allowed UID range. Pre-create the namespace and service account, grant SCC,
+then install with the UID overridden so OpenShift assigns one from the
+namespace range instead.
+
 ```bash
+# 1. Pre-create namespace and certgen service account
+oc create namespace envoy-gateway-system
+oc create sa eg-gateway-helm-certgen -n envoy-gateway-system
+oc adm policy add-scc-to-user anyuid -z eg-gateway-helm-certgen -n envoy-gateway-system
+
+# 2. Install — override certgen UID so OpenShift assigns from the namespace range
 helm install eg oci://docker.io/envoyproxy/gateway-helm \
-  --version v1.3.2 -n envoy-gateway-system --create-namespace --skip-crds
-```
+  --version v1.3.2 -n envoy-gateway-system --skip-crds \
+  --set-json 'certgen.job.securityContext.runAsUser=null' \
+  --set-json 'certgen.job.securityContext.runAsGroup=null' \
+  --set-json 'certgen.job.securityContext.seccompProfile=null'
 
-Grant privileged SCC to Envoy ServiceAccounts:
-
-```bash
+# 3. Grant privileged SCC to the main controller service account
 oc adm policy add-scc-to-user privileged -z envoy-gateway -n envoy-gateway-system
 ```
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -63,20 +63,30 @@ EOF
 
 ### 2. Install Envoy Gateway
 
-On OpenShift 4.22+, Gateway API CRDs are managed by the Ingress Operator.
-Use `--skip-crds` to avoid conflicts. On 4.16-4.21, omit `--skip-crds`
-to let the Helm chart install the CRDs:
+The certgen pre-install hook runs as uid 65534, outside OpenShift's allowed
+UID range. Pre-create the namespace and service account, grant SCC, then
+install with the UID overridden:
 
 ```bash
+# 1. Pre-create namespace and certgen service account
+oc create namespace envoy-gateway-system
+oc create sa eg-gateway-helm-certgen -n envoy-gateway-system
+oc adm policy add-scc-to-user anyuid -z eg-gateway-helm-certgen -n envoy-gateway-system
+
+# 2. Install — override certgen UID so OpenShift assigns from the namespace range
 helm install eg oci://docker.io/envoyproxy/gateway-helm \
-  --version v1.3.2 -n envoy-gateway-system --create-namespace --skip-crds
+  --version v1.3.2 -n envoy-gateway-system --skip-crds \
+  --set-json 'certgen.job.securityContext.runAsUser=null' \
+  --set-json 'certgen.job.securityContext.runAsGroup=null' \
+  --set-json 'certgen.job.securityContext.seccompProfile=null'
+
+# 3. Grant privileged SCC to the main controller service account
+oc adm policy add-scc-to-user privileged -z envoy-gateway -n envoy-gateway-system
 ```
 
-Grant the required SCCs and create the GatewayClass:
+Create the GatewayClass:
 
 ```bash
-oc adm policy add-scc-to-user privileged -z envoy-gateway -n envoy-gateway-system
-
 cat <<EOF | oc apply -f -
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -67,7 +67,7 @@ The certgen pre-install hook runs as uid 65534, outside OpenShift's allowed
 UID range. Pre-create the namespace and service account, grant SCC, then
 install with the UID overridden.
  
-IMPORTANT: On OpenShift 4.22+, Gateway API CRDs are managed by the Ingress Operator.
+IMPORTANT: On OpenShift 4.20+, Gateway API CRDs are managed by the Ingress Operator.
 Use `--skip-crds` to avoid conflicts. On 4.16-4.21, omit `--skip-crds`
 to let the Helm chart install the CRDs:
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -65,7 +65,11 @@ EOF
 
 The certgen pre-install hook runs as uid 65534, outside OpenShift's allowed
 UID range. Pre-create the namespace and service account, grant SCC, then
-install with the UID overridden:
+install with the UID overridden.
+ 
+IMPORTANT: On OpenShift 4.22+, Gateway API CRDs are managed by the Ingress Operator.
+Use `--skip-crds` to avoid conflicts. On 4.16-4.21, omit `--skip-crds`
+to let the Helm chart install the CRDs:
 
 ```bash
 # 1. Pre-create namespace and certgen service account


### PR DESCRIPTION
Was able to deploy on OSD 4.20 only using this updated instructions. With the current one, it fails with:

<img width="1624" height="648" alt="Screenshot 2026-07-14 at 14 17 01" src="https://github.com/user-attachments/assets/1ffe95c8-45bf-4c18-bef7-5250c58f7b73" />

````
Error creating: pods "eg-gateway-helm-certgen-" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, provider restricted-v2: .containers[0].runAsUser: Invalid value: 65534: must be in the ranges: [1001690000, 1001699999], provider restricted-v3: .spec.securityContext.hostUsers: Invalid value: "null": Host Users must be set to false, provider restricted: .containers[0].runAsUser: Invalid value: 65534: must be in the ranges: [1001690000, 1001699999], pod.metadata.annotations[container.seccomp.security.alpha.kubernetes.io/envoy-gateway-certgen]: Forbidden: seccomp may not be set, provider "container-build": Forbidden: not usable by user or serviceaccount, provider "nested-container": Forbidden: not usable by user or serviceaccount, provider "nonroot-v2": Forbidden: not usable by user or serviceaccount, provider "nonroot": Forbidden: not usable by user or serviceaccount, provider "pcap-dedicated-admins": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid-v2": Forbidden: not usable by user or serviceaccount, provider "machine-api-termination-handler": Forbidden: not usable by user or serviceaccount, provider "hostnetwork-v2": Forbidden: not usable by user or serviceaccount, provider "hostnetwork": Forbidden: not usable by user or serviceaccount, provider "hostaccess": Forbidden: not usable by user or serviceaccount, provider "insights-runtime-extractor-scc": Forbidden: not usable by user or serviceaccount, provider "splunkforwarder": Forbidden: not usable by user or serviceaccount, provider "node-exporter": Forbidden: not usable by user or serviceaccount, provider "privileged": Forbidden: not usable by user or serviceaccount]
````

