### PR TITLE
fix: auth-bridge token exchange for ServiceAccount identities

### DIFF
--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -145,13 +144,12 @@ func (c *OpenShiftClient) GetUserInfo(ctx context.Context, accessToken string, g
 		Groups: raw.Groups,
 	}
 
-	if strings.HasPrefix(info.Name, "system:serviceaccount:") {
+	if strings.HasPrefix(info.Name, "system:serviceaccount:") && len(groupNames) > 0 {
 		extraGroups, err := c.checkGroupMemberships(ctx, info.Name, groupNames)
 		if err != nil {
-			log.Printf("warning: group CR lookup failed for %s: %v", info.Name, err)
-		} else {
-			info.Groups = append(info.Groups, extraGroups...)
+			return nil, fmt.Errorf("group CR lookup for %s: %w", info.Name, err)
 		}
+		info.Groups = append(info.Groups, extraGroups...)
 	}
 
 	return info, nil

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -192,6 +192,9 @@ func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username st
 		return nil, fmt.Errorf("reading service account token: %w", err)
 	}
 	saToken := strings.TrimSpace(string(rawToken))
+	if saToken == "" {
+		return nil, fmt.Errorf("service account token file %s is empty", c.SATokenPath)
+	}
 
 	// groupNames is expected to be a small set (typically ≤2: UserGroup + AdminGroup),
 	// so sequential lookups are fine.

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -142,9 +142,70 @@ func (c *OpenShiftClient) GetUserInfo(ctx context.Context, accessToken string) (
 		return nil, fmt.Errorf("decoding user info: %w", err)
 	}
 
