### PR TITLE
fix: derive dependency-bump tag base from the latest release, not Makefile

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -193,15 +193,25 @@ jobs:
       - name: Compute and push dependency-bump tag
         if: steps.check.outputs.dependency_only == 'true'
         run: |
-          BASE=$(grep -oP 'VERSION \?= \K[\d.]+' Makefile)
-          if ! echo "${BASE}" | grep -qP '^\d+\.\d+\.\d+$'; then
-            echo "Makefile VERSION '${BASE}' is not bare semver (X.Y.Z) - refusing to use it in git ls-remote/tag"
-            exit 1
-          fi
+          # BASE must be the latest REAL release tag (bare vX.Y.Z, pushed
+          # manually per AGENTS.md's tag strategy), NOT Makefile's VERSION -
+          # that field is deliberately frozen at its original stub value
+          # ("VERSION in Makefile stays as base") and never reflects actual
+          # releases. Using it here silently anchored every dependency tag
+          # to v0.1.0 forever, regardless of how many real vX.Y.Z releases
+          # had since shipped - caught 2026-08-04 before merging a PR that
+          # would have produced v0.1.0-<huge number> right after v0.2.4.
+          #
           # Check existing tags via the remote, not local `git rev-parse` -
           # this job's checkout has no fetch-depth override for tags, but
           # relying on local refs at all is fragile; ls-remote is always
           # authoritative regardless of what this checkout happened to fetch.
+          BASE=$(git ls-remote --tags origin 'refs/tags/v*' \
+            | grep -oP 'refs/tags/v\K\d+\.\d+\.\d+$' | sort -V | tail -1)
+          if ! echo "${BASE}" | grep -qP '^\d+\.\d+\.\d+$'; then
+            echo "No real vX.Y.Z release tag found on origin - refusing to guess a base for the dependency-bump tag"
+            exit 1
+          fi
           ESCAPED_BASE=$(echo "${BASE}" | sed 's/\./\\./g')
           LAST=$(git ls-remote --tags origin "refs/tags/v${BASE}-*" \
             | grep -oP "v${ESCAPED_BASE}-\K\d+" | sort -n | tail -1)


### PR DESCRIPTION
## Summary

The tag job in upstream-sync.yml read BASE from Makefile's VERSION field, which is deliberately frozen at its original stub value per this repo's own convention ("VERSION in Makefile stays as base, CI overrides from the git tag"). That meant every dependency-only bump tag was silently anchored to v0.1.0 forever, regardless of how many real vX.Y.Z releases had since shipped.

Confirmed live before merging #59 (the openshell gateway/supervisor pin bump): the old logic would have produced v0.1.0-2607282216 (incrementing a years-old calver-style suffix) right after v0.2.4, instead of the expected v0.2.4-1.

Derives BASE from the latest bare vX.Y.Z tag on origin instead, so N correctly resets against whatever real release was most recently cut, matching AGENTS.md's documented tag strategy.

## Test plan

- [x] Simulated the new logic locally against real remote tags: computes BASE=0.2.4, produces v0.2.4-1 as expected
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/upstream-sync.yml'))"` passes
- [ ] Confirmed by observation the next time #59 (or a future dependency-only bump) merges

Assisted-by: Claude