### PR TITLE
refactor: migrate from deprecated scheme.Builder to runtime.SchemeBuilder

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -29,8 +30,21 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "gateway.ogo.aknochow.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(s *runtime.Scheme) error {
+	s.AddKnownTypes(GroupVersion,
+		&OpenShellGateway{},
+		&OpenShellGatewayList{},
+		&OpenShellProvider{},
+		&OpenShellProviderList{},
+		&OpenShellPolicy{},
+		&OpenShellPolicyList{},
+	)
+	metav1.AddToGroupVersion(s, GroupVersion)
+	return nil
+}

--- a/api/v1alpha1/openshellgateway_types.go
+++ b/api/v1alpha1/openshellgateway_types.go
@@ -279,7 +279,3 @@ type OpenShellGatewayList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []OpenShellGateway `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&OpenShellGateway{}, &OpenShellGatewayList{})
-}

--- a/api/v1alpha1/openshellpolicy_types.go
+++ b/api/v1alpha1/openshellpolicy_types.go
@@ -142,7 +142,3 @@ type OpenShellPolicyList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []OpenShellPolicy `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&OpenShellPolicy{}, &OpenShellPolicyList{})
-}

--- a/api/v1alpha1/openshellprovider_types.go
+++ b/api/v1alpha1/openshellprovider_types.go
@@ -85,7 +85,3 @@ type OpenShellProviderList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []OpenShellProvider `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&OpenShellProvider{}, &OpenShellProviderList{})
-}


### PR DESCRIPTION
## Summary

Migrate from deprecated `scheme.Builder` (controller-runtime) to `runtime.NewSchemeBuilder` (k8s.io/apimachinery).

Required for controller-runtime 0.24.x upgrade (PR #18). The deprecation causes `staticcheck SA1019` lint failures.

### Changes

- `groupversion_info.go`: replace `&scheme.Builder{GroupVersion}` with `runtime.NewSchemeBuilder(addKnownTypes)`
- Remove per-file `init()` registration from gateway, provider, and policy types
- Centralize type registration in `addKnownTypes`

## Test plan

- [ ] `go build ./...` passes
- [ ] `make test` passes
- [ ] CRD generation unchanged (`make manifests`)

Assisted-by: Claude