-	return &UserInfo{
+	info := &UserInfo{
 		Name:   raw.Metadata.Name,
 		UID:    raw.Metadata.UID,
 		Groups: raw.Groups,
-	}, nil
+	}
+
+	if strings.HasPrefix(info.Name, "system:serviceaccount:") {
+		extraGroups, err := c.getGroupMemberships(ctx, accessToken, info.Name)
+		if err == nil {
+			info.Groups = append(info.Groups, extraGroups...)
+		}
+	}
+
+	return info, nil
+}
+
+func (c *OpenShiftClient) getGroupMemberships(ctx context.Context, _ string, username string) ([]string, error) {
+	apiURL := os.Getenv("KUBERNETES_API_URL")
+	if apiURL == "" {
+		apiURL = "https://kubernetes.default.svc:443"
+	}
+	apiURL = strings.TrimRight(apiURL, "/")
+
+	saToken, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	if err != nil {
+		return nil, fmt.Errorf("reading service account token: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL+"/apis/user.openshift.io/v1/groups", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+string(saToken))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("group list request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("group list failed (%d)", resp.StatusCode)
+	}
+
+	var groupList struct {
+		Items []struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+			Users []string `json:"users"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&groupList); err != nil {
+		return nil, fmt.Errorf("decoding group list: %w", err)
+	}
+
+	var groups []string
+	for _, g := range groupList.Items {
+		for _, u := range g.Users {
+			if u == username {
+				groups = append(groups, g.Metadata.Name)
+				break
+			}
+		}
+	}
+	return groups, nil
 }

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -210,6 +210,7 @@ func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username st
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<10))
 			_ = resp.Body.Close()
 			continue
 		}

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -161,6 +161,9 @@ func (c *OpenShiftClient) GetUserInfo(ctx context.Context, accessToken string, g
 	return info, nil
 }
 
+// checkGroupMemberships queries OpenShift Group CRs using the bridge's own SA token
+// to determine which of the given groupNames contain the specified username.
+// Returns the subset of groupNames the user belongs to.
 func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username string, groupNames []string) ([]string, error) {
 	apiURL := c.kubeAPIURL()
 

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -53,7 +53,13 @@ func NewOpenShiftClient(oauthServerURL, clientID, clientSecret string) *OpenShif
 		oauthServerURL: strings.TrimRight(oauthServerURL, "/"),
 		clientID:       clientID,
 		clientSecret:   clientSecret,
-		httpClient:     &http.Client{Transport: transport, Timeout: 30 * time.Second},
+		httpClient: &http.Client{
+			Transport: transport,
+			Timeout:   30 * time.Second,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
 	}
 }
 
@@ -209,9 +215,9 @@ func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username st
 			continue
 		}
 		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<10))
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<10))
 			_ = resp.Body.Close()
-			return nil, fmt.Errorf("group lookup for %s failed (%d): %s", groupName, resp.StatusCode, string(body))
+			return nil, fmt.Errorf("group lookup for %s failed with status %d", groupName, resp.StatusCode)
 		}
 
 		var group struct {

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -155,7 +155,15 @@ func (c *OpenShiftClient) GetUserInfo(ctx context.Context, accessToken string, g
 		if err != nil {
 			return nil, fmt.Errorf("group CR lookup for %s: %w", info.Name, err)
 		}
-		info.Groups = append(info.Groups, extraGroups...)
+		seen := make(map[string]bool, len(info.Groups))
+		for _, g := range info.Groups {
+			seen[g] = true
+		}
+		for _, g := range extraGroups {
+			if !seen[g] {
+				info.Groups = append(info.Groups, g)
+			}
+		}
 	}
 
 	return info, nil
@@ -177,6 +185,8 @@ func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username st
 	}
 	saToken := strings.TrimSpace(string(rawToken))
 
+	// groupNames is expected to be a small set (typically ≤2: UserGroup + AdminGroup),
+	// so sequential lookups are fine.
 	var matched []string
 	for _, groupName := range groupNames {
 		if groupName == "" {

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -110,6 +110,9 @@ type UserInfo struct {
 	Groups []string `json:"groups"`
 }
 
+// GetUserInfo retrieves user info from the OpenShift users/~ API. For ServiceAccount
+// identities, it additionally checks membership in the specified groupNames by querying
+// Group CRs directly, since the users/~ endpoint does not return custom group memberships for SAs.
 func (c *OpenShiftClient) GetUserInfo(ctx context.Context, accessToken string, groupNames ...string) (*UserInfo, error) {
 	apiURL := c.kubeAPIURL()
 
@@ -165,10 +168,11 @@ func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username st
 	if tokenPath == "" {
 		tokenPath = defaultSATokenPath
 	}
-	saToken, err := os.ReadFile(tokenPath)
+	rawToken, err := os.ReadFile(tokenPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading service account token: %w", err)
 	}
+	saToken := strings.TrimSpace(string(rawToken))
 
 	var matched []string
 	for _, groupName := range groupNames {
@@ -180,7 +184,7 @@ func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username st
 		if err != nil {
 			return nil, err
 		}
-		req.Header.Set("Authorization", "Bearer "+string(saToken))
+		req.Header.Set("Authorization", "Bearer "+saToken)
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -135,7 +135,10 @@ func (c *OpenShiftClient) GetUserInfo(ctx context.Context, accessToken string, g
 	if err != nil {
 		return nil, fmt.Errorf("user info request: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -165,7 +165,7 @@ func (c *OpenShiftClient) GetUserInfo(ctx context.Context, accessToken string, g
 	if strings.HasPrefix(info.Name, "system:serviceaccount:") && len(groupNames) > 0 {
 		extraGroups, err := c.checkGroupMemberships(ctx, info.Name, groupNames)
 		if err != nil {
-			return nil, fmt.Errorf("group CR lookup for %s: %w", info.Name, err)
+			return nil, fmt.Errorf("group CR lookup for %q: %w", info.Name, err)
 		}
 		seen := make(map[string]bool, len(info.Groups))
 		for _, g := range info.Groups {
@@ -209,7 +209,7 @@ func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username st
 
 		resp, err := c.saHTTPClient.Do(req)
 		if err != nil {
-			return nil, fmt.Errorf("group lookup for %s: %w", groupName, err)
+			return nil, fmt.Errorf("group lookup for %q: %w", groupName, err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -220,7 +220,7 @@ func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username st
 		if resp.StatusCode != http.StatusOK {
 			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<10))
 			_ = resp.Body.Close()
-			return nil, fmt.Errorf("group lookup for %s failed with status %d", groupName, resp.StatusCode)
+			return nil, fmt.Errorf("group lookup for %q failed with status %d", groupName, resp.StatusCode)
 		}
 
 		var group struct {

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -108,7 +108,7 @@ type UserInfo struct {
 	Groups []string `json:"groups"`
 }
 
-func (c *OpenShiftClient) GetUserInfo(ctx context.Context, accessToken string) (*UserInfo, error) {
+func (c *OpenShiftClient) GetUserInfo(ctx context.Context, accessToken string, groupNames ...string) (*UserInfo, error) {
 	apiURL := os.Getenv("KUBERNETES_API_URL")
 	if apiURL == "" {
 		apiURL = "https://kubernetes.default.svc:443"
@@ -150,7 +150,7 @@ func (c *OpenShiftClient) GetUserInfo(ctx context.Context, accessToken string) (
 	}
 
 	if strings.HasPrefix(info.Name, "system:serviceaccount:") {
-		extraGroups, err := c.getGroupMemberships(ctx, info.Name)
+		extraGroups, err := c.checkGroupMemberships(ctx, info.Name, groupNames)
 		if err != nil {
 			log.Printf("warning: group CR lookup failed for %s: %v", info.Name, err)
 		} else {
@@ -161,54 +161,64 @@ func (c *OpenShiftClient) GetUserInfo(ctx context.Context, accessToken string) (
 	return info, nil
 }
 
-func (c *OpenShiftClient) getGroupMemberships(ctx context.Context, username string) ([]string, error) {
-	apiURL := os.Getenv("KUBERNETES_API_URL")
-	if apiURL == "" {
-		apiURL = "https://kubernetes.default.svc:443"
-	}
-	apiURL = strings.TrimRight(apiURL, "/")
+func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username string, groupNames []string) ([]string, error) {
+	apiURL := c.kubeAPIURL()
 
 	saToken, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
 	if err != nil {
 		return nil, fmt.Errorf("reading service account token: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", apiURL+"/apis/user.openshift.io/v1/groups", nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+string(saToken))
+	var matched []string
+	for _, groupName := range groupNames {
+		if groupName == "" {
+			continue
+		}
+		req, err := http.NewRequestWithContext(ctx, "GET",
+			apiURL+"/apis/user.openshift.io/v1/groups/"+url.PathEscape(groupName), nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+string(saToken))
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("group list request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("group lookup for %s: %w", groupName, err)
+		}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("group list failed (%d)", resp.StatusCode)
-	}
+		if resp.StatusCode == http.StatusNotFound {
+			_ = resp.Body.Close()
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<10))
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("group lookup for %s failed (%d): %s", groupName, resp.StatusCode, string(body))
+		}
 
-	var groupList struct {
-		Items []struct {
-			Metadata struct {
-				Name string `json:"name"`
-			} `json:"metadata"`
+		var group struct {
 			Users []string `json:"users"`
-		} `json:"items"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&groupList); err != nil {
-		return nil, fmt.Errorf("decoding group list: %w", err)
-	}
+		}
+		err = json.NewDecoder(resp.Body).Decode(&group)
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("decoding group %s: %w", groupName, err)
+		}
 
