### PR TITLE
fix: reject browser SSO with routing enabled but no hostname

### DIFF
--- a/api/v1alpha1/openshellgateway_types.go
+++ b/api/v1alpha1/openshellgateway_types.go
@@ -305,6 +305,7 @@ const (
 	ConditionOpenShiftGroups    = "OpenShiftGroupsReady"
 	ConditionEnvoyProxySCCReady = "EnvoyProxySCCReady"
 	ConditionEnvoyRouteReady    = "EnvoyRouteReady"
+	ConditionBrowserSSOReady    = "BrowserSSOReady"
 )
 
 // Phase values for OpenShellGateway.

--- a/docs/guides/openshift-sso.md
+++ b/docs/guides/openshift-sso.md
@@ -48,6 +48,14 @@ Browser SSO requires `spec.route.enabled` to be true and an explicit
 hostname. With routing disabled, use the internal HTTPS Service for headless
 token exchange instead; no browser callback is available.
 
+If browser SSO and routing are both enabled but `spec.route.hostname` is
+left empty, OGO does not create the auth Route or `OAuthClient` — a
+router-assigned host isn't known until after the Route exists, so there is
+nothing stable to register as the OAuth redirect URI. The gateway reports
+`Available: False` with a `BrowserSSOReady` condition
+(`Reason: HostnameMissing`) instead of silently registering a redirect that
+can't work. Headless (mTLS/ServiceAccount) access is unaffected either way.
+
 ## User group (required)
 
 The `userGroup` field specifies the OpenShift group required for SSO access.
@@ -101,6 +109,27 @@ expires. If the files are temporarily inconsistent during rotation, the bridge
 continues serving the last valid pair until it can load the replacement.
 
 ## Troubleshooting
+
+### Gateway reports `BrowserSSOReady: False, Reason: HostnameMissing`
+
+Browser SSO (`spec.auth.openshift.enabled`) and routing are both enabled,
+but `spec.route.hostname` is empty. Set it explicitly:
+
+```yaml
+spec:
+  route:
+    hostname: openshell.apps.example.com
+```
+
+Or, for headless-only access (mTLS/ServiceAccount, no browser login), disable
+browser SSO instead:
+
+```yaml
+spec:
+  auth:
+    openshift:
+      enabled: false
+```
 
 ### "access denied: you are not a member of the required OpenShift group"
 

--- a/internal/controller/browser_sso_hostname_test.go
+++ b/internal/controller/browser_sso_hostname_test.go
@@ -17,10 +17,21 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"testing"
 
 	ogov1alpha1 "github.com/aknochow/ogo/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestBrowserSSOMissingHostname(t *testing.T) {
