### PR TITLE
fix: honor route.enabled on disable, use Recreate for embedded PostgreSQL

### DIFF
--- a/internal/controller/dep_postgres.go
+++ b/internal/controller/dep_postgres.go
@@ -180,6 +180,11 @@ func (p *PostgreSQLReconciler) ensureDeployment(ctx context.Context, gw *ogov1al
 			"ogo.aknochow.io/warning":  "Not for production use",
 		}
 		deploy.Spec.Replicas = ptr.To(int32(1))
+		// Recreate, not the default RollingUpdate: the single replica mounts
+		// one ReadWriteOnce PVC, so a replacement pod scheduled on another
+		// node can't attach the volume while the old pod (and its node
+		// attachment) is still around. Recreate tears down first.
+		deploy.Spec.Strategy = appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType}
 		deploy.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"app": gw.Name + "-pg"}}
 		deploy.Spec.Template = corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": gw.Name + "-pg"}},

--- a/internal/controller/openshellgateway_controller.go
+++ b/internal/controller/openshellgateway_controller.go
@@ -901,11 +901,21 @@ func (r *OpenShellGatewayReconciler) reconcileNetworkPolicy(ctx context.Context,
 // --- OpenShift Route ---
 
 func (r *OpenShellGatewayReconciler) reconcileRoute(ctx context.Context, gw *ogov1alpha1.OpenShellGateway) error {
+	ns := gatewayNamespace(gw)
+
 	if gw.Spec.Route.Enabled != nil && !*gw.Spec.Route.Enabled {
-		return nil
+		existing := &unstructured.Unstructured{}
+		existing.SetGroupVersionKind(schema.GroupVersionKind{Group: "route.openshift.io", Version: "v1", Kind: "Route"})
+		err := r.Get(ctx, types.NamespacedName{Name: gw.Name, Namespace: ns}, existing)
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		return r.Delete(ctx, existing)
 	}
 
-	ns := gatewayNamespace(gw)
 	tlsEnabled := gw.Spec.TLS.Enabled == nil || *gw.Spec.TLS.Enabled
 	tlsTermination := "passthrough"
 	if !tlsEnabled {
@@ -1664,6 +1674,17 @@ func (r *OpenShellGatewayReconciler) reconcileAuthBridgeRoute(ctx context.Contex
 	existing := &unstructured.Unstructured{}
 	existing.SetGroupVersionKind(schema.GroupVersionKind{Group: "route.openshift.io", Version: "v1", Kind: "Route"})
 	err := r.Get(ctx, types.NamespacedName{Name: routeName, Namespace: ns}, existing)
+
+	if gw.Spec.Route.Enabled != nil && !*gw.Spec.Route.Enabled {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		return r.Delete(ctx, existing)
+	}
+
 	if apierrors.IsNotFound(err) {
 		hostname := ""
 		if gw.Spec.Route.Hostname != "" {


### PR DESCRIPTION
## Summary

Two bugs reported by an external contributor (waveywaves), both confirmed
against source and fixed here:

- `reconcileRoute` returned immediately when `spec.route.enabled` was
  `false`, but never deleted an already-created Route if the setting was
  flipped from `true` to `false` later. `reconcileAuthBridgeRoute` didn't
  check the setting at all, always creating/recreating the `<gateway>-auth`
  Route whenever OpenShift auth was enabled. Both reconcilers now delete
  their managed Route when the setting is disabled, matching the existing
  create-if-absent handling for the enabled case.
- The embedded PostgreSQL Deployment had no rollout strategy set, so
  Kubernetes defaulted to `RollingUpdate`. With a single replica mounting
  one `ReadWriteOnce` PVC, a pod-template change whose replacement pod
  lands on a different node can stall indefinitely, since the new pod
  can't attach the volume while the old pod still holds it. Set to
  `Recreate`.

Closes #42, closes #43.

## Test plan

- [x] `make manifests generate fmt vet` clean, no drift
- [x] `make lint` clean (0 issues)
- [x] `make test` — `internal/controller` (where both fixes live) passes
      cleanly; unrelated packages hit a pre-existing local Go
      1.26/1.25 toolchain mismatch on this machine, confirmed earlier
      to not reproduce in CI
- [ ] Live-verify on SNO: enable routing, confirm Route exists; disable
      it, confirm both the gateway and auth-bridge Routes are deleted;
      re-enable, confirm they're recreated. Required before this ships
      in a tagged release.

Assisted-by: Claude