### PR TITLE
docs: document OpenShellWorkspaceMember, fix OpenShellPolicy singleton docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ CRD specifications and field-level documentation.
 - [OpenShellGateway](docs/reference/openshellgateway.md) - gateway CRD reference
 - [OpenShellProvider](docs/reference/openshellprovider.md) - provider CRD reference
 - [OpenShellPolicy](docs/reference/openshellpolicy.md) - policy CRD reference
+- [OpenShellWorkspaceMember](docs/reference/openshellworkspacemember.md) - workspace membership CRD reference
 
 ## Examples
 

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -12,4 +12,6 @@ resources:
 - ogo_v1alpha1_openshellpolicy.yaml
 # - ogo_v1alpha1_openshellpolicy_vertex.yaml
 # - ogo_v1alpha1_openshellpolicy_developer.yaml
+# Workspace membership
+- ogo_v1alpha1_openshellworkspacemember.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/ogo_v1alpha1_openshellworkspacemember.yaml
+++ b/config/samples/ogo_v1alpha1_openshellworkspacemember.yaml
@@ -1,0 +1,16 @@
+# OpenShellWorkspaceMember — grant a headless workload identity access
+#
+# Grants the "ci-pipeline" ServiceAccount (in this same namespace) user-role
+# membership in the "default" OpenShell workspace, so it can create and
+# manage sandboxes once it exchanges its Kubernetes token for an OpenShell
+# JWT (see docs/concepts/authentication.md).
+apiVersion: gateway.ogo.aknochow.io/v1alpha1
+kind: OpenShellWorkspaceMember
+metadata:
+  name: ci-pipeline
+  namespace: ogo
+spec:
+  workspace: default
+  serviceAccountRef:
+    name: ci-pipeline
+  role: user

--- a/docs.toml
+++ b/docs.toml
@@ -59,6 +59,7 @@ img   = "https://img.shields.io/badge/OpenShell-v0.0.96-76b900?logo=nvidia&logoC
   { "Authentication" = "concepts/authentication.md" },
   { "Provider" = "concepts/provider.md" },
   { "Policy" = "concepts/policy.md" },
+  { "Workspace Membership" = "concepts/workspace-membership.md" },
 ]
 
 [[project.nav]]
@@ -77,6 +78,7 @@ img   = "https://img.shields.io/badge/OpenShell-v0.0.96-76b900?logo=nvidia&logoC
   { "OpenShellGateway" = "reference/openshellgateway.md" },
   { "OpenShellProvider" = "reference/openshellprovider.md" },
   { "OpenShellPolicy" = "reference/openshellpolicy.md" },
+  { "OpenShellWorkspaceMember" = "reference/openshellworkspacemember.md" },
 ]
 
 [[project.nav]]

--- a/docs/concepts/authentication.md
+++ b/docs/concepts/authentication.md
@@ -87,3 +87,4 @@ The first authenticator that matches handles the request.
 - [OpenShift SSO guide](../guides/openshift-sso.md)
 - [OpenShellGateway CRD](../reference/openshellgateway.md) - `spec.auth` fields
 - [Gateway concept](gateway.md) - architecture overview
+- [Workspace Membership](workspace-membership.md) - authorization once a token is issued; a valid token alone doesn't grant sandbox access

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -12,3 +12,4 @@ description: Core building blocks of an OGO deployment.
 - [Authentication](authentication.md) - how users and sandboxes authenticate
 - [Provider](provider.md) - API credentials injected into sandboxes
 - [Policy](policy.md) - network, filesystem, and process controls for sandboxes
+- [Workspace Membership](workspace-membership.md) - authorization for workload identities

--- a/docs/concepts/policy.md
+++ b/docs/concepts/policy.md
@@ -42,6 +42,18 @@ Controls the identity of processes inside the sandbox:
 - `runAsUser` - the user name or UID (default: `sandbox`)
 - `runAsGroup` - the group name or GID (default: `sandbox`)
 
+## Singleton
+
+The OpenShell gateway has exactly one global policy — there's no concept of
+multiple named policies at the gateway level. Only **one** `OpenShellPolicy`
+CR is ever active at a time; if you create more than one, the oldest wins and
+the rest sit idle with `status.phase: Superseded`, having no effect on the
+gateway. `spec.policyName` is a cosmetic label for humans, not something the
+gateway looks up by name.
+
+Deleting the active CR promotes the next-oldest one automatically. Deleting
+the last remaining CR reverts the gateway to its restrictive default below.
+
 ## Default policy
 
 When no `OpenShellPolicy` is configured, the gateway applies a restrictive