@@ -63,6 +74,111 @@ func TestBrowserSSOMissingHostname(t *testing.T) {
 			}
 			if got := browserSSOMissingHostname(gw, tt.authEnabled); got != tt.want {
 				t.Errorf("browserSSOMissingHostname() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReconcileOpenShiftRoutingBrowserSSOHostname exercises the actual
+// Reconcile-level branching (not just the browserSSOMissingHostname decision
+// function above) with a fake client, proving that a missing hostname really
+// does skip creating the auth-bridge Route/OAuthClient, and that an explicit
+// hostname really does create them. TLS is disabled on the fixture purely to
+// avoid needing a server-tls Secret/CA ConfigMap for this test's own sake -
+// unrelated to the hostname behavior under test.
+func TestReconcileOpenShiftRoutingBrowserSSOHostname(t *testing.T) {
+	routeGVK := schema.GroupVersionKind{Group: "route.openshift.io", Version: "v1", Kind: "Route"}
+	oauthClientGVK := schema.GroupVersionKind{Group: "oauth.openshift.io", Version: "v1", Kind: "OAuthClient"}
+
+	newScheme := func(t *testing.T) *runtime.Scheme {
+		t.Helper()
+		scheme := runtime.NewScheme()
+		if err := corev1.AddToScheme(scheme); err != nil {
+			t.Fatal(err)
+		}
+		if err := rbacv1.AddToScheme(scheme); err != nil {
+			t.Fatal(err)
+		}
+		if err := ogov1alpha1.AddToScheme(scheme); err != nil {
+			t.Fatal(err)
+		}
+		scheme.AddKnownTypeWithName(routeGVK, &unstructured.Unstructured{})
+		scheme.AddKnownTypeWithName(routeGVK.GroupVersion().WithKind("RouteList"), &unstructured.UnstructuredList{})
+		scheme.AddKnownTypeWithName(oauthClientGVK, &unstructured.Unstructured{})
+		metav1.AddToGroupVersion(scheme, routeGVK.GroupVersion())
+		metav1.AddToGroupVersion(scheme, oauthClientGVK.GroupVersion())
+		return scheme
+	}
+
+	const gatewayName = "test-gateway"
+	const namespace = "test-namespace"
+
+	for _, tt := range []struct {
+		name           string
+		hostname       string
+		wantConditions metav1.ConditionStatus
+		wantRoute      bool
+	}{
+		{
+			name:           "no hostname -- auth-bridge Route/OAuthClient must not be created",
+			hostname:       "",
+			wantConditions: metav1.ConditionFalse,
+			wantRoute:      false,
+		},
+		{
+			name:           "explicit hostname -- auth-bridge Route/OAuthClient must be created",
+			hostname:       "openshell.apps.example.com",
+			wantConditions: metav1.ConditionTrue,
+			wantRoute:      true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			gw := &ogov1alpha1.OpenShellGateway{
+				ObjectMeta: metav1.ObjectMeta{Name: gatewayName},
+				Spec: ogov1alpha1.OpenShellGatewaySpec{
+					Namespace: namespace,
+					TLS:       ogov1alpha1.TLSSpec{Enabled: ptr.To(false)},
+					Auth:      ogov1alpha1.AuthSpec{OpenShift: ogov1alpha1.OpenShiftAuth{Enabled: ptr.To(true)}},
+					Route:     ogov1alpha1.RouteSpec{Hostname: tt.hostname},
+				},
+			}
+			r := &OpenShellGatewayReconciler{
+				Client: clientfake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(gw).Build(),
+			}
+
+			step, err := r.reconcileOpenShiftRouting(context.Background(), gw, false, true)
+			if err != nil {
+				t.Fatalf("reconcileOpenShiftRouting: step=%q err=%v", step, err)
+			}
+
+			condition := apimeta.FindStatusCondition(gw.Status.Conditions, ogov1alpha1.ConditionBrowserSSOReady)
+			if condition == nil {
+				t.Fatal("BrowserSSOReady condition was not set")
+			}
+			if condition.Status != tt.wantConditions {
+				t.Errorf("BrowserSSOReady.Status = %v, want %v", condition.Status, tt.wantConditions)
+			}
+
+			route := &unstructured.Unstructured{}
+			route.SetGroupVersionKind(routeGVK)
+			err = r.Get(context.Background(), types.NamespacedName{Name: gatewayName + "-auth", Namespace: namespace}, route)
+			gotRoute := err == nil
+			if !gotRoute && !apierrors.IsNotFound(err) {
+				t.Fatalf("unexpected error getting auth-bridge Route: %v", err)
+			}
+			if gotRoute != tt.wantRoute {
+				t.Errorf("auth-bridge Route exists = %v, want %v", gotRoute, tt.wantRoute)
+			}
+
+			oauthClient := &unstructured.Unstructured{}
+			oauthClient.SetGroupVersionKind(oauthClientGVK)
+			err = r.Get(context.Background(), types.NamespacedName{Name: "openshell"}, oauthClient)
+			gotOAuthClient := err == nil
+			if !gotOAuthClient && !apierrors.IsNotFound(err) {
+				t.Fatalf("unexpected error getting OAuthClient: %v", err)
+			}
+			if gotOAuthClient != tt.wantRoute {
+				t.Errorf("OAuthClient exists = %v, want %v", gotOAuthClient, tt.wantRoute)
 			}
 		})
 	}

--- a/internal/controller/browser_sso_hostname_test.go
+++ b/internal/controller/browser_sso_hostname_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	ogov1alpha1 "github.com/aknochow/ogo/api/v1alpha1"
+	"k8s.io/utils/ptr"
+)
+
+func TestBrowserSSOMissingHostname(t *testing.T) {
+	tests := []struct {
+		name        string
+		authEnabled bool
+		routeSpec   ogov1alpha1.RouteSpec
+		want        bool
+	}{
+		{
+			name:        "browser SSO and routing enabled, no hostname -- the bug in #50",
+			authEnabled: true,
+			routeSpec:   ogov1alpha1.RouteSpec{Hostname: ""},
+			want:        true,
+		},
+		{
+			name:        "browser SSO and routing enabled, explicit hostname",
+			authEnabled: true,
+			routeSpec:   ogov1alpha1.RouteSpec{Hostname: "openshell.apps.example.com"},
+			want:        false,
+		},
+		{
+			name:        "browser SSO enabled, routing explicitly disabled -- headless-shaped, unaffected",
+			authEnabled: true,
+			routeSpec:   ogov1alpha1.RouteSpec{Enabled: ptr.To(false), Hostname: ""},
+			want:        false,
+		},
+		{
+			name:        "browser SSO disabled -- headless-only access, unaffected regardless of hostname",
+			authEnabled: false,
+			routeSpec:   ogov1alpha1.RouteSpec{Hostname: ""},
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw := &ogov1alpha1.OpenShellGateway{
+				Spec: ogov1alpha1.OpenShellGatewaySpec{Route: tt.routeSpec},
+			}
+			if got := browserSSOMissingHostname(gw, tt.authEnabled); got != tt.want {
+				t.Errorf("browserSSOMissingHostname() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/openshellgateway_controller.go
+++ b/internal/controller/openshellgateway_controller.go
@@ -162,6 +162,7 @@ func (r *OpenShellGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	isOCP := openshift.IsOpenShift(r.DiscoveryClient)
 	hasGWAPI := openshift.HasGatewayAPI(r.DiscoveryClient)
 	useGWAPI := gatewayAPIEnabled(gw, hasGWAPI)
+	authEnabled := authBridgeEnabled(gw, isOCP)
 	ns := gatewayNamespace(gw)
 	sandboxNS := sandboxNamespace(gw)
 
@@ -224,72 +225,81 @@ func (r *OpenShellGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	if isOCP {
-		authEnabled := authBridgeEnabled(gw, isOCP)
-		if err := r.reconcileObsoleteRoutes(ctx, gw, useGWAPI, authEnabled); err != nil {
-			log.Error(err, "Failed to clean up obsolete Routes")
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, r.setDegraded(ctx, gw, "RouteCleanup", err)
-		}
-		if useGWAPI {
-			condition, err := r.reconcileEnvoyRoute(ctx, gw)
-			if condition.Type != "" {
-				meta.SetStatusCondition(&gw.Status.Conditions, condition)
-			}
-			// reconcileEnvoyRoute returns nil for the reasonHostnameMissing
-			// case (an incomplete config waiting on the user, not a
-			// reconcile failure - the condition set above already surfaces
-			// exactly what is missing), so any non-nil error here is a
-			// genuine failure. No special-casing needed at this call site.
-			if err != nil {
-				log.Error(err, "Failed to reconcile Envoy Route")
-				return ctrl.Result{RequeueAfter: 30 * time.Second}, r.setDegraded(ctx, gw, "EnvoyRoute", err)
-			}
-		} else {
-			if err := r.reconcileRoute(ctx, gw); err != nil {
-				log.Error(err, "Failed to reconcile Route")
-				return ctrl.Result{RequeueAfter: 30 * time.Second}, r.setDegraded(ctx, gw, "Route", err)
-			}
-		}
-		if err := r.reconcileSCCBinding(ctx, gw); err != nil {
-			log.Error(err, "Failed to reconcile SCC binding")
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, r.setDegraded(ctx, gw, "SCCBinding", err)
-		}
-		if authEnabled {
-			if browserSSOMissingHostname(gw, authEnabled) {
-				// Browser SSO needs a stable, known hostname to register as
-				// the OAuth redirect URI and external issuer (see
-				// authBridgeExternalURL) - a router-assigned host isn't
-				// known until after the Route is created, and OGO never
-				// reads it back. Reject the combination here rather than
-				// silently registering an internal cluster URL as the OAuth
-				// redirect, which would report healthy while browser login
-				// cannot complete. Headless (mTLS/ServiceAccount) access is
-				// unaffected. Same "incomplete config waiting on the user,
-				// not a reconcile failure" shape as reasonHostnameMissing's
-				// other two sites.
-				meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
-					Type: ogov1alpha1.ConditionBrowserSSOReady, Status: metav1.ConditionFalse,
-					Reason: reasonHostnameMissing,
-					Message: "spec.route.hostname is required when OpenShift browser SSO (spec.auth.openshift.enabled) and routing are both enabled; " +
-						"set it explicitly, or disable browser SSO for headless-only (mTLS/ServiceAccount) access",
-				})
-			} else {
-				meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
-					Type: ogov1alpha1.ConditionBrowserSSOReady, Status: metav1.ConditionTrue,
-					Reason: "Ready", Message: "Browser SSO hostname configured",
-				})
-				if err := r.reconcileAuthBridgeRoute(ctx, gw); err != nil {
-					log.Error(err, "Failed to reconcile auth-bridge Route")
-					return ctrl.Result{RequeueAfter: 30 * time.Second}, r.setDegraded(ctx, gw, "AuthBridgeRoute", err)
-				}
-				if err := r.reconcileOAuthClient(ctx, gw); err != nil {
-					log.Error(err, "Failed to reconcile OAuthClient")
-					return ctrl.Result{RequeueAfter: 30 * time.Second}, r.setDegraded(ctx, gw, "OAuthClient", err)
-				}
-			}
+		if step, err := r.reconcileOpenShiftRouting(ctx, gw, useGWAPI, authEnabled); err != nil {
+			log.Error(err, "Failed to reconcile OpenShift routing", "step", step)
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, r.setDegraded(ctx, gw, step, err)
 		}
 	}
 
-	return ctrl.Result{RequeueAfter: requeueInterval}, r.updateStatus(ctx, gw)
+	return ctrl.Result{RequeueAfter: requeueInterval}, r.updateStatus(ctx, gw, authEnabled)
+}
+
+// reconcileOpenShiftRouting reconciles the OpenShift-only Route/SCC/OAuthClient
+// surface (extracted from Reconcile so it's directly unit-testable with a
+// fake client + faked OpenShift discovery, without standing up the full
+// envtest fixture's Phase 1/2 prerequisites). On error, returns the step name
+// that failed so the caller can pass it through to setDegraded unchanged.
+func (r *OpenShellGatewayReconciler) reconcileOpenShiftRouting(ctx context.Context, gw *ogov1alpha1.OpenShellGateway, useGWAPI, authEnabled bool) (string, error) {
+	log := logf.FromContext(ctx)
+
+	if err := r.reconcileObsoleteRoutes(ctx, gw, useGWAPI, authEnabled); err != nil {
+		return "RouteCleanup", err
+	}
+	if useGWAPI {
+		condition, err := r.reconcileEnvoyRoute(ctx, gw)
+		if condition.Type != "" {
+			meta.SetStatusCondition(&gw.Status.Conditions, condition)
+		}
+		// reconcileEnvoyRoute returns nil for the reasonHostnameMissing
+		// case (an incomplete config waiting on the user, not a
+		// reconcile failure - the condition set above already surfaces
+		// exactly what is missing), so any non-nil error here is a
+		// genuine failure. No special-casing needed at this call site.
+		if err != nil {
+			return "EnvoyRoute", err
+		}
+	} else {
+		if err := r.reconcileRoute(ctx, gw); err != nil {
+			return "Route", err
+		}
+	}
+	if err := r.reconcileSCCBinding(ctx, gw); err != nil {
+		return "SCCBinding", err
+	}
+	if authEnabled {
+		if browserSSOMissingHostname(gw, authEnabled) {
+			// Browser SSO needs a stable, known hostname to register as
+			// the OAuth redirect URI and external issuer (see
+			// authBridgeExternalURL) - a router-assigned host isn't
+			// known until after the Route is created, and OGO never
+			// reads it back. Reject the combination here rather than
+			// silently registering an internal cluster URL as the OAuth
+			// redirect, which would report healthy while browser login
+			// cannot complete. Headless (mTLS/ServiceAccount) access is
+			// unaffected. Same "incomplete config waiting on the user,
+			// not a reconcile failure" shape as reasonHostnameMissing's
+			// other two sites.
+			meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
+				Type: ogov1alpha1.ConditionBrowserSSOReady, Status: metav1.ConditionFalse,
+				Reason: reasonHostnameMissing,
+				Message: "spec.route.hostname is required when OpenShift browser SSO (spec.auth.openshift.enabled) and routing are both enabled; " +
+					"set it explicitly, or disable browser SSO for headless-only (mTLS/ServiceAccount) access",
+			})
+		} else {
+			meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
+				Type: ogov1alpha1.ConditionBrowserSSOReady, Status: metav1.ConditionTrue,
+				Reason: "Ready", Message: "Browser SSO hostname configured",
+			})
+			if err := r.reconcileAuthBridgeRoute(ctx, gw); err != nil {
+				return "AuthBridgeRoute", err
+			}
+			if err := r.reconcileOAuthClient(ctx, gw); err != nil {
+				return "OAuthClient", err
+			}
+		}
+	}
+	log.V(1).Info("Reconciled OpenShift routing")
+	return "", nil
 }
 
 // --- Deletion ---
