### PR TITLE
fix: decode b64-encoded SA names in OpenShift Group membership

### DIFF
--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -237,7 +238,13 @@ func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username st
 		}
 
 		for _, u := range group.Users {
-			if u == username {
+			candidate := u
+			if strings.HasPrefix(u, "b64:") {
+				if decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(u, "b64:")); err == nil {
+					candidate = string(decoded)
+				}
+			}
+			if candidate == username {
 				matched = append(matched, groupName)
 				break
 			}

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -245,9 +245,10 @@ func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username st
 				if err != nil {
 					decoded, err = base64.RawStdEncoding.DecodeString(encoded)
 				}
-				if err == nil {
-					candidate = string(decoded)
+				if err != nil {
+					continue
 				}
+				candidate = string(decoded)
 			}
 			if candidate == username {
 				matched = append(matched, groupName)

--- a/internal/authbridge/openshift.go
+++ b/internal/authbridge/openshift.go
@@ -240,7 +240,12 @@ func (c *OpenShiftClient) checkGroupMemberships(ctx context.Context, username st
 		for _, u := range group.Users {
 			candidate := u
 			if strings.HasPrefix(u, "b64:") {
-				if decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(u, "b64:")); err == nil {
+				encoded := strings.TrimPrefix(u, "b64:")
+				decoded, err := base64.StdEncoding.DecodeString(encoded)
+				if err != nil {
+					decoded, err = base64.RawStdEncoding.DecodeString(encoded)
+				}
+				if err == nil {
 					candidate = string(decoded)
 				}
 			}

--- a/internal/authbridge/server_test.go
+++ b/internal/authbridge/server_test.go
@@ -507,7 +507,8 @@ func TestCheckGroupMemberships(t *testing.T) {
 		switch r.URL.Path {
 		case "/apis/user.openshift.io/v1/groups/openshell-users":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"metadata":{"name":"openshell-users"},"users":["system:serviceaccount:ns:mysa","alice"]}`))
+			// OpenShift stores SA names with colons as b64-encoded entries
+			_, _ = w.Write([]byte(`{"metadata":{"name":"openshell-users"},"users":["b64:c3lzdGVtOnNlcnZpY2VhY2NvdW50Om5zOm15c2E=","alice"]}`))
 		case "/apis/user.openshift.io/v1/groups/openshell-admins":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"metadata":{"name":"openshell-admins"},"users":["alice"]}`))

--- a/internal/authbridge/server_test.go
+++ b/internal/authbridge/server_test.go
@@ -507,8 +507,8 @@ func TestCheckGroupMemberships(t *testing.T) {
 		switch r.URL.Path {
 		case "/apis/user.openshift.io/v1/groups/openshell-users":
 			w.Header().Set("Content-Type", "application/json")
-			// OpenShift stores SA names with colons as b64-encoded entries; include both plain and encoded
-			_, _ = w.Write([]byte(`{"metadata":{"name":"openshell-users"},"users":["b64:c3lzdGVtOnNlcnZpY2VhY2NvdW50Om5zOm15c2E=","system:serviceaccount:ns:mysa-plain","alice"]}`))
+			// OpenShift stores SA names with colons as b64-encoded entries; include plain, encoded, and invalid
+			_, _ = w.Write([]byte(`{"metadata":{"name":"openshell-users"},"users":["b64:c3lzdGVtOnNlcnZpY2VhY2NvdW50Om5zOm15c2E=","system:serviceaccount:ns:mysa-plain","b64:!!!invalid","alice"]}`))
 		case "/apis/user.openshift.io/v1/groups/openshell-admins":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"metadata":{"name":"openshell-admins"},"users":["alice"]}`))
@@ -538,6 +538,7 @@ func TestCheckGroupMemberships(t *testing.T) {
 		{"SA in user group via plain", "system:serviceaccount:ns:mysa-plain", []string{"openshell-users"}, []string{"openshell-users"}},
 		{"SA not in admin group", "system:serviceaccount:ns:mysa", []string{"openshell-admins"}, nil},
 		{"SA in user but not admin", "system:serviceaccount:ns:mysa", []string{"openshell-users", "openshell-admins"}, []string{"openshell-users"}},
+		{"invalid b64 entry skipped", "!!!invalid", []string{"openshell-users"}, nil},
 		{"nonexistent group", "system:serviceaccount:ns:mysa", []string{"nonexistent"}, nil},
 		{"empty groups", "system:serviceaccount:ns:mysa", []string{}, nil},
 		{"empty string group", "system:serviceaccount:ns:mysa", []string{""}, nil},

--- a/internal/authbridge/server_test.go
+++ b/internal/authbridge/server_test.go
@@ -507,8 +507,8 @@ func TestCheckGroupMemberships(t *testing.T) {
 		switch r.URL.Path {
 		case "/apis/user.openshift.io/v1/groups/openshell-users":
 			w.Header().Set("Content-Type", "application/json")
-			// OpenShift stores SA names with colons as b64-encoded entries
-			_, _ = w.Write([]byte(`{"metadata":{"name":"openshell-users"},"users":["b64:c3lzdGVtOnNlcnZpY2VhY2NvdW50Om5zOm15c2E=","alice"]}`))
+			// OpenShift stores SA names with colons as b64-encoded entries; include both plain and encoded
+			_, _ = w.Write([]byte(`{"metadata":{"name":"openshell-users"},"users":["b64:c3lzdGVtOnNlcnZpY2VhY2NvdW50Om5zOm15c2E=","system:serviceaccount:ns:mysa-plain","alice"]}`))
 		case "/apis/user.openshift.io/v1/groups/openshell-admins":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"metadata":{"name":"openshell-admins"},"users":["alice"]}`))
@@ -534,7 +534,8 @@ func TestCheckGroupMemberships(t *testing.T) {
 		groups    []string
 		wantMatch []string
 	}{
-		{"SA in user group", "system:serviceaccount:ns:mysa", []string{"openshell-users"}, []string{"openshell-users"}},
+		{"SA in user group via b64", "system:serviceaccount:ns:mysa", []string{"openshell-users"}, []string{"openshell-users"}},
+		{"SA in user group via plain", "system:serviceaccount:ns:mysa-plain", []string{"openshell-users"}, []string{"openshell-users"}},
 		{"SA not in admin group", "system:serviceaccount:ns:mysa", []string{"openshell-admins"}, nil},
 		{"SA in user but not admin", "system:serviceaccount:ns:mysa", []string{"openshell-users", "openshell-admins"}, []string{"openshell-users"}},
 		{"nonexistent group", "system:serviceaccount:ns:mysa", []string{"nonexistent"}, nil},


### PR DESCRIPTION
## Summary

- Fix SA group membership check failing because OpenShift stores ServiceAccount names with colons as `b64:`-prefixed base64-encoded entries in Group CR `users[]` arrays
- The raw string comparison (`u == username`) never matched because `b64:c3lzdGVtOnNlcnZpY2VhY2NvdW50Om5zOm15c2E=` != `system:serviceaccount:ns:mysa`
- Decode `b64:`-prefixed entries before comparing

Discovered during live testing on RDU — not catchable by diff-based review.

## Test plan

- [x] TestCheckGroupMemberships passes with b64-encoded mock entries
- [ ] SA token exchange succeeds on RDU after deploy

Generated with [Claude Code](https://claude.com/claude-code)