### PR TITLE
docs: remove now-resolved OpenShellProvider/OpenShellPolicy warnings

### DIFF
--- a/docs/concepts/policy.md
+++ b/docs/concepts/policy.md
@@ -7,15 +7,6 @@ tags: [core, security]
 
 # Policy
 
-> **Warning:** `OpenShellPolicy` currently only validates the resource's
-> fields locally. It does not yet sync network, filesystem, or process
-> rules to the running OpenShell gateway, so creating this resource has
-> no effect on sandbox enforcement. `Synced: True` reflects validation
-> only, not enforcement. Sandboxes always run under the gateway's
-> built-in default policy described below, regardless of any
-> `OpenShellPolicy` CR. Tracked in
-> [#52](https://github.com/aknochow/ogo/issues/52).
-
 Policies define the security boundary for sandbox pods. The `OpenShellPolicy`
 CRD configures three dimensions of control:
 

--- a/docs/concepts/provider.md
+++ b/docs/concepts/provider.md
@@ -7,13 +7,6 @@ tags: [core, credentials]
 
 # Provider
 
-> **Warning:** `OpenShellProvider` currently only validates that the
-> referenced Secret and key exist. It does not yet sync credentials or
-> configuration to the running OpenShell gateway, so creating this
-> resource has no effect on sandbox behavior. `Synced: True` reflects
-> validation only, not enforcement. Tracked in
-> [#51](https://github.com/aknochow/ogo/issues/51).
-
 A provider represents an external service that sandboxes need access to -
 an LLM inference API, a source control platform, or a cloud service. The
 `OpenShellProvider` CRD tells the operator which credentials to inject and

--- a/docs/examples/claude-code.md
+++ b/docs/examples/claude-code.md
@@ -7,15 +7,6 @@ tags: [claude, anthropic, inference]
 
 # Claude Code with Anthropic API
 
-> **Warning:** The Provider and Policy CRs below do not yet have any
-> effect on the running gateway (see
-> [Provider](../concepts/provider.md) and [Policy](../concepts/policy.md)).
-> Following this example as written will not actually inject the API key
-> or allow network access to `api.anthropic.com`. The sandbox will run
-> under the gateway's default policy, which permits no external network
-> access. Tracked in [#51](https://github.com/aknochow/ogo/issues/51) and
-> [#52](https://github.com/aknochow/ogo/issues/52).
-
 This example configures OGO to run Claude Code in sandboxes with direct
 access to the Anthropic API.
 

--- a/docs/examples/developer-policy.md
+++ b/docs/examples/developer-policy.md
@@ -7,15 +7,6 @@ tags: [policy, github, developer]
 
 # Developer policy
 
-> **Warning:** The Provider and Policy CRs below do not yet have any
-> effect on the running gateway (see
-> [Provider](../concepts/provider.md) and [Policy](../concepts/policy.md)).
-> Following this example as written will not actually grant network
-> access to GitHub, PyPI, or npm - the sandbox will run under the
-> gateway's default policy, which permits no external network access.
-> Tracked in [#51](https://github.com/aknochow/ogo/issues/51) and
-> [#52](https://github.com/aknochow/ogo/issues/52).
-
 This example configures a sandbox policy for general development workflows:
 git operations, package installation, and GitHub API access.
 

--- a/docs/examples/vertex-ai.md
+++ b/docs/examples/vertex-ai.md
@@ -7,16 +7,6 @@ tags: [claude, vertex, gcp, inference]
 
 # Claude Code with Vertex AI
 
-> **Warning:** The Provider and Policy CRs below do not yet have any
-> effect on the running gateway (see
-> [Provider](../concepts/provider.md) and [Policy](../concepts/policy.md)).
-> Following this example as written will not actually configure GCP
-> credential refresh or allow network access to Vertex AI endpoints -
-> the sandbox will run under the gateway's default policy, which permits
-> no external network access. Tracked in
-> [#51](https://github.com/aknochow/ogo/issues/51) and
-> [#52](https://github.com/aknochow/ogo/issues/52).
-
 This example configures OGO to run Claude Code in sandboxes using Google
 Vertex AI for inference. The gateway manages GCP credential refresh - no
 `gcloud` CLI needed in sandboxes.

--- a/docs/reference/openshellpolicy.md
+++ b/docs/reference/openshellpolicy.md
@@ -8,12 +8,6 @@ tags: [crd, policy, security]
 
 # OpenShellPolicy
 
-> **Warning:** This CRD currently only validates the resource's fields
-> locally. It does not sync network, filesystem, or process rules to the
-> running OpenShell gateway yet. `phase: Synced` reflects validation
-> only, not enforcement. Tracked in
-> [#52](https://github.com/aknochow/ogo/issues/52).
-
 **API Group:** `gateway.ogo.aknochow.io`
 **Version:** `v1alpha1`
 **Scope:** Namespaced (in the gateway namespace)

--- a/docs/reference/openshellprovider.md
+++ b/docs/reference/openshellprovider.md
@@ -8,12 +8,6 @@ tags: [crd, provider, credentials]
 
 # OpenShellProvider
 
-> **Warning:** This CRD currently only validates that the referenced
-> Secret and key exist. It does not sync credentials or configuration to
-> the running OpenShell gateway yet. `phase: Synced` reflects validation
-> only, not enforcement. Tracked in
-> [#51](https://github.com/aknochow/ogo/issues/51).
-
 **API Group:** `gateway.ogo.aknochow.io`
 **Version:** `v1alpha1`
 **Scope:** Namespaced (in the gateway namespace)


### PR DESCRIPTION
## Summary

Reverts commit f48b61e, which added temporary "not yet implemented" warnings to 7 doc files while `OpenShellProvider` and `OpenShellPolicy` never actually configured the running OpenShell gateway (#51, #52).

That gap is now closed: PR #65 (merged, tagged `v0.3.1`, deployed to both SNO and RDU) reconciles both CRDs through the gateway's real gRPC API — live-verified end-to-end, including credential/config sync, retraction, deletion, and (for Policy) singleton-based gateway-global policy enforcement with hand-off.

## Files

- `docs/concepts/policy.md`
- `docs/concepts/provider.md`
- `docs/examples/claude-code.md`
- `docs/examples/developer-policy.md`
- `docs/examples/vertex-ai.md`
- `docs/reference/openshellpolicy.md`
- `docs/reference/openshellprovider.md`