@@ -1612,7 +1622,7 @@ func (r *OpenShellGatewayReconciler) reconcileSCCBinding(ctx context.Context, gw
 
 // --- Status ---
 
-func (r *OpenShellGatewayReconciler) updateStatus(ctx context.Context, gw *ogov1alpha1.OpenShellGateway) error {
+func (r *OpenShellGatewayReconciler) updateStatus(ctx context.Context, gw *ogov1alpha1.OpenShellGateway, authEnabled bool) error {
 	// Re-fetch to avoid conflicts from earlier mutations
 	latest := &ogov1alpha1.OpenShellGateway{}
 	if err := r.Get(ctx, types.NamespacedName{Name: gw.Name}, latest); err != nil {
@@ -1658,16 +1668,15 @@ func (r *OpenShellGatewayReconciler) updateStatus(ctx context.Context, gw *ogov1
 	// ConditionBrowserSSOReady (set in Reconcile) — fold it into
 	// Available/Phase the same way EnvoyRouteReady is above, so the gateway
 	// doesn't report "Running" while browser login is known to be broken.
-	// Only call IsOpenShift when Auth.OpenShift.Enabled is actually unset --
-	// r.DiscoveryClient can be nil in unit tests exercising non-OpenShift
-	// paths (mirrors how envoyRouteActive above only reaches HasGatewayAPI
-	// when routeEnabled(gw) is true, for the same reason).
-	authBridgeActive := false
-	if gw.Spec.Auth.OpenShift.Enabled != nil {
-		authBridgeActive = *gw.Spec.Auth.OpenShift.Enabled
-	} else if r.DiscoveryClient != nil {
-		authBridgeActive = openshift.IsOpenShift(r.DiscoveryClient)
-	}
+	// authEnabled is passed in from Reconcile rather than re-derived here
+	// (contrast envoyRouteActive above, which re-derives via
+	// openshift.HasGatewayAPI) so there is exactly one place that decides
+	// whether the auth bridge is active per reconcile - re-deriving it here
+	// too would risk the two computations silently drifting apart, and
+	// unconditionally calling openshift.IsOpenShift would panic callers that
+	// invoke updateStatus directly with a nil DiscoveryClient (as this
+	// package's other direct-fake-client tests do).
+	authBridgeActive := authEnabled
 	browserSSOBlocking := false
 	if c := meta.FindStatusCondition(gw.Status.Conditions, ogov1alpha1.ConditionBrowserSSOReady); authBridgeActive && c != nil && c.Status != metav1.ConditionTrue {
 		browserSSOBlocking = true
@@ -1678,11 +1687,16 @@ func (r *OpenShellGatewayReconciler) updateStatus(ctx context.Context, gw *ogov1
 
 	blocking := envoyRouteBlocking || browserSSOBlocking
 	blockedReason, blockedMessage := "EnvoyRouteNotReady", "Waiting for the Envoy Gateway Route to become ready"
+	progressingReason := "Deploying"
 	if browserSSOBlocking {
 		// Takes precedence in the rare case both are blocking simultaneously
 		// — it names a user-actionable config gap rather than a transient
 		// wait, so it's the more useful of the two messages to surface.
+		// progressingReason changes too: unlike EnvoyRouteReady catching up
+		// on its own, a missing hostname never self-resolves, so "Deploying"
+		// would misleadingly suggest an in-progress rollout.
 		blockedReason, blockedMessage = reasonHostnameMissing, "spec.route.hostname is required for OpenShift browser SSO — see the BrowserSSOReady condition"
+		progressingReason = "WaitingForConfig"
 	}
 
 	switch {
@@ -1704,7 +1718,7 @@ func (r *OpenShellGatewayReconciler) updateStatus(ctx context.Context, gw *ogov1
 		})
 		meta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
 			Type: ogov1alpha1.ConditionProgressing, Status: metav1.ConditionTrue,
-			Reason: "Deploying", Message: blockedMessage,
+			Reason: progressingReason, Message: blockedMessage,
 		})
 	default:
 		latest.Status.Phase = ogov1alpha1.PhaseCreating

--- a/internal/controller/openshellgateway_controller.go
+++ b/internal/controller/openshellgateway_controller.go
@@ -78,12 +78,14 @@ const (
 	// while doing nothing" problem #51/#52 were filed for.
 	phaseSuperseded = "Superseded"
 
-	// reasonHostnameMissing is set by both reconcileGatewayAPI and
-	// reconcileEnvoyRoute (each independently checks route.hostname, since
-	// one runs regardless of isOCP and the other only on OpenShift), and
-	// checked again at the reconcileEnvoyRoute call site to avoid
-	// escalating this specific reason to Phase: Failed. A shared constant
-	// keeps those three sites from silently drifting apart.
+	// reasonHostnameMissing is set by reconcileGatewayAPI, reconcileEnvoyRoute,
+	// and the browser-SSO check in Reconcile (each independently checks
+	// route.hostname, since they run under different conditions: one
+	// regardless of isOCP, one only on OpenShift with Gateway API, one only
+	// on OpenShift with the auth bridge enabled), and checked again at the
+	// reconcileEnvoyRoute call site to avoid escalating this specific reason
+	// to Phase: Failed. A shared constant keeps those sites from silently
+	// drifting apart.
 	reasonHostnameMissing = "HostnameMissing"
 )
 
@@ -252,13 +254,37 @@ func (r *OpenShellGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, r.setDegraded(ctx, gw, "SCCBinding", err)
 		}
 		if authEnabled {
-			if err := r.reconcileAuthBridgeRoute(ctx, gw); err != nil {
-				log.Error(err, "Failed to reconcile auth-bridge Route")
-				return ctrl.Result{RequeueAfter: 30 * time.Second}, r.setDegraded(ctx, gw, "AuthBridgeRoute", err)
-			}
-			if err := r.reconcileOAuthClient(ctx, gw); err != nil {
-				log.Error(err, "Failed to reconcile OAuthClient")
-				return ctrl.Result{RequeueAfter: 30 * time.Second}, r.setDegraded(ctx, gw, "OAuthClient", err)
+			if browserSSOMissingHostname(gw, authEnabled) {
+				// Browser SSO needs a stable, known hostname to register as
+				// the OAuth redirect URI and external issuer (see
+				// authBridgeExternalURL) - a router-assigned host isn't
+				// known until after the Route is created, and OGO never
+				// reads it back. Reject the combination here rather than
+				// silently registering an internal cluster URL as the OAuth
+				// redirect, which would report healthy while browser login
+				// cannot complete. Headless (mTLS/ServiceAccount) access is
+				// unaffected. Same "incomplete config waiting on the user,
+				// not a reconcile failure" shape as reasonHostnameMissing's
+				// other two sites.
+				meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
+					Type: ogov1alpha1.ConditionBrowserSSOReady, Status: metav1.ConditionFalse,
+					Reason: reasonHostnameMissing,
+					Message: "spec.route.hostname is required when OpenShift browser SSO (spec.auth.openshift.enabled) and routing are both enabled; " +
+						"set it explicitly, or disable browser SSO for headless-only (mTLS/ServiceAccount) access",
+				})
+			} else {
+				meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
+					Type: ogov1alpha1.ConditionBrowserSSOReady, Status: metav1.ConditionTrue,
+					Reason: "Ready", Message: "Browser SSO hostname configured",
+				})
+				if err := r.reconcileAuthBridgeRoute(ctx, gw); err != nil {
+					log.Error(err, "Failed to reconcile auth-bridge Route")
+					return ctrl.Result{RequeueAfter: 30 * time.Second}, r.setDegraded(ctx, gw, "AuthBridgeRoute", err)
+				}
+				if err := r.reconcileOAuthClient(ctx, gw); err != nil {
+					log.Error(err, "Failed to reconcile OAuthClient")
+					return ctrl.Result{RequeueAfter: 30 * time.Second}, r.setDegraded(ctx, gw, "OAuthClient", err)
+				}
 			}
 		}
 	}
@@ -1628,8 +1654,39 @@ func (r *OpenShellGatewayReconciler) updateStatus(ctx context.Context, gw *ogov1
 		meta.RemoveStatusCondition(&latest.Status.Conditions, ogov1alpha1.ConditionEnvoyRouteReady)
 	}
 
+	// Browser SSO reports its own hostname precondition via
+	// ConditionBrowserSSOReady (set in Reconcile) — fold it into
+	// Available/Phase the same way EnvoyRouteReady is above, so the gateway
+	// doesn't report "Running" while browser login is known to be broken.
+	// Only call IsOpenShift when Auth.OpenShift.Enabled is actually unset --
+	// r.DiscoveryClient can be nil in unit tests exercising non-OpenShift
+	// paths (mirrors how envoyRouteActive above only reaches HasGatewayAPI
+	// when routeEnabled(gw) is true, for the same reason).
+	authBridgeActive := false
+	if gw.Spec.Auth.OpenShift.Enabled != nil {
+		authBridgeActive = *gw.Spec.Auth.OpenShift.Enabled
+	} else if r.DiscoveryClient != nil {
+		authBridgeActive = openshift.IsOpenShift(r.DiscoveryClient)
+	}
+	browserSSOBlocking := false
+	if c := meta.FindStatusCondition(gw.Status.Conditions, ogov1alpha1.ConditionBrowserSSOReady); authBridgeActive && c != nil && c.Status != metav1.ConditionTrue {
+		browserSSOBlocking = true
+	}
+	if !authBridgeActive {
+		meta.RemoveStatusCondition(&latest.Status.Conditions, ogov1alpha1.ConditionBrowserSSOReady)
+	}
+
+	blocking := envoyRouteBlocking || browserSSOBlocking
+	blockedReason, blockedMessage := "EnvoyRouteNotReady", "Waiting for the Envoy Gateway Route to become ready"
+	if browserSSOBlocking {
+		// Takes precedence in the rare case both are blocking simultaneously
+		// — it names a user-actionable config gap rather than a transient
+		// wait, so it's the more useful of the two messages to surface.
+		blockedReason, blockedMessage = reasonHostnameMissing, "spec.route.hostname is required for OpenShift browser SSO — see the BrowserSSOReady condition"
+	}
+
 	switch {
-	case podsReady && !envoyRouteBlocking:
+	case podsReady && !blocking:
 		latest.Status.Phase = ogov1alpha1.PhaseRunning
 		meta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
 			Type: ogov1alpha1.ConditionAvailable, Status: metav1.ConditionTrue,
@@ -1639,15 +1696,15 @@ func (r *OpenShellGatewayReconciler) updateStatus(ctx context.Context, gw *ogov1
 			Type: ogov1alpha1.ConditionProgressing, Status: metav1.ConditionFalse,
 			Reason: "Complete", Message: "Rollout complete",
 		})
-	case podsReady && envoyRouteBlocking:
+	case podsReady && blocking:
 		latest.Status.Phase = ogov1alpha1.PhaseCreating
 		meta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
 			Type: ogov1alpha1.ConditionAvailable, Status: metav1.ConditionFalse,
-			Reason: "EnvoyRouteNotReady", Message: "Waiting for the Envoy Gateway Route to become ready",
+			Reason: blockedReason, Message: blockedMessage,
 		})
 		meta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
 			Type: ogov1alpha1.ConditionProgressing, Status: metav1.ConditionTrue,