-	var groups []string
-	for _, g := range groupList.Items {
-		for _, u := range g.Users {
+		for _, u := range group.Users {
 			if u == username {
-				groups = append(groups, g.Metadata.Name)
+				matched = append(matched, groupName)
 				break
 			}
 		}
 	}
-	return groups, nil
+	return matched, nil
+}
+
+func (c *OpenShiftClient) kubeAPIURL() string {
+	apiURL := os.Getenv("KUBERNETES_API_URL")
+	if apiURL == "" {
+		apiURL = "https://kubernetes.default.svc:443"
+	}
+	return strings.TrimRight(apiURL, "/")
 }

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -193,7 +193,7 @@ func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username st
 		var group struct {
 			Users []string `json:"users"`
 		}
-		err = json.NewDecoder(resp.Body).Decode(&group)
+		err = json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&group)
 		_ = resp.Body.Close()
 		if err != nil {
 			return nil, fmt.Errorf("decoding group %s: %w", groupName, err)

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -37,6 +37,7 @@ type OpenShiftClient struct {
 	clientID       string
 	clientSecret   string
 	httpClient     *http.Client
+	saHTTPClient   *http.Client
 	SATokenPath    string
 }
 
@@ -53,13 +54,15 @@ func NewOpenShiftClient(oauthServerURL, clientID, clientSecret string) *OpenShif
 		oauthServerURL: strings.TrimRight(oauthServerURL, "/"),
 		clientID:       clientID,
 		clientSecret:   clientSecret,
-		httpClient: &http.Client{
+		httpClient:     &http.Client{Transport: transport, Timeout: 30 * time.Second},
+		saHTTPClient: &http.Client{
 			Transport: transport,
 			Timeout:   30 * time.Second,
 			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
 		},
+		SATokenPath: defaultSATokenPath,
 	}
 }
 
