### PR TITLE
fix: harden auth-bridge TLS (safe-by-default listener, CA-only trust material)

### DIFF
--- a/cmd/auth-bridge/main.go
+++ b/cmd/auth-bridge/main.go
@@ -34,11 +34,19 @@ import (
 func main() {
 	internalIssuer := envOrDefault("AUTH_BRIDGE_ISSUER", "http://localhost:8085")
 	externalIssuer := envOrDefault("AUTH_BRIDGE_EXTERNAL_ISSUER", internalIssuer)
+
+	tlsCert := os.Getenv("AUTH_BRIDGE_TLS_CERT")
+	tlsKey := os.Getenv("AUTH_BRIDGE_TLS_KEY")
+	if err := validateTLSFiles(tlsCert, tlsKey); err != nil {
+		log.Fatal(err)
+	}
+	explicitListen, listenExplicitlySet := os.LookupEnv("AUTH_BRIDGE_LISTEN")
+
 	config := authbridge.Config{
 		Issuer:         internalIssuer,
 		ExternalIssuer: externalIssuer,
 		Audience:       envOrDefault("AUTH_BRIDGE_AUDIENCE", "openshell-cli"),
-		ListenAddr:     envOrDefault("AUTH_BRIDGE_LISTEN", ":8085"),
+		ListenAddr:     resolveListenAddr(explicitListen, listenExplicitlySet, tlsCert != ""),
 		OpenShiftOAuth: envOrDefault("AUTH_BRIDGE_OPENSHIFT_ISSUER", "https://oauth-openshift.apps.example.com"),
 		ClientID:       envOrDefault("AUTH_BRIDGE_CLIENT_ID", "openshell"),
 		ClientSecret:   os.Getenv("AUTH_BRIDGE_CLIENT_SECRET"),
@@ -62,11 +70,6 @@ func main() {
 
 	handler := server.Handler()
 	servers := []*http.Server{newHTTPServer(config.ListenAddr, handler)}
-	tlsCert := os.Getenv("AUTH_BRIDGE_TLS_CERT")
-	tlsKey := os.Getenv("AUTH_BRIDGE_TLS_KEY")
-	if err := validateTLSFiles(tlsCert, tlsKey); err != nil {
-		log.Fatal(err)
-	}
 	if tlsCert != "" {
 		servers = append(servers, newHTTPServer(envOrDefault("AUTH_BRIDGE_TLS_LISTEN", ":8443"), handler))
 	}
@@ -164,6 +167,20 @@ func validateTLSFiles(cert, key string) error {
 		}
 	}
 	return nil
+}
+
+// resolveListenAddr decides the plaintext HTTP listen address. An address the
+// caller set explicitly via AUTH_BRIDGE_LISTEN is always honored, even if TLS
+// is configured. Otherwise, once TLS is configured, the plaintext listener
+// defaults to loopback-only (127.0.0.1:8085) instead of all interfaces.
+func resolveListenAddr(explicit string, explicitlySet, tlsConfigured bool) string {
+	if explicitlySet {
+		return explicit
+	}
+	if tlsConfigured {
+		return "127.0.0.1:8085"
+	}
+	return ":8085"
 }
 
 func envOrDefault(key, fallback string) string {

--- a/cmd/auth-bridge/main.go
+++ b/cmd/auth-bridge/main.go
@@ -174,7 +174,7 @@ func validateTLSFiles(cert, key string) error {
 // is configured. Otherwise, once TLS is configured, the plaintext listener
 // defaults to loopback-only (127.0.0.1:8085) instead of all interfaces.
 func resolveListenAddr(explicit string, explicitlySet, tlsConfigured bool) string {
-	if explicitlySet {
+	if explicitlySet && explicit != "" {
 		return explicit
 	}
 	if tlsConfigured {

--- a/cmd/auth-bridge/main.go
+++ b/cmd/auth-bridge/main.go
@@ -169,10 +169,14 @@ func validateTLSFiles(cert, key string) error {
 	return nil
 }
 
-// resolveListenAddr decides the plaintext HTTP listen address. An address the
-// caller set explicitly via AUTH_BRIDGE_LISTEN is always honored, even if TLS
-// is configured. Otherwise, once TLS is configured, the plaintext listener
-// defaults to loopback-only (127.0.0.1:8085) instead of all interfaces.
+// resolveListenAddr decides the plaintext HTTP listen address. A non-empty
+// address the caller set explicitly via AUTH_BRIDGE_LISTEN is always
+// honored, even if TLS is configured; an explicitly-empty value is treated
+// as unset rather than passed through, since an empty http.Server.Addr
+// defaults to :http (port 80, all interfaces) — the opposite of intent.
+// Once TLS is configured and no address was supplied, the plaintext
+// listener defaults to loopback-only (127.0.0.1:8085) instead of all
+// interfaces.
 func resolveListenAddr(explicit string, explicitlySet, tlsConfigured bool) string {
 	if explicitlySet && explicit != "" {
 		return explicit

--- a/cmd/auth-bridge/main_test.go
+++ b/cmd/auth-bridge/main_test.go
@@ -119,6 +119,36 @@ func TestValidateTLSFiles(t *testing.T) {
 	}
 }
 
+func TestResolveListenAddr(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		explicit      string
+		explicitlySet bool
+		tlsConfigured bool
+		want          string
+	}{
+		{name: "no tls, unset defaults to all interfaces", want: ":8085"},
+		{name: "tls configured, unset defaults to loopback only", tlsConfigured: true, want: "127.0.0.1:8085"},
+		{name: "no tls, explicit value honored", explicit: ":9000", explicitlySet: true, want: ":9000"},
+		{
+			name:     "tls configured, explicit non-loopback value still honored",
+			explicit: ":8085", explicitlySet: true, tlsConfigured: true, want: ":8085",
+		},
+		{
+			name:     "tls configured, explicit loopback value honored",
+			explicit: "127.0.0.1:9000", explicitlySet: true, tlsConfigured: true, want: "127.0.0.1:9000",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveListenAddr(tt.explicit, tt.explicitlySet, tt.tlsConfigured)
+			if got != tt.want {
+				t.Fatalf("resolveListenAddr(%q, %v, %v) = %q, want %q",
+					tt.explicit, tt.explicitlySet, tt.tlsConfigured, got, tt.want)
+			}
+		})
+	}
+}
+
 func tlsFiles(t *testing.T) (string, string) {
 	t.Helper()
 	dir := t.TempDir()

--- a/cmd/auth-bridge/main_test.go
+++ b/cmd/auth-bridge/main_test.go
@@ -138,6 +138,10 @@ func TestResolveListenAddr(t *testing.T) {
 			name:     "tls configured, explicit loopback value honored",
 			explicit: "127.0.0.1:9000", explicitlySet: true, tlsConfigured: true, want: "127.0.0.1:9000",
 		},
+		{
+			name:     "tls configured, explicitly-set empty value treated as unset",
+			explicit: "", explicitlySet: true, tlsConfigured: true, want: "127.0.0.1:8085",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got := resolveListenAddr(tt.explicit, tt.explicitlySet, tt.tlsConfigured)

--- a/internal/controller/openshellgateway_controller.go
+++ b/internal/controller/openshellgateway_controller.go
@@ -610,7 +610,8 @@ func (r *OpenShellGatewayReconciler) reconcileAuthBridgeCA(ctx context.Context, 
 
 func (r *OpenShellGatewayReconciler) serverTLSCA(ctx context.Context, gw *ogov1alpha1.OpenShellGateway) ([]byte, error) {
 	secretName := gw.Name + "-server-tls"
-	if gw.Spec.TLS.ServerCertSecretName != "" {
+	external := gw.Spec.TLS.ServerCertSecretName != ""
+	if external {
 		secretName = gw.Spec.TLS.ServerCertSecretName
 	}
 	secret := &corev1.Secret{}
@@ -619,6 +620,11 @@ func (r *OpenShellGatewayReconciler) serverTLSCA(ctx context.Context, gw *ogov1a
 	}
 	destinationCA := secret.Data["ca.crt"]
 	if len(destinationCA) == 0 {
+		if external {
+			return nil, fmt.Errorf("server TLS secret %q (spec.tls.serverCertSecretName) has no ca.crt; "+
+				"external server certificates must include the issuing CA under the ca.crt key — "+
+				"a rotating leaf tls.crt certificate cannot be published as stable trust material", secretName)
+		}
 		destinationCA = secret.Data[corev1.TLSCertKey]
 	}
 	if len(destinationCA) == 0 {

--- a/internal/controller/openshellgateway_controller_test.go
+++ b/internal/controller/openshellgateway_controller_test.go
@@ -92,6 +92,19 @@ var _ = Describe("OpenShellGateway Controller", func() {
 		}
 	}
 
+	setupExternalServerCertGateway := func(secretName string) (*OpenShellGatewayReconciler, *ogov1alpha1.OpenShellGateway) {
+		r := reconciler()
+		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
+		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
+
+		gw := &ogov1alpha1.OpenShellGateway{}
+		Expect(k8sClient.Get(ctx, gwKey, gw)).To(Succeed())
+		gw.Spec.Auth.OpenShift.Enabled = ptr.To(true)
+		gw.Spec.TLS.ServerCertSecretName = secretName
+		Expect(k8sClient.Update(ctx, gw)).To(Succeed())
+		return r, gw
+	}
+
 	It("should add a finalizer on first reconcile", func() {
 		r := reconciler()
 		result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
@@ -324,15 +337,7 @@ var _ = Describe("OpenShellGateway Controller", func() {
 	})
 
 	It("should require an explicit ca.crt for an external server certificate secret", func() {
-		r := reconciler()
-		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
-		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
-
-		gw := &ogov1alpha1.OpenShellGateway{}
-		Expect(k8sClient.Get(ctx, gwKey, gw)).To(Succeed())
-		gw.Spec.Auth.OpenShift.Enabled = ptr.To(true)
-		gw.Spec.TLS.ServerCertSecretName = "external-tls-no-ca"
-		Expect(k8sClient.Update(ctx, gw)).To(Succeed())
+		r, gw := setupExternalServerCertGateway("external-tls-no-ca")
 
 		externalSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "external-tls-no-ca", Namespace: "ogo-test"},
@@ -350,15 +355,7 @@ var _ = Describe("OpenShellGateway Controller", func() {
 	})
 
 	It("should publish the external secret's ca.crt, not its rotating leaf certificate", func() {
-		r := reconciler()
-		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
-		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
-
-		gw := &ogov1alpha1.OpenShellGateway{}
-		Expect(k8sClient.Get(ctx, gwKey, gw)).To(Succeed())
-		gw.Spec.Auth.OpenShift.Enabled = ptr.To(true)
-		gw.Spec.TLS.ServerCertSecretName = "external-tls-with-ca"
-		Expect(k8sClient.Update(ctx, gw)).To(Succeed())
+		r, gw := setupExternalServerCertGateway("external-tls-with-ca")
 
 		externalSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "external-tls-with-ca", Namespace: "ogo-test"},

--- a/internal/controller/openshellgateway_controller_test.go
+++ b/internal/controller/openshellgateway_controller_test.go
@@ -323,6 +323,64 @@ var _ = Describe("OpenShellGateway Controller", func() {
 			types.NamespacedName{Name: gwName + "-auth-ca", Namespace: "ogo-test"}, &corev1.ConfigMap{}))).To(BeTrue())
 	})
 
+	It("should require an explicit ca.crt for an external server certificate secret", func() {
+		r := reconciler()
+		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
+		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
+
+		gw := &ogov1alpha1.OpenShellGateway{}
+		Expect(k8sClient.Get(ctx, gwKey, gw)).To(Succeed())
+		gw.Spec.Auth.OpenShift.Enabled = ptr.To(true)
+		gw.Spec.TLS.ServerCertSecretName = "external-tls-no-ca"
+		Expect(k8sClient.Update(ctx, gw)).To(Succeed())
+
+		externalSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "external-tls-no-ca", Namespace: "ogo-test"},
+			Type:       corev1.SecretTypeTLS,
+			Data:       map[string][]byte{"tls.crt": []byte("leaf-cert-data"), "tls.key": []byte("leaf-key-data")},
+		}
+		Expect(k8sClient.Create(ctx, externalSecret)).To(Succeed())
+
+		_, err := r.serverTLSCA(ctx, gw)
+		Expect(err).To(MatchError(ContainSubstring("ca.crt")))
+
+		Expect(r.reconcileAuthBridgeCA(ctx, gw)).To(HaveOccurred())
+		Expect(errors.IsNotFound(k8sClient.Get(ctx,
+			types.NamespacedName{Name: gwName + "-auth-ca", Namespace: "ogo-test"}, &corev1.ConfigMap{}))).To(BeTrue())
+	})
+
+	It("should publish the external secret's ca.crt, not its rotating leaf certificate", func() {
+		r := reconciler()
+		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
+		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
+
+		gw := &ogov1alpha1.OpenShellGateway{}
+		Expect(k8sClient.Get(ctx, gwKey, gw)).To(Succeed())
+		gw.Spec.Auth.OpenShift.Enabled = ptr.To(true)
+		gw.Spec.TLS.ServerCertSecretName = "external-tls-with-ca"
+		Expect(k8sClient.Update(ctx, gw)).To(Succeed())
+
+		externalSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "external-tls-with-ca", Namespace: "ogo-test"},
+			Type:       corev1.SecretTypeTLS,
+			Data: map[string][]byte{
+				"tls.crt": []byte("leaf-cert-data"),
+				"tls.key": []byte("leaf-key-data"),
+				"ca.crt":  []byte("external-ca-data"),
+			},
+		}
+		Expect(k8sClient.Create(ctx, externalSecret)).To(Succeed())
+
+		ca, err := r.serverTLSCA(ctx, gw)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(ca)).To(Equal("external-ca-data"))
+
+		Expect(r.reconcileAuthBridgeCA(ctx, gw)).To(Succeed())
+		configMap := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: gwName + "-auth-ca", Namespace: "ogo-test"}, configMap)).To(Succeed())
+		Expect(configMap.Data["ca.crt"]).To(Equal("external-ca-data"))
+	})
+
 	It("should set status URL from route hostname", func() {
 		r := reconciler()
 		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})


### PR DESCRIPTION
## Summary

Follow-up from #47's review (filed as #54), required before the next release tag:

- Default the auth-bridge plaintext listener to loopback (`127.0.0.1`) once TLS is configured, unless `AUTH_BRIDGE_LISTEN` is explicitly set. Previously the plaintext listener always bound to all interfaces regardless of TLS state; only the operator's own env-var wiring prevented exposure.
- Require an explicit `ca.crt` for externally-provided server certificates (`spec.tls.serverCertSecretName`), instead of silently falling back to a rotating leaf `tls.crt` as pinned CA trust material. That fallback remains in place for OGO's own self-signed secret, where it's harmless.

Fixes #54

## Testing

- `make build`
- `make test`
- `make lint`