### PR TITLE
feat: publish gateway TLS CA without client credentials

### DIFF
--- a/docs/concepts/authentication.md
+++ b/docs/concepts/authentication.md
@@ -45,6 +45,26 @@ oc get secret openshell-client-tls -n ogo -o jsonpath='{.data.tls\.crt}' | base6
 oc get secret openshell-client-tls -n ogo -o jsonpath='{.data.tls\.key}' | base64 -d > client.key
 ```
 
+### TLS trust for OIDC and bearer-token clients
+
+Clients that authenticate with an OIDC or bearer token still need to trust
+the gateway's server certificate to connect over TLS, but they should not
+need access to a Secret that also carries client mTLS credentials. OGO
+publishes the gateway's public CA chain — no private key, no client cert —
+in the `{gateway}-gateway-ca` ConfigMap whenever `spec.tls.enabled` is true,
+independent of whether the auth bridge is enabled.
+
+```bash
+oc get configmap openshell-gateway-ca -n ogo -o jsonpath='{.data.ca\.crt}' > ca.crt
+```
+
+This is a separate resource from `{gateway}-auth-ca`, which the auth bridge
+publishes for its own HTTPS listener (see
+[Internal workload clients](../guides/openshift-sso.md#internal-workload-clients)).
+Both currently carry the same CA, since the auth bridge shares the gateway's
+server TLS Secret, but they serve different client audiences and are
+reconciled independently.
+
 ## Sandbox bootstrap
 
 When a sandbox pod starts, the supervisor process inside it must

--- a/docs/guides/openshift-sso.md
+++ b/docs/guides/openshift-sso.md
@@ -71,6 +71,11 @@ Gateway Service on port 8085. OGO publishes the verification certificate
 without private keys in the `<gateway>-auth-ca` ConfigMap in the gateway
 namespace.
 
+This ConfigMap is specific to the auth bridge's HTTPS listener. Clients
+connecting to the gateway's own gRPC listener with an OIDC or bearer token
+instead should use `<gateway>-gateway-ca` — see
+[TLS trust for OIDC and bearer-token clients](../concepts/authentication.md#tls-trust-for-oidc-and-bearer-token-clients).
+
 A workload in that namespace can mount the ConfigMap directly. For a
 workload in another namespace, copy only `ca.crt` into a ConfigMap in the
 workload namespace and mount that copy. The client can then verify the

--- a/internal/controller/openshellgateway_controller.go
+++ b/internal/controller/openshellgateway_controller.go
@@ -65,6 +65,13 @@ const (
 	managedByValue   = "ogo"
 	defaultNamespace = "ogo"
 	phaseFailed      = "Failed"
+	// authCASuffix and gatewayCASuffix name the two CA-only ConfigMaps
+	// published from the same underlying server TLS CA (see serverTLSCA):
+	// authCASuffix for the auth-bridge's separate HTTPS listener, gatewayCASuffix
+	// for the gateway's own gRPC listener. Kept as constants so reconcileDelete's
+	// cleanup list can't drift from what reconcileCAConfigMap actually creates.
+	authCASuffix    = "-auth-ca"
+	gatewayCASuffix = "-gateway-ca"
 	// phaseSuperseded marks an OpenShellPolicy CR that isn't the active
 	// gateway-global policy (see OpenShellPolicyReconciler). Not a failure --
 	// collapsing it into phaseFailed would repeat the same "reports success
@@ -191,6 +198,7 @@ func (r *OpenShellGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		{"RoleBinding", r.reconcileRoleBinding},
 		{"TLS", r.reconcileTLS},
 		{"AuthBridgeCA", r.reconcileAuthBridgeCA},
+		{"GatewayCA", r.reconcileGatewayCA},
 		{"JWTKeys", r.reconcileJWTKeys},
 		{"AuthBridgeKeys", r.reconcileAuthBridgeKeys},
 		{"ConfigMap", r.reconcileConfigMap},
@@ -339,16 +347,18 @@ func (r *OpenShellGatewayReconciler) reconcileDelete(ctx context.Context, gw *og
 		}
 	}
 
-	authCA := &corev1.ConfigMap{}
-	authCAKey := types.NamespacedName{Name: gw.Name + "-auth-ca", Namespace: ns}
-	if err := r.Get(ctx, authCAKey, authCA); err == nil {
-		if authCA.Labels[labelManagedBy] == managedByValue && authCA.Labels[labelInstance] == gw.Name {
-			if err := r.Delete(ctx, authCA); err != nil && !apierrors.IsNotFound(err) {
-				cleanupErrors = append(cleanupErrors, err)
+	for _, suffix := range []string{authCASuffix, gatewayCASuffix} {
+		ca := &corev1.ConfigMap{}
+		caKey := types.NamespacedName{Name: gw.Name + suffix, Namespace: ns}
+		if err := r.Get(ctx, caKey, ca); err == nil {
+			if ca.Labels[labelManagedBy] == managedByValue && ca.Labels[labelInstance] == gw.Name {
+				if err := r.Delete(ctx, ca); err != nil && !apierrors.IsNotFound(err) {
+					cleanupErrors = append(cleanupErrors, err)
+				}
 			}
+		} else if !apierrors.IsNotFound(err) {
+			cleanupErrors = append(cleanupErrors, err)
 		}
-	} else if !apierrors.IsNotFound(err) {
-		cleanupErrors = append(cleanupErrors, err)
 	}
 
 	if len(cleanupErrors) > 0 {
@@ -578,11 +588,31 @@ func (r *OpenShellGatewayReconciler) reconcileSelfSignedTLS(ctx context.Context,
 }
 
 func (r *OpenShellGatewayReconciler) reconcileAuthBridgeCA(ctx context.Context, gw *ogov1alpha1.OpenShellGateway) error {
-	name := gw.Name + "-auth-ca"
+	tlsEnabled := gw.Spec.TLS.Enabled == nil || *gw.Spec.TLS.Enabled
+	enabled := tlsEnabled && authBridgeEnabled(gw, openshift.IsOpenShift(r.DiscoveryClient))
+	return r.reconcileCAConfigMap(ctx, gw, gw.Name+authCASuffix, enabled)
+}
+
+// reconcileGatewayCA publishes the gateway's own server TLS CA — the same
+// material the gateway's gRPC listener presents — into a ConfigMap with no
+// private key or client mTLS credential, for bearer/OIDC clients that only
+// need to establish server trust. This is distinct from -auth-ca (above),
+// which gates on the auth-bridge being enabled; the gateway's own listener
+// needs TLS trust published whenever gateway TLS itself is enabled.
+func (r *OpenShellGatewayReconciler) reconcileGatewayCA(ctx context.Context, gw *ogov1alpha1.OpenShellGateway) error {
+	tlsEnabled := gw.Spec.TLS.Enabled == nil || *gw.Spec.TLS.Enabled
+	return r.reconcileCAConfigMap(ctx, gw, gw.Name+gatewayCASuffix, tlsEnabled)
+}
+
+// reconcileCAConfigMap ensures a CA-only ConfigMap (public chain, no private
+// key or client credential) exists under name when enabled, and removes it
+// -- if OGO-managed -- when not. Shared by reconcileAuthBridgeCA and
+// reconcileGatewayCA, which publish the same underlying server TLS CA under
+// different names for different client audiences.
+func (r *OpenShellGatewayReconciler) reconcileCAConfigMap(ctx context.Context, gw *ogov1alpha1.OpenShellGateway, name string, enabled bool) error {
 	namespace := gatewayNamespace(gw)
 	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
-	tlsEnabled := gw.Spec.TLS.Enabled == nil || *gw.Spec.TLS.Enabled
-	if !tlsEnabled || !authBridgeEnabled(gw, openshift.IsOpenShift(r.DiscoveryClient)) {
+	if !enabled {
 		if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, configMap); err != nil {
 			if apierrors.IsNotFound(err) {
 				return nil
@@ -1900,7 +1930,7 @@ func (r *OpenShellGatewayReconciler) authBridgeRouteTLS(ctx context.Context, gw 
 		}, nil
 	}
 
-	configMapName := gw.Name + "-auth-ca"
+	configMapName := gw.Name + authCASuffix
 	configMap := &corev1.ConfigMap{}
 	if err := r.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: gatewayNamespace(gw)}, configMap); err != nil {
 		return nil, fmt.Errorf("reading auth-bridge CA ConfigMap: %w", err)

--- a/internal/controller/openshellgateway_controller_test.go
+++ b/internal/controller/openshellgateway_controller_test.go
@@ -378,6 +378,54 @@ var _ = Describe("OpenShellGateway Controller", func() {
 		Expect(configMap.Data["ca.crt"]).To(Equal("external-ca-data"))
 	})
 
+	It("should publish the gateway CA ConfigMap whenever TLS is enabled, independent of the auth bridge", func() {
+		r := reconciler()
+		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
+		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
+
+		gw := &ogov1alpha1.OpenShellGateway{}
+		Expect(k8sClient.Get(ctx, gwKey, gw)).To(Succeed())
+
+		ca := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: gwName + "-gateway-ca", Namespace: "ogo-test"}, ca)).To(Succeed())
+		Expect(ca.Data).To(HaveLen(1))
+		Expect(ca.Data["ca.crt"]).NotTo(BeEmpty())
+
+		// The auth bridge is not enabled on this fixture (non-OpenShift
+		// discovery, Auth.OpenShift.Enabled unset) — -gateway-ca must exist
+		// regardless, since it gates on TLS alone, not on the auth bridge.
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: gwName + "-auth-ca", Namespace: "ogo-test"}, &corev1.ConfigMap{})
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+
+		ca.BinaryData = map[string][]byte{"tls.key": []byte("drift")}
+		Expect(k8sClient.Update(ctx, ca)).To(Succeed())
+		Expect(r.reconcileGatewayCA(ctx, gw)).To(Succeed())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: gwName + "-gateway-ca", Namespace: "ogo-test"}, ca)).To(Succeed())
+		Expect(ca.BinaryData).To(BeEmpty())
+
+		gw.Spec.TLS.Enabled = ptr.To(false)
+		Expect(r.reconcileGatewayCA(ctx, gw)).To(Succeed())
+		Expect(errors.IsNotFound(k8sClient.Get(ctx,
+			types.NamespacedName{Name: gwName + "-gateway-ca", Namespace: "ogo-test"}, &corev1.ConfigMap{}))).To(BeTrue())
+	})
+
+	It("should reject takeover of an unmanaged gateway CA ConfigMap", func() {
+		r := reconciler()
+		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
+
+		gw := &ogov1alpha1.OpenShellGateway{}
+		Expect(k8sClient.Get(ctx, gwKey, gw)).To(Succeed())
+
+		unmanaged := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name: gwName + "-gateway-ca", Namespace: "ogo-test",
+		}}
+		Expect(k8sClient.Create(ctx, unmanaged)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, unmanaged) }()
+
+		err := r.reconcileGatewayCA(ctx, gw)
+		Expect(err).To(MatchError(ContainSubstring("not managed by OGO")))
+	})
+
 	It("should set status URL from route hostname", func() {
 		r := reconciler()
 		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
@@ -553,6 +601,11 @@ var _ = Describe("OpenShellGateway Controller", func() {
 		err = k8sClient.Get(ctx, types.NamespacedName{Name: gwName + "-node-reader"}, cr)
 		Expect(errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Get(ctx, types.NamespacedName{Name: gwName + "-auth-ca", Namespace: "ogo-test"}, &corev1.ConfigMap{})
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+		// -gateway-ca was created for real by the two Reconcile calls above
+		// (TLS defaults to enabled), unlike -auth-ca which needed a manual
+		// fixture since the auth bridge is disabled by default here.
+		err = k8sClient.Get(ctx, types.NamespacedName{Name: gwName + "-gateway-ca", Namespace: "ogo-test"}, &corev1.ConfigMap{})
 		Expect(errors.IsNotFound(err)).To(BeTrue())
 	})
 })


### PR DESCRIPTION
## Summary

- Bearer/OIDC-authenticated clients need the gateway's public TLS CA to establish HTTPS trust with the gateway's own gRPC listener, but that CA was previously only available bundled inside a Secret that also carries client mTLS credentials, or gated behind the auth-bridge-only `-auth-ca` ConfigMap.
- Adds a `<gateway>-gateway-ca` ConfigMap, published whenever gateway TLS is enabled, independent of whether the auth bridge is enabled. Publishes only the public CA chain — no private key, no client credential.
- Both CA ConfigMaps now share a `reconcileCAConfigMap` helper, and gateway-deletion cleanup covers both.

Closes #49.

## Test plan

- [x] Unit/envtest coverage: creation, drift-repair, deletion when TLS is disabled, rejection of takeover of an unmanaged ConfigMap, and cleanup on gateway deletion
- [x] `make manifests generate` produces no diff (no CRD/RBAC changes needed)
- [x] Live-verified on SNO: toggled `spec.tls.enabled` on the staging gateway, confirmed the ConfigMap is created with the correct CA content (matching `-auth-ca`), confirmed drift-repair via the periodic reconcile, confirmed cleanup when TLS is disabled again, then restored the staging CR to its original state