--- a/docs/concepts/workspace-membership.md
+++ b/docs/concepts/workspace-membership.md
@@ -1,0 +1,56 @@
+---
+type: Concept
+title: Workspace Membership
+description: Workspace membership is the authorization layer that decides which authenticated identities can use a given OpenShell workspace.
+tags: [core, security, authorization]
+---
+
+# Workspace Membership
+
+Authentication proves *who* is calling the gateway (see
+[Authentication](authentication.md)). Workspace membership decides *what
+that identity is allowed to do* once authenticated — a separate
+authorization layer keyed on the caller's JWT `sub` claim. A ServiceAccount
+or user can have a perfectly valid token and still get `PERMISSION_DENIED`
+on every sandbox operation if it isn't a member of the workspace it's
+targeting.
+
+The `OpenShellWorkspaceMember` CRD reconciles this membership declaratively,
+so headless workload identities (CI pipelines, controllers, other
+operators) don't need a manual, one-off grant to use the gateway.
+
+## How it works
+
+1. Admin creates an `OpenShellWorkspaceMember` CR referencing a
+   ServiceAccount in the same namespace, a target workspace, and a role
+2. The operator resolves the ServiceAccount's real UID and grants
+   membership on the gateway using that UID as the principal subject
+3. When that ServiceAccount later exchanges its Kubernetes token for an
+   OpenShell JWT (see [Authentication](authentication.md)), the JWT's
+   `sub` claim matches the granted membership and gateway calls succeed
+4. If the ServiceAccount is deleted and recreated, its UID changes — the
+   controller notices, retracts the stale membership, and grants the new
+   identity, so access is never silently inherited across a recreation
+
+## Roles
+
+| Role | Grants |
+|------|--------|
+| `user` (default) | Create, list, and manage sandboxes in the workspace |
+| `admin` | `user` permissions plus workspace-level administration |
+
+## Why this needed its own CRD
+
+The real gateway has no concept of "workspace membership for a Kubernetes
+identity" out of the box — only a gRPC API to add/remove named principals
+per workspace. Before this CRD existed, granting a headless identity access
+meant a hand-run `grpcurl` call with a manually-minted admin token: it
+worked, but it was a one-off that the system would never redo on its own
+(e.g. after the ServiceAccount's UID changed). `OpenShellWorkspaceMember`
+turns that manual step into normal, continuously-reconciled cluster state.
+
+## See also
+
+- [OpenShellWorkspaceMember CRD](../reference/openshellworkspacemember.md)
+- [Authentication](authentication.md) - how identities get a token in the first place
+- [Gateway](gateway.md) - architecture overview

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ CRD specifications and field-level documentation.
 - [OpenShellGateway](reference/openshellgateway.md) - gateway CRD reference
 - [OpenShellProvider](reference/openshellprovider.md) - provider CRD reference
 - [OpenShellPolicy](reference/openshellpolicy.md) - policy CRD reference
+- [OpenShellWorkspaceMember](reference/openshellworkspacemember.md) - workspace membership CRD reference
 
 ## Examples
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -9,3 +9,4 @@ description: CRD specifications and field-level documentation.
 - [OpenShellGateway](openshellgateway.md) - gateway CRD reference
 - [OpenShellProvider](openshellprovider.md) - provider CRD reference
 - [OpenShellPolicy](openshellpolicy.md) - policy CRD reference
+- [OpenShellWorkspaceMember](openshellworkspacemember.md) - workspace membership CRD reference

--- a/docs/reference/openshellpolicy.md
+++ b/docs/reference/openshellpolicy.md
@@ -12,11 +12,22 @@ tags: [crd, policy, security]
 **Version:** `v1alpha1`
 **Scope:** Namespaced (in the gateway namespace)
 
+## Singleton
+
+The OpenShell gateway has exactly one global policy, not named policy
+objects — so only **one** `OpenShellPolicy` CR is ever active at a time.
+The oldest CR (by creation timestamp) wins and reconciles the gateway's
+global policy; any other `OpenShellPolicy` CRs are `Superseded` and have
+**no effect on the gateway** while a different CR is active. Deleting the
+active CR promotes the next-oldest one automatically. Deleting the last
+remaining CR reverts the gateway to its [restrictive default
+policy](#default-policy).
+
 ## Spec
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `policyName` | string | yes | Name of the policy in the gateway |
+| `policyName` | string | yes | Cosmetic label only — the gateway has no named policy objects, so this has no effect on gateway behavior |
 | `filesystem` | FilesystemPolicy | | Filesystem access controls |
 | `network` | map[string]NetworkPolicyRule | | Network access rules keyed by name |
 | `process` | ProcessPolicy | | Process identity controls |
@@ -64,9 +75,10 @@ tags: [crd, policy, security]
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `phase` | enum | `Pending`, `Synced`, `Failed` |
+| `phase` | enum | `Pending`, `Synced`, `Failed`, `Superseded` (see [Singleton](#singleton)) |
 | `observedGeneration` | int | Latest observed spec generation |
 | `conditions` | []Condition | Sync status conditions |
+| `appliedToGateway` | bool | True once this CR has successfully pushed its policy as the gateway's active global policy |
 
 ## Default policy
 

--- a/docs/reference/openshellprovider.md
+++ b/docs/reference/openshellprovider.md
@@ -34,6 +34,8 @@ tags: [crd, provider, credentials]
 | `phase` | enum | `Pending`, `Synced`, `Failed` |
 | `observedGeneration` | int | Latest observed spec generation |
 | `conditions` | []Condition | Sync status conditions |
+| `reconciledCredentialKeys` | []string | `credentials` keys last pushed to the gateway — used to explicitly retract a key removed from spec |
+| `reconciledConfigKeys` | []string | `config` keys last pushed to the gateway — same retraction purpose as above |
 
 ## Provider types
 

--- a/docs/reference/openshellworkspacemember.md
+++ b/docs/reference/openshellworkspacemember.md
@@ -1,0 +1,59 @@
+---
+type: CRD Reference
+title: OpenShellWorkspaceMember
+description: Namespaced CRD that grants a workload ServiceAccount identity membership in an OpenShell workspace.
+resource: gateway.ogo.aknochow.io/v1alpha1
+tags: [crd, authorization, workspace]
+---
+
+# OpenShellWorkspaceMember
+
+**API Group:** `gateway.ogo.aknochow.io`
+**Version:** `v1alpha1`
+**Scope:** Namespaced
+
+Grants a Kubernetes ServiceAccount workspace membership on the OpenShell
+gateway — the authorization layer that sits below authentication. A
+ServiceAccount can hold a perfectly valid OIDC token (see
+[Authentication](../concepts/authentication.md)) and still get
+`PERMISSION_DENIED` on every sandbox operation if it isn't a member of the
+workspace it's trying to use. `OpenShellWorkspaceMember` reconciles that
+membership declaratively instead of requiring a manual grant.
+
+## Spec
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `workspace` | string | yes | The OpenShell workspace name to grant membership in |
+| `serviceAccountRef.name` | string | yes | Name of the ServiceAccount, in the **same namespace** as this CR (no cross-namespace references — see [Security](#security)) |
+| `role` | enum | | `user` (default) or `admin` |
+
+## Status
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `phase` | enum | `Pending`, `Synced`, `Failed` |
+| `observedGeneration` | int | Latest observed spec generation |
+| `conditions` | []Condition | Sync status conditions (`Ready` type; `Reason` includes `Synced`, `GatewayNotFound`, `GatewayUnreachable`, `IdentityNotFound`) |
+| `reconciledSubject` | string | The ServiceAccount UID last successfully granted membership |
+
+## Recreation handling
+
+`reconciledSubject` tracks the ServiceAccount's UID, not just its name. If
+the referenced ServiceAccount is deleted and recreated (a new UID), the
+controller detects the mismatch, removes the stale membership tied to the
+old UID, and grants the new identity — a recreated ServiceAccount never
+silently inherits a prior identity's access.
+
+## Security
+
+`serviceAccountRef` deliberately has no namespace field: it always resolves
+within the CR's own namespace. Allowing a cross-namespace reference would
+let anyone with create access to this resource in namespace A grant
+workspace membership to an identity in namespace B, bypassing that
+namespace's own RBAC boundary.
+
+## Examples
+
+See [config/samples/](https://github.com/aknochow/ogo/tree/main/config/samples)
+for ready-to-use `OpenShellWorkspaceMember` CRs.


### PR DESCRIPTION
## Summary

- **New**: `OpenShellWorkspaceMember` (shipped v0.3.0, PR #64) had no documentation anywhere on the docs site — added a reference page, a concept page, a sample CR, and wired both docs into `docs.toml` nav plus every index/CRD-list page (`docs/index.md`, `README.md`, `docs/reference/index.md`, `docs/concepts/index.md`).
- **Fix**: `docs/reference/openshellpolicy.md` and `docs/concepts/policy.md` still described `policyName` as gateway-meaningful and never mentioned the singleton/`Superseded` behavior shipped in v0.3.1 — this was factually wrong, not just incomplete, since the real gateway has exactly one global policy, not named ones.
- **Fix**: `docs/reference/openshellprovider.md`'s status table was missing `reconciledCredentialKeys`/`reconciledConfigKeys` (also from v0.3.1). Bundled in since it's the same class of drift.
- Added a cross-reference from `docs/concepts/authentication.md` to the new workspace-membership concept page (authentication vs. authorization are easy to conflate here).

Docs-only change, no Go code touched (one new sample CR in `config/samples/`, added after the review pass found the reference doc's Examples section pointed at a sample that didn't exist yet).

## Test plan

- [x] `make docs-lint` — 24 docs checked, 0 warnings
- [x] `make docs` — new pages (`/reference/openshellworkspacemember/`, `/concepts/workspace-membership/`) build successfully alongside the rest
- [x] `kubectl kustomize config/samples/` — new sample CR builds cleanly
- [x] ansible-ai `review.yml` pass — 98.3%, `READY_FOR_HUMAN_REVIEW`; one real Minor finding (missing sample CR) found and fixed in a follow-up commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)