-			Reason: "Deploying", Message: "Waiting for the Envoy Gateway Route",
+			Reason: "Deploying", Message: blockedMessage,
 		})
 	default:
 		latest.Status.Phase = ogov1alpha1.PhaseCreating
@@ -1672,8 +1729,12 @@ func (r *OpenShellGatewayReconciler) updateStatus(ctx context.Context, gw *ogov1
 		ogov1alpha1.ConditionEnvoyProxySCCReady,
 		ogov1alpha1.ConditionOpenShiftGroups,
 		ogov1alpha1.ConditionEnvoyRouteReady,
+		ogov1alpha1.ConditionBrowserSSOReady,
 	} {
 		if condType == ogov1alpha1.ConditionEnvoyRouteReady && !envoyRouteActive {
+			continue
+		}
+		if condType == ogov1alpha1.ConditionBrowserSSOReady && !authBridgeActive {
 			continue
 		}
 		if c := meta.FindStatusCondition(gw.Status.Conditions, condType); c != nil {
@@ -1816,6 +1877,16 @@ func authBridgeEnabled(gw *ogov1alpha1.OpenShellGateway, isOCP bool) bool {
 		return *gw.Spec.Auth.OpenShift.Enabled
 	}
 	return isOCP
+}
+
+// browserSSOMissingHostname reports whether browser SSO (the auth bridge)
+// and routing are both enabled but no hostname is configured -- the
+// combination issue #50 was filed against, where the OAuth redirect and
+// external issuer can't be derived from a router-assigned host that OGO
+// never reads back. Headless (mTLS/ServiceAccount) access and
+// routing-disabled deployments are unaffected.
+func browserSSOMissingHostname(gw *ogov1alpha1.OpenShellGateway, authEnabled bool) bool {
+	return authEnabled && routeEnabled(gw) && gw.Spec.Route.Hostname == ""
 }
 
 func authBridgeImage(gw *ogov1alpha1.OpenShellGateway) string {

--- a/internal/controller/openshellgateway_controller_test.go
+++ b/internal/controller/openshellgateway_controller_test.go
@@ -248,7 +248,7 @@ var _ = Describe("OpenShellGateway Controller", func() {
 		})
 		Expect(k8sClient.Status().Update(ctx, gw)).To(Succeed())
 
-		Expect(r.updateStatus(ctx, gw)).To(Succeed())
+		Expect(r.updateStatus(ctx, gw, false)).To(Succeed())
 
 		updated := &ogov1alpha1.OpenShellGateway{}
 		Expect(k8sClient.Get(ctx, gwKey, updated)).To(Succeed())
@@ -285,7 +285,7 @@ var _ = Describe("OpenShellGateway Controller", func() {
 		})
 		Expect(k8sClient.Status().Update(ctx, gw)).To(Succeed())
 
-		Expect(r.updateStatus(ctx, gw)).To(Succeed())
+		Expect(r.updateStatus(ctx, gw, true)).To(Succeed())
 
 		updated := &ogov1alpha1.OpenShellGateway{}
 		Expect(k8sClient.Get(ctx, gwKey, updated)).To(Succeed())
@@ -298,7 +298,7 @@ var _ = Describe("OpenShellGateway Controller", func() {
 		// Disabling browser SSO again should clear the stale condition rather
 		// than leaving it to block Available forever.
 		gw.Spec.Auth.OpenShift.Enabled = ptr.To(false)
-		Expect(r.updateStatus(ctx, gw)).To(Succeed())
+		Expect(r.updateStatus(ctx, gw, false)).To(Succeed())
 		Expect(k8sClient.Get(ctx, gwKey, updated)).To(Succeed())
 		Expect(meta.FindStatusCondition(updated.Status.Conditions, ogov1alpha1.ConditionBrowserSSOReady)).To(BeNil())
 	})

--- a/internal/controller/openshellgateway_controller_test.go
+++ b/internal/controller/openshellgateway_controller_test.go
@@ -259,6 +259,50 @@ var _ = Describe("OpenShellGateway Controller", func() {
 		Expect(available.Reason).To(Equal("EnvoyRouteNotReady"))
 	})
 
+	It("should not report Available while browser SSO is missing a hostname, even with pods Ready", func() {
+		r := reconciler()
+		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
+		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
+
+		deploy := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: gwName, Namespace: "ogo-test"}, deploy)).To(Succeed())
+		deploy.Status.Replicas = 1
+		deploy.Status.ReadyReplicas = 1
+		Expect(k8sClient.Status().Update(ctx, deploy)).To(Succeed())
+
+		gw := &ogov1alpha1.OpenShellGateway{}
+		Expect(k8sClient.Get(ctx, gwKey, gw)).To(Succeed())
+		gw.Spec.Auth.OpenShift.Enabled = ptr.To(true)
+		Expect(k8sClient.Update(ctx, gw)).To(Succeed())
+		Expect(k8sClient.Get(ctx, gwKey, gw)).To(Succeed())
+		// Simulates what Reconcile sets when browser SSO and routing are both
+		// enabled but spec.route.hostname is empty (issue #50) - the resource
+		// used to report Available=True/Phase=Running here even though the
+		// OAuth redirect and external issuer had nothing to derive from.
+		meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
+			Type: ogov1alpha1.ConditionBrowserSSOReady, Status: metav1.ConditionFalse,
+			Reason: reasonHostnameMissing, Message: "spec.route.hostname is required",
+		})
+		Expect(k8sClient.Status().Update(ctx, gw)).To(Succeed())
+
+		Expect(r.updateStatus(ctx, gw)).To(Succeed())
+
+		updated := &ogov1alpha1.OpenShellGateway{}
+		Expect(k8sClient.Get(ctx, gwKey, updated)).To(Succeed())
+		Expect(updated.Status.Phase).To(Equal(ogov1alpha1.PhaseCreating))
+		available := meta.FindStatusCondition(updated.Status.Conditions, ogov1alpha1.ConditionAvailable)
+		Expect(available).NotTo(BeNil())
+		Expect(available.Status).To(Equal(metav1.ConditionFalse))
+		Expect(available.Reason).To(Equal(reasonHostnameMissing))
+
+		// Disabling browser SSO again should clear the stale condition rather
+		// than leaving it to block Available forever.
+		gw.Spec.Auth.OpenShift.Enabled = ptr.To(false)
+		Expect(r.updateStatus(ctx, gw)).To(Succeed())
+		Expect(k8sClient.Get(ctx, gwKey, updated)).To(Succeed())
+		Expect(meta.FindStatusCondition(updated.Status.Conditions, ogov1alpha1.ConditionBrowserSSOReady)).To(BeNil())
+	})
+
 	It("should create a Service", func() {
 		r := reconciler()
 		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})