@@ -181,11 +184,7 @@ func (c *OpenShiftClient) GetUserInfo(ctx context.Context, accessToken string, g
 func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username string, groupNames []string) ([]string, error) {
 	apiURL := c.kubeAPIURL()
 
-	tokenPath := c.SATokenPath
-	if tokenPath == "" {
-		tokenPath = defaultSATokenPath
-	}
-	rawToken, err := os.ReadFile(tokenPath)
+	rawToken, err := os.ReadFile(c.SATokenPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading service account token: %w", err)
 	}
@@ -205,7 +204,7 @@ func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username st
 		}
 		req.Header.Set("Authorization", "Bearer "+saToken)
 
-		resp, err := c.httpClient.Do(req)
+		resp, err := c.saHTTPClient.Do(req)
 		if err != nil {
 			return nil, fmt.Errorf("group lookup for %s: %w", groupName, err)
 		}

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -189,7 +189,7 @@ func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username st
 
 	rawToken, err := os.ReadFile(c.SATokenPath)
 	if err != nil {
-		return nil, fmt.Errorf("reading service account token: %w", err)
+		return nil, fmt.Errorf("reading service account token failed")
 	}
 	saToken := strings.TrimSpace(string(rawToken))
 	if saToken == "" {

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -109,11 +109,7 @@ type UserInfo struct {
 }
 
 func (c *OpenShiftClient) GetUserInfo(ctx context.Context, accessToken string, groupNames ...string) (*UserInfo, error) {
-	apiURL := os.Getenv("KUBERNETES_API_URL")
-	if apiURL == "" {
-		apiURL = "https://kubernetes.default.svc:443"
-	}
-	apiURL = strings.TrimRight(apiURL, "/")
+	apiURL := c.kubeAPIURL()
 
 	req, err := http.NewRequestWithContext(ctx, "GET", apiURL+"/apis/user.openshift.io/v1/users/~", nil)
 	if err != nil {

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -141,7 +141,7 @@ func (c *OpenShiftClient) GetUserInfo(ctx context.Context, accessToken string, g
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		return nil, fmt.Errorf("user info failed (%d): %s", resp.StatusCode, string(body))
 	}
 
@@ -230,6 +230,7 @@ func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username st
 			Users []string `json:"users"`
 		}
 		err = json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&group)
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<10))
 		_ = resp.Body.Close()
 		if err != nil {
 			return nil, fmt.Errorf("decoding group %s: %w", groupName, err)

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -30,11 +30,14 @@ import (
 	"time"
 )
 
+const defaultSATokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
 type OpenShiftClient struct {
 	oauthServerURL string
 	clientID       string
 	clientSecret   string
 	httpClient     *http.Client
+	SATokenPath    string
 }
 
 func NewOpenShiftClient(oauthServerURL, clientID, clientSecret string) *OpenShiftClient {
@@ -158,7 +161,11 @@ func (c *OpenShiftClient) GetUserInfo(ctx context.Context, accessToken string, g
 func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username string, groupNames []string) ([]string, error) {
 	apiURL := c.kubeAPIURL()
 
-	saToken, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	tokenPath := c.SATokenPath
+	if tokenPath == "" {
+		tokenPath = defaultSATokenPath
+	}
+	saToken, err := os.ReadFile(tokenPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading service account token: %w", err)
 	}

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -193,7 +193,7 @@ func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username st
 	}
 	saToken := strings.TrimSpace(string(rawToken))
 	if saToken == "" {
-		return nil, fmt.Errorf("service account token file %s is empty", c.SATokenPath)
+		return nil, fmt.Errorf("service account token file is empty")
 	}
 
 	// groupNames is expected to be a small set (typically ≤2: UserGroup + AdminGroup),

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -149,8 +150,10 @@ func (c *OpenShiftClient) GetUserInfo(ctx context.Context, accessToken string) (
 	}
 
 	if strings.HasPrefix(info.Name, "system:serviceaccount:") {
-		extraGroups, err := c.getGroupMemberships(ctx, accessToken, info.Name)
-		if err == nil {
+		extraGroups, err := c.getGroupMemberships(ctx, info.Name)
+		if err != nil {
+			log.Printf("warning: group CR lookup failed for %s: %v", info.Name, err)
+		} else {
 			info.Groups = append(info.Groups, extraGroups...)
 		}
 	}
@@ -158,7 +161,7 @@ func (c *OpenShiftClient) GetUserInfo(ctx context.Context, accessToken string) (
 	return info, nil
 }
 
-func (c *OpenShiftClient) getGroupMemberships(ctx context.Context, _ string, username string) ([]string, error) {
+func (c *OpenShiftClient) getGroupMemberships(ctx context.Context, username string) ([]string, error) {
 	apiURL := os.Getenv("KUBERNETES_API_URL")
 	if apiURL == "" {
 		apiURL = "https://kubernetes.default.svc:443"

--- a/internal/authbridge/server.go
+++ b/internal/authbridge/server.go
@@ -229,7 +229,7 @@ func (s *Server) handleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userInfo, err := s.osc.GetUserInfo(r.Context(), tokenResp.AccessToken)
+	userInfo, err := s.osc.GetUserInfo(r.Context(), tokenResp.AccessToken, s.config.UserGroup, s.config.AdminGroup)
 	if err != nil {
 		log.Printf("user info failed: %v", err)
 		http.Error(w, "failed to get user info", http.StatusInternalServerError)
@@ -342,7 +342,7 @@ func (s *Server) handleTokenExchange(w http.ResponseWriter, r *http.Request) {
 	}
 	ocpToken := strings.TrimPrefix(auth, "Bearer ")
 
-	userInfo, err := s.osc.GetUserInfo(r.Context(), ocpToken)
+	userInfo, err := s.osc.GetUserInfo(r.Context(), ocpToken, s.config.UserGroup, s.config.AdminGroup)
 	if err != nil {
 		log.Printf("token exchange: user info failed: %v", err)
 		http.Error(w, `{"error":"invalid OpenShift token"}`, http.StatusUnauthorized)

--- a/internal/authbridge/server.go
+++ b/internal/authbridge/server.go
@@ -229,7 +229,7 @@ func (s *Server) handleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userInfo, err := s.osc.GetUserInfo(r.Context(), tokenResp.AccessToken)
+	userInfo, err := s.osc.GetUserInfo(r.Context(), tokenResp.AccessToken, s.config.UserGroup, s.config.AdminGroup)
 	if err != nil {
 		log.Printf("user info failed: %v", err)
 		http.Error(w, "failed to get user info", http.StatusInternalServerError)

--- a/internal/authbridge/server.go
+++ b/internal/authbridge/server.go
@@ -229,7 +229,7 @@ func (s *Server) handleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userInfo, err := s.osc.GetUserInfo(r.Context(), tokenResp.AccessToken, s.config.UserGroup, s.config.AdminGroup)
+	userInfo, err := s.osc.GetUserInfo(r.Context(), tokenResp.AccessToken)
 	if err != nil {
 		log.Printf("user info failed: %v", err)
 		http.Error(w, "failed to get user info", http.StatusInternalServerError)

--- a/internal/authbridge/server_test.go
+++ b/internal/authbridge/server_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package authbridge
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -542,7 +543,7 @@ func TestCheckGroupMemberships(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			matched, err := osc.checkGroupMemberships(t.Context(), tt.username, tt.groups)
+			matched, err := osc.checkGroupMemberships(context.Background(), tt.username, tt.groups)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/internal/authbridge/server_test.go
+++ b/internal/authbridge/server_test.go
@@ -435,16 +435,12 @@ func TestTokenExchangeServiceAccountGroupLookup(t *testing.T) {
 	t.Setenv("KUBERNETES_API_URL", mock.URL)
 
 	tokenFile := t.TempDir() + "/token"
-	if err := os.WriteFile(tokenFile, []byte("sa-bridge-token"), 0600); err != nil {
+	if err := os.WriteFile(tokenFile, []byte("bridge-sa-token"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	origPath := "/var/run/secrets/kubernetes.io/serviceaccount/token"
-	// Override the SA token path via a symlink in the test's temp dir
-	// Since we can't override the hardcoded path, we use KUBERNETES_API_URL
-	// and the mock accepts any bearer token for the groups endpoint
-	_ = origPath
 
 	s := testServer(t)
+	s.osc.SATokenPath = tokenFile
 	handler := s.Handler()
 
 	req := httptest.NewRequest("POST", "/token/exchange", nil)
@@ -452,22 +448,16 @@ func TestTokenExchangeServiceAccountGroupLookup(t *testing.T) {
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 
-	// The SA token file read will fail in test (no /var/run/secrets/...),
-	// so checkGroupMemberships returns an error, which now propagates.
-	// This validates the error propagation path.
-	if w.Code == http.StatusOK {
-		// If we somehow got 200, verify the token was issued
-		var resp map[string]interface{}
-		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if resp["access_token"] == nil || resp["access_token"] == "" {
-			t.Error("access_token is empty")
-		}
-	} else if w.Code != http.StatusUnauthorized {
-		// Expected: 401 because SA token file doesn't exist in test env,
-		// causing checkGroupMemberships to fail and GetUserInfo to return error
-		t.Errorf("status = %d, want 200 or 401, body: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["access_token"] == nil || resp["access_token"] == "" {
+		t.Error("access_token is empty")
 	}
 }
 
@@ -488,7 +478,13 @@ func TestTokenExchangeServiceAccountNotInGroup(t *testing.T) {
 
 	t.Setenv("KUBERNETES_API_URL", mock.URL)
 
+	tokenFile := t.TempDir() + "/token"
+	if err := os.WriteFile(tokenFile, []byte("bridge-sa-token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
 	s := testServer(t)
+	s.osc.SATokenPath = tokenFile
 	handler := s.Handler()
 
 	req := httptest.NewRequest("POST", "/token/exchange", nil)
@@ -496,10 +492,8 @@ func TestTokenExchangeServiceAccountNotInGroup(t *testing.T) {
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 
-	// SA token file won't exist, so this will fail with 401 (error propagation)
-	// In a real cluster, it would reach the group check and get 403 (not in group)
-	if w.Code != http.StatusUnauthorized && w.Code != http.StatusForbidden {
-		t.Errorf("status = %d, want 401 or 403 for SA not in group", w.Code)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for SA not in group, body: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -512,8 +506,6 @@ func TestCheckGroupMemberships(t *testing.T) {
 		case "/apis/user.openshift.io/v1/groups/openshell-admins":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"metadata":{"name":"openshell-admins"},"users":["alice"]}`))
-		case "/apis/user.openshift.io/v1/groups/nonexistent":
-			http.Error(w, "not found", http.StatusNotFound)
 		default:
 			http.Error(w, "not found", http.StatusNotFound)
 		}
@@ -522,45 +514,41 @@ func TestCheckGroupMemberships(t *testing.T) {
 
 	t.Setenv("KUBERNETES_API_URL", mock.URL)
 
-	// Create a fake SA token file
-	tokenDir := t.TempDir()
-	tokenFile := tokenDir + "/token"
+	tokenFile := t.TempDir() + "/token"
 	if err := os.WriteFile(tokenFile, []byte("fake-sa-token"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
 	osc := NewOpenShiftClient(mock.URL, "test", "test")
+	osc.SATokenPath = tokenFile
 
-	// We can't easily override the hardcoded token path, so test the
-	// mock HTTP serving directly
 	tests := []struct {
-		name       string
-		username   string
-		groups     []string
-		wantMatch  []string
-		wantErr    bool
+		name      string
+		username  string
+		groups    []string
+		wantMatch []string
 	}{
-		{"SA in user group", "system:serviceaccount:ns:mysa", []string{"openshell-users"}, []string{"openshell-users"}, false},
-		{"SA not in admin group", "system:serviceaccount:ns:mysa", []string{"openshell-admins"}, nil, false},
-		{"SA in user but not admin", "system:serviceaccount:ns:mysa", []string{"openshell-users", "openshell-admins"}, []string{"openshell-users"}, false},
-		{"nonexistent group", "system:serviceaccount:ns:mysa", []string{"nonexistent"}, nil, false},
-		{"empty groups", "system:serviceaccount:ns:mysa", []string{}, nil, false},
-		{"empty string group", "system:serviceaccount:ns:mysa", []string{""}, nil, false},
+		{"SA in user group", "system:serviceaccount:ns:mysa", []string{"openshell-users"}, []string{"openshell-users"}},
+		{"SA not in admin group", "system:serviceaccount:ns:mysa", []string{"openshell-admins"}, nil},
+		{"SA in user but not admin", "system:serviceaccount:ns:mysa", []string{"openshell-users", "openshell-admins"}, []string{"openshell-users"}},
+		{"nonexistent group", "system:serviceaccount:ns:mysa", []string{"nonexistent"}, nil},
+		{"empty groups", "system:serviceaccount:ns:mysa", []string{}, nil},
+		{"empty string group", "system:serviceaccount:ns:mysa", []string{""}, nil},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// checkGroupMemberships reads SA token from disk, which won't work
-			// in tests. Test the HTTP mock behavior directly instead.
-			for _, groupName := range tt.groups {
-				if groupName == "" {
-					continue
+			matched, err := osc.checkGroupMemberships(t.Context(), tt.username, tt.groups)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(matched) != len(tt.wantMatch) {
+				t.Errorf("matched = %v, want %v", matched, tt.wantMatch)
+			}
+			for i := range matched {
+				if i < len(tt.wantMatch) && matched[i] != tt.wantMatch[i] {
+					t.Errorf("matched[%d] = %q, want %q", i, matched[i], tt.wantMatch[i])
 				}
-				resp, err := osc.httpClient.Get(mock.URL + "/apis/user.openshift.io/v1/groups/" + groupName)
-				if err != nil {
-					t.Fatalf("group lookup: %v", err)
-				}
-				_ = resp.Body.Close()
 			}
 		})
 	}

--- a/internal/authbridge/server_test.go
+++ b/internal/authbridge/server_test.go
@@ -424,6 +424,10 @@ func TestTokenExchangeServiceAccountGroupLookup(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"metadata":{"name":"system:serviceaccount:mynamespace:mysa","uid":"uid-sa"},"groups":["system:authenticated","system:serviceaccounts","system:serviceaccounts:mynamespace"]}`))
 		case "/apis/user.openshift.io/v1/groups/openshell-users":
+			if r.Header.Get("Authorization") != "Bearer bridge-sa-token" {
+				http.Error(w, "forbidden: wrong token for group lookup", http.StatusForbidden)
+				return
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"metadata":{"name":"openshell-users"},"users":["system:serviceaccount:mynamespace:mysa","alice"]}`))
 		default:

--- a/internal/authbridge/server_test.go
+++ b/internal/authbridge/server_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -408,6 +409,160 @@ func TestTokenExchangeRejectsInvalidToken(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want 401 for invalid token", w.Code)
+	}
+}
+
+func TestTokenExchangeServiceAccountGroupLookup(t *testing.T) {
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/apis/user.openshift.io/v1/users/~":
+			auth := r.Header.Get("Authorization")
+			if auth != "Bearer sa-token-123" {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"metadata":{"name":"system:serviceaccount:mynamespace:mysa","uid":"uid-sa"},"groups":["system:authenticated","system:serviceaccounts","system:serviceaccounts:mynamespace"]}`))
+		case "/apis/user.openshift.io/v1/groups/openshell-users":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"metadata":{"name":"openshell-users"},"users":["system:serviceaccount:mynamespace:mysa","alice"]}`))
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer mock.Close()
+
+	t.Setenv("KUBERNETES_API_URL", mock.URL)
+
+	tokenFile := t.TempDir() + "/token"
+	if err := os.WriteFile(tokenFile, []byte("sa-bridge-token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	origPath := "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	// Override the SA token path via a symlink in the test's temp dir
+	// Since we can't override the hardcoded path, we use KUBERNETES_API_URL
+	// and the mock accepts any bearer token for the groups endpoint
+	_ = origPath
+
+	s := testServer(t)
+	handler := s.Handler()
+
+	req := httptest.NewRequest("POST", "/token/exchange", nil)
+	req.Header.Set("Authorization", "Bearer sa-token-123")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// The SA token file read will fail in test (no /var/run/secrets/...),
+	// so checkGroupMemberships returns an error, which now propagates.
+	// This validates the error propagation path.
+	if w.Code == http.StatusOK {
+		// If we somehow got 200, verify the token was issued
+		var resp map[string]interface{}
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp["access_token"] == nil || resp["access_token"] == "" {
+			t.Error("access_token is empty")
+		}
+	} else if w.Code != http.StatusUnauthorized {
+		// Expected: 401 because SA token file doesn't exist in test env,
+		// causing checkGroupMemberships to fail and GetUserInfo to return error
+		t.Errorf("status = %d, want 200 or 401, body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestTokenExchangeServiceAccountNotInGroup(t *testing.T) {
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/apis/user.openshift.io/v1/users/~":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"metadata":{"name":"system:serviceaccount:other:stranger","uid":"uid-stranger"},"groups":["system:authenticated","system:serviceaccounts"]}`))
+		case "/apis/user.openshift.io/v1/groups/openshell-users":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"metadata":{"name":"openshell-users"},"users":["alice"]}`))
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer mock.Close()
+
+	t.Setenv("KUBERNETES_API_URL", mock.URL)
+
+	s := testServer(t)
+	handler := s.Handler()
+
+	req := httptest.NewRequest("POST", "/token/exchange", nil)
+	req.Header.Set("Authorization", "Bearer stranger-token")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// SA token file won't exist, so this will fail with 401 (error propagation)
+	// In a real cluster, it would reach the group check and get 403 (not in group)
+	if w.Code != http.StatusUnauthorized && w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 401 or 403 for SA not in group", w.Code)
+	}
+}
+
+func TestCheckGroupMemberships(t *testing.T) {
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/apis/user.openshift.io/v1/groups/openshell-users":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"metadata":{"name":"openshell-users"},"users":["system:serviceaccount:ns:mysa","alice"]}`))
+		case "/apis/user.openshift.io/v1/groups/openshell-admins":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"metadata":{"name":"openshell-admins"},"users":["alice"]}`))
+		case "/apis/user.openshift.io/v1/groups/nonexistent":
+			http.Error(w, "not found", http.StatusNotFound)
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer mock.Close()
+
+	t.Setenv("KUBERNETES_API_URL", mock.URL)
+
+	// Create a fake SA token file
+	tokenDir := t.TempDir()
+	tokenFile := tokenDir + "/token"
+	if err := os.WriteFile(tokenFile, []byte("fake-sa-token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	osc := NewOpenShiftClient(mock.URL, "test", "test")
+
+	// We can't easily override the hardcoded token path, so test the
+	// mock HTTP serving directly
+	tests := []struct {
+		name       string
+		username   string
+		groups     []string
+		wantMatch  []string
+		wantErr    bool
+	}{
+		{"SA in user group", "system:serviceaccount:ns:mysa", []string{"openshell-users"}, []string{"openshell-users"}, false},
+		{"SA not in admin group", "system:serviceaccount:ns:mysa", []string{"openshell-admins"}, nil, false},
+		{"SA in user but not admin", "system:serviceaccount:ns:mysa", []string{"openshell-users", "openshell-admins"}, []string{"openshell-users"}, false},
+		{"nonexistent group", "system:serviceaccount:ns:mysa", []string{"nonexistent"}, nil, false},
+		{"empty groups", "system:serviceaccount:ns:mysa", []string{}, nil, false},
+		{"empty string group", "system:serviceaccount:ns:mysa", []string{""}, nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// checkGroupMemberships reads SA token from disk, which won't work
+			// in tests. Test the HTTP mock behavior directly instead.
+			for _, groupName := range tt.groups {
+				if groupName == "" {
+					continue
+				}
+				resp, err := osc.httpClient.Get(mock.URL + "/apis/user.openshift.io/v1/groups/" + groupName)
+				if err != nil {
+					t.Fatalf("group lookup: %v", err)
+				}
+				_ = resp.Body.Close()
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix auth-bridge `/token/exchange` rejecting ServiceAccount identities even when they are members of the required OpenShift Group
- Root cause: the `users/~` self-lookup API only returns synthetic groups for ServiceAccounts, never custom Group CR memberships
- Fix: when the identity is a ServiceAccount, query Group CRs directly using the auth-bridge's own SA token and check the `users[]` array

Unblocks unattended access to the gateway via token exchange (AAP job templates, CI pipelines).

## Test plan

- [ ] SA in `openshell-users` group can exchange token: `curl -X POST /token/exchange -H "Authorization: Bearer <sa-token>"`
- [ ] Human user OAuth login still works
- [ ] SA NOT in group is still rejected

Generated with [Claude Code](https://claude.com/claude-code)