### PR TITLE
fix: sync OAuthClient and cert-manager Certificate drift on every reconcile

### DIFF
--- a/internal/controller/openshellgateway_controller.go
+++ b/internal/controller/openshellgateway_controller.go
@@ -1116,10 +1116,7 @@ func (r *OpenShellGatewayReconciler) reconcileGatewayTLSCert(ctx context.Context
 	existing := &unstructured.Unstructured{}
 	existing.SetGroupVersionKind(schema.GroupVersionKind{Group: "cert-manager.io", Version: "v1", Kind: "Certificate"})
 	err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: ns}, existing)
-	if err == nil {
-		return nil
-	}
-	if !apierrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		if _, discoveryErr := r.DiscoveryClient.ServerResourcesForGroupVersion("cert-manager.io/v1"); discoveryErr != nil {
 			return fmt.Errorf("cert-manager CRDs not installed — required for Gateway API TLS")
 		}
@@ -1135,20 +1132,35 @@ func (r *OpenShellGatewayReconciler) reconcileGatewayTLSCert(ctx context.Context
 		issuerKind = "ClusterIssuer"
 	}
 
-	cert := &unstructured.Unstructured{}
-	cert.SetGroupVersionKind(schema.GroupVersionKind{Group: "cert-manager.io", Version: "v1", Kind: "Certificate"})
-	cert.SetName(secretName)
-	cert.SetNamespace(ns)
-	cert.SetLabels(gatewayLabels(gw))
-	cert.Object["spec"] = map[string]interface{}{
-		"secretName": secretName,
-		"dnsNames":   []interface{}{hostname},
-		"issuerRef": map[string]interface{}{
-			"name": issuerName,
-			"kind": issuerKind,
-		},
+	if apierrors.IsNotFound(err) {
+		cert := &unstructured.Unstructured{}
+		cert.SetGroupVersionKind(schema.GroupVersionKind{Group: "cert-manager.io", Version: "v1", Kind: "Certificate"})
+		cert.SetName(secretName)
+		cert.SetNamespace(ns)
+		cert.SetLabels(gatewayLabels(gw))
+		cert.Object["spec"] = map[string]interface{}{
+			"secretName": secretName,
+			"dnsNames":   []interface{}{hostname},
+			"issuerRef": map[string]interface{}{
+				"name": issuerName,
+				"kind": issuerKind,
+			},
+		}
+		return r.Create(ctx, cert)
 	}
-	return r.Create(ctx, cert)
+
+	// Keep the Certificate's dnsNames in sync with the current hostname —
+	// route.Hostname can change between deployments (e.g. promoting a new
+	// build to staging), and cert-manager won't reissue for a new hostname
+	// unless the Certificate spec itself is updated to request it.
+	existingDNSNames, _, _ := unstructured.NestedStringSlice(existing.Object, "spec", "dnsNames")
+	if len(existingDNSNames) == 1 && existingDNSNames[0] == hostname {
+		return nil
+	}
+	if err := unstructured.SetNestedStringSlice(existing.Object, []string{hostname}, "spec", "dnsNames"); err != nil {
+		return fmt.Errorf("updating Certificate dnsNames: %w", err)
+	}
+	return r.Update(ctx, existing)
 }
 
 func (r *OpenShellGatewayReconciler) reconcileEnvoyRoute(ctx context.Context, gw *ogov1alpha1.OpenShellGateway) error {

--- a/internal/controller/openshellgateway_controller.go
+++ b/internal/controller/openshellgateway_controller.go
@@ -21,6 +21,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -1131,6 +1132,7 @@ func (r *OpenShellGatewayReconciler) reconcileGatewayTLSCert(ctx context.Context
 	if issuerKind == "" {
 		issuerKind = "ClusterIssuer"
 	}
+	desiredDNSNames := []string{hostname}
 
 	if apierrors.IsNotFound(err) {
 		cert := &unstructured.Unstructured{}
@@ -1149,16 +1151,26 @@ func (r *OpenShellGatewayReconciler) reconcileGatewayTLSCert(ctx context.Context
 		return r.Create(ctx, cert)
 	}
 
-	// Keep the Certificate's dnsNames in sync with the current hostname —
-	// route.Hostname can change between deployments (e.g. promoting a new
-	// build to staging), and cert-manager won't reissue for a new hostname
-	// unless the Certificate spec itself is updated to request it.
+	// Keep the Certificate in sync with the CR's current desired state —
+	// route.Hostname or the issuer config can change between deployments
+	// (e.g. promoting a new build to staging), and cert-manager won't
+	// reissue for a new hostname/issuer unless the Certificate spec itself
+	// is updated to request it.
 	existingDNSNames, _, _ := unstructured.NestedStringSlice(existing.Object, "spec", "dnsNames")
-	if len(existingDNSNames) == 1 && existingDNSNames[0] == hostname {
+	existingIssuerName, _, _ := unstructured.NestedString(existing.Object, "spec", "issuerRef", "name")
+	existingIssuerKind, _, _ := unstructured.NestedString(existing.Object, "spec", "issuerRef", "kind")
+	if slices.Equal(existingDNSNames, desiredDNSNames) &&
+		existingIssuerName == issuerName && existingIssuerKind == issuerKind {
 		return nil
 	}
-	if err := unstructured.SetNestedStringSlice(existing.Object, []string{hostname}, "spec", "dnsNames"); err != nil {
+	if err := unstructured.SetNestedStringSlice(existing.Object, desiredDNSNames, "spec", "dnsNames"); err != nil {
 		return fmt.Errorf("updating Certificate dnsNames: %w", err)
+	}
+	if err := unstructured.SetNestedField(existing.Object, issuerName, "spec", "issuerRef", "name"); err != nil {
+		return fmt.Errorf("updating Certificate issuerRef.name: %w", err)
+	}
+	if err := unstructured.SetNestedField(existing.Object, issuerKind, "spec", "issuerRef", "kind"); err != nil {
+		return fmt.Errorf("updating Certificate issuerRef.kind: %w", err)
 	}
 	return r.Update(ctx, existing)
 }
@@ -1537,7 +1549,7 @@ func (r *OpenShellGatewayReconciler) reconcileOAuthClient(ctx context.Context, g
 	// that fails OIDC token exchange with "unauthorized_client".
 	existingSecret, _, _ := unstructured.NestedString(existing.Object, "secret")
 	existingRedirectURIs, _, _ := unstructured.NestedStringSlice(existing.Object, "redirectURIs")
-	if existingSecret == clientSecret && len(existingRedirectURIs) == 1 && existingRedirectURIs[0] == callbackURL {
+	if existingSecret == clientSecret && slices.Equal(existingRedirectURIs, []string{callbackURL}) {
 		return nil
 	}
 	existing.Object["secret"] = clientSecret

--- a/internal/controller/openshellgateway_controller.go
+++ b/internal/controller/openshellgateway_controller.go
@@ -1513,13 +1513,12 @@ func (r *OpenShellGatewayReconciler) reconcileOAuthClient(ctx context.Context, g
 	clientSecret := string(secret.Data["secret"])
 	callbackURL := authBridgeExternalURL(gw) + "/callback"
 
-	oauthClient := &unstructured.Unstructured{}
-	oauthClient.SetGroupVersionKind(schema.GroupVersionKind{Group: "oauth.openshift.io", Version: "v1", Kind: "OAuthClient"})
-
 	existing := &unstructured.Unstructured{}
 	existing.SetGroupVersionKind(schema.GroupVersionKind{Group: "oauth.openshift.io", Version: "v1", Kind: "OAuthClient"})
 	err = r.Get(ctx, types.NamespacedName{Name: "openshell"}, existing)
 	if apierrors.IsNotFound(err) {
+		oauthClient := &unstructured.Unstructured{}
+		oauthClient.SetGroupVersionKind(schema.GroupVersionKind{Group: "oauth.openshift.io", Version: "v1", Kind: "OAuthClient"})
 		oauthClient.SetName("openshell")
 		oauthClient.SetLabels(gatewayLabels(gw))
 		oauthClient.Object["secret"] = clientSecret
@@ -1527,7 +1526,23 @@ func (r *OpenShellGatewayReconciler) reconcileOAuthClient(ctx context.Context, g
 		oauthClient.Object["redirectURIs"] = []interface{}{callbackURL}
 		return r.Create(ctx, oauthClient)
 	}
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Keep an existing OAuthClient in sync. The namespace Secret is the
+	// source of truth and can be regenerated independently of this
+	// cluster-scoped object (e.g. a redeploy onto a fresh namespace), which
+	// must not leave the OAuthClient pointing at a stale secret/redirect —
+	// that fails OIDC token exchange with "unauthorized_client".
+	existingSecret, _, _ := unstructured.NestedString(existing.Object, "secret")
+	existingRedirectURIs, _, _ := unstructured.NestedStringSlice(existing.Object, "redirectURIs")
+	if existingSecret == clientSecret && len(existingRedirectURIs) == 1 && existingRedirectURIs[0] == callbackURL {
+		return nil
+	}
+	existing.Object["secret"] = clientSecret
+	existing.Object["redirectURIs"] = []interface{}{callbackURL}
+	return r.Update(ctx, existing)
 }
 
 func generateOAuthSecret() string {

--- a/internal/controller/openshellgateway_controller.go
+++ b/internal/controller/openshellgateway_controller.go
@@ -1156,9 +1156,18 @@ func (r *OpenShellGatewayReconciler) reconcileGatewayTLSCert(ctx context.Context
 	// (e.g. promoting a new build to staging), and cert-manager won't
 	// reissue for a new hostname/issuer unless the Certificate spec itself
 	// is updated to request it.
-	existingDNSNames, _, _ := unstructured.NestedStringSlice(existing.Object, "spec", "dnsNames")
-	existingIssuerName, _, _ := unstructured.NestedString(existing.Object, "spec", "issuerRef", "name")
-	existingIssuerKind, _, _ := unstructured.NestedString(existing.Object, "spec", "issuerRef", "kind")
+	existingDNSNames, _, err := unstructured.NestedStringSlice(existing.Object, "spec", "dnsNames")
+	if err != nil {
+		return fmt.Errorf("reading existing Certificate dnsNames: %w", err)
+	}
+	existingIssuerName, _, err := unstructured.NestedString(existing.Object, "spec", "issuerRef", "name")
+	if err != nil {
+		return fmt.Errorf("reading existing Certificate issuerRef.name: %w", err)
+	}
+	existingIssuerKind, _, err := unstructured.NestedString(existing.Object, "spec", "issuerRef", "kind")
+	if err != nil {
+		return fmt.Errorf("reading existing Certificate issuerRef.kind: %w", err)
+	}
 	if slices.Equal(existingDNSNames, desiredDNSNames) &&
 		existingIssuerName == issuerName && existingIssuerKind == issuerKind {
 		return nil
@@ -1547,13 +1556,25 @@ func (r *OpenShellGatewayReconciler) reconcileOAuthClient(ctx context.Context, g
 	// cluster-scoped object (e.g. a redeploy onto a fresh namespace), which
 	// must not leave the OAuthClient pointing at a stale secret/redirect —
 	// that fails OIDC token exchange with "unauthorized_client".
-	existingSecret, _, _ := unstructured.NestedString(existing.Object, "secret")
-	existingRedirectURIs, _, _ := unstructured.NestedStringSlice(existing.Object, "redirectURIs")
-	if existingSecret == clientSecret && slices.Equal(existingRedirectURIs, []string{callbackURL}) {
+	existingSecret, _, err := unstructured.NestedString(existing.Object, "secret")
+	if err != nil {
+		return fmt.Errorf("reading existing OAuthClient secret: %w", err)
+	}
+	existingRedirectURIs, _, err := unstructured.NestedStringSlice(existing.Object, "redirectURIs")
+	if err != nil {
+		return fmt.Errorf("reading existing OAuthClient redirectURIs: %w", err)
+	}
+	existingGrantMethod, _, err := unstructured.NestedString(existing.Object, "grantMethod")
+	if err != nil {
+		return fmt.Errorf("reading existing OAuthClient grantMethod: %w", err)
+	}
+	if existingSecret == clientSecret && slices.Equal(existingRedirectURIs, []string{callbackURL}) &&
+		existingGrantMethod == "auto" {
 		return nil
 	}
 	existing.Object["secret"] = clientSecret
 	existing.Object["redirectURIs"] = []interface{}{callbackURL}
+	existing.Object["grantMethod"] = "auto"
 	return r.Update(ctx, existing)
 }
 

--- a/internal/controller/openshellgateway_controller_test.go
+++ b/internal/controller/openshellgateway_controller_test.go
@@ -133,7 +133,7 @@ var _ = Describe("OpenShellGateway Controller", func() {
 
 		cr := &rbacv1.ClusterRole{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: gwName + "-node-reader"}, cr)).To(Succeed())
-		Expect(cr.Rules).To(HaveLen(2))
+		Expect(cr.Rules).To(HaveLen(3))
 
 		crb := &rbacv1.ClusterRoleBinding{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: gwName + "-node-reader"}, crb)).To(Succeed())


### PR DESCRIPTION
## Summary
Fixes two instances of the same reconcile bug pattern — "create if absent, never sync drift on an existing object" — found while getting SNO working as a staging deployment today:

- **`reconcileOAuthClient`**: returned immediately once the cluster-scoped `OAuthClient` existed, never checking whether its `secret`/`redirectURIs` still matched the current namespace `Secret`. Any redeploy that regenerates that `Secret` independently (e.g. a fresh namespace) leaves the `OAuthClient` pointing at a stale secret, failing OIDC token exchange with `unauthorized_client`. Hit this on both RDU and SNO today, patched by hand each time.
- **`reconcileGatewayTLSCert`**: same pattern for the Gateway API listener's cert-manager `Certificate` — never checked whether `dnsNames` still matched the CR's current `route.Hostname`. Since staging hostnames change per build (by design, to dodge Let's Encrypt rate limits), the stale `Certificate` kept the old hostname and cert-manager never reissued, which cascaded into Envoy Gateway never creating its proxy Deployment at all (`ResolvedRefs: False` → "no listeners found").

Also includes a one-line test fix (`HaveLen(2)` → `HaveLen(3)`) that an earlier commit (`19b785e`, already on `main`) should have made when it added a third rule to the gateway ClusterRole.

## Test plan
- [x] `make lint` / `make test` clean
- [x] Both bugs reproduced and root-caused live against RDU/SNO before being fixed (not speculative)
- [ ] Re-verify against a real cluster per `CONTRIBUTING.md`'s real-cluster testing requirement before merge (not yet re-deployed with these specific fixes)
