### PR TITLE
fix: group OpenShell gateway/supervisor pin bumps into one Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,9 +31,22 @@ updates:
   # never-built pin file at hack/openshell-pins/Dockerfile. See that
   # file's header comment for why it's named "Dockerfile" instead of
   # "Containerfile".
+  #
+  # groups: gateway and supervisor MUST land in one PR, never two.
+  # spec.imageTag is a single CRD field shared by both images (see
+  # openshellgateway_types.go), and upstream-sync.yml's sync job
+  # refuses to auto-tag a release when the two pins diverge - which is
+  # exactly what happens if Dependabot opens separate PRs for each
+  # FROM line (its default behavior, confirmed live 2026-08-04 with
+  # PRs #56/#57). The wildcard pattern is safe here because this
+  # directory pins exactly these two images and nothing else.
   - package-ecosystem: docker
     directory: /hack/openshell-pins
     schedule:
       interval: daily
     commit-message:
       prefix: "chore(openshell):"
+    groups:
+      openshell-images:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Dependabot's docker ecosystem opens one PR per FROM line by default, so a version bump split gateway and supervisor into two independent PRs (#56, #57). spec.imageTag is a single CRD field shared by both images, and upstream-sync.yml's sync job correctly refuses to auto-tag a release when the two pins diverge, which is exactly the state each of those PRs was in on its own branch:

```
gateway (0.0.96) and supervisor (0.0.92) tags diverged - ImageTag is shared, refusing to guess
```

Adds a `groups:` block so both images are grouped into a single PR going forward.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` passes
- [ ] Confirmed by observation on the next OpenShell version bump (single PR instead of two)

Assisted-by: Claude