--- a/internal/controller/route_disabled_test.go
+++ b/internal/controller/route_disabled_test.go
@@ -291,7 +291,7 @@ func TestDisabledRouteClearsEnvoyCondition(t *testing.T) {
 		Build()
 	r := &OpenShellGatewayReconciler{Client: fakeClient}
 
-	if err := r.updateStatus(context.Background(), gw); err != nil {
+	if err := r.updateStatus(context.Background(), gw, false); err != nil {
 		t.Fatalf("update status: %v", err)
 	}
 	updated := &ogov1alpha1.OpenShellGateway{}


### PR DESCRIPTION
## Summary

- OGO let OpenShift routing and browser SSO (`spec.auth.openshift.enabled`) be enabled together while `spec.route.hostname` was left empty for the router to assign. The OAuth redirect URI and external issuer are derived from `spec.route.hostname` before that assigned host exists, and OGO never reads it back from the created Route, so the auth-bridge Route and `OAuthClient` ended up pointing at an internal cluster URL instead. The gateway reported healthy while browser login could not complete.
- Rejects the combination instead: when browser SSO and routing are both enabled with no explicit hostname, skip creating the auth-bridge Route and `OAuthClient`, and report a `BrowserSSOReady=False` condition (`Reason: HostnameMissing`) that blocks `Available`/`Phase` the same way `EnvoyRouteReady` already does for the Gateway API ingress path.
- Headless (mTLS/ServiceAccount) access is unaffected, and this only applies when routing is enabled — disabling routing keeps working as before.

Closes #50.

## Test plan

- [x] New unit test (`TestBrowserSSOMissingHostname`) covering the gating decision: browser SSO + routing enabled + no hostname (blocked), explicit hostname (allowed), routing disabled (unaffected/headless), browser SSO disabled (unaffected)
- [x] New fake-client test (`TestReconcileOpenShiftRoutingBrowserSSOHostname`) proving the actual reconcile branching skips creating the auth-bridge Route/OAuthClient when hostname is missing, and creates them when it's set
- [x] New envtest coverage: `Available=False`/`Phase=Creating` while `BrowserSSOReady=False`, and the condition clears when browser SSO is disabled again
- [x] Full existing controller test suite passes
- [x] `make manifests generate` produces no diff
- [x] Live-verified on SNO: removed `spec.route.hostname` entirely from the staging gateway (confirmed the CRD's own pattern validation separately rejects an explicit empty string, so this had to be a real field removal, not `hostname: ""`) and confirmed `BrowserSSOReady=False`/`Available=False` with the expected messages, that the existing auth-bridge Route and OAuthClient were left untouched rather than corrupted with a broken redirect, and that restoring the hostname fully self-healed everything (`Available=True`, `BrowserSSOReady=True`, main Route recreated)
