### PR TITLE
docs: document mounting existing PVCs into sandboxes via driver_config

### DIFF
--- a/docs.toml
+++ b/docs.toml
@@ -70,6 +70,7 @@ img   = "https://img.shields.io/badge/OpenShell-v0.0.96-76b900?logo=nvidia&logoC
   { "Envoy Gateway" = "guides/envoy-gateway.md" },
   { "OpenShift SSO" = "guides/openshift-sso.md" },
   { "Dev Spaces" = "guides/devspaces.md" },
+  { "Shared Volumes" = "guides/shared-volumes.md" },
 ]
 
 [[project.nav]]
@@ -87,4 +88,5 @@ img   = "https://img.shields.io/badge/OpenShell-v0.0.96-76b900?logo=nvidia&logoC
   { "Claude Code + Anthropic" = "examples/claude-code.md" },
   { "Claude Code + Vertex AI" = "examples/vertex-ai.md" },
   { "Developer Policy" = "examples/developer-policy.md" },
+  { "Tekton Shared Workspace" = "examples/tekton-shared-workspace.md" },
 ]

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -9,3 +9,4 @@ description: Ready-to-use configurations for common deployment patterns.
 - [Claude Code + Anthropic](claude-code.md) - direct Anthropic API access
 - [Claude Code + Vertex AI](vertex-ai.md) - Google Vertex AI inference
 - [Developer Policy](developer-policy.md) - GitHub, PyPI, npm access
+- [Tekton Shared Workspace](tekton-shared-workspace.md) - CI/CD pipeline with a sandboxed step sharing a PVC

--- a/docs/examples/tekton-shared-workspace.md
+++ b/docs/examples/tekton-shared-workspace.md
@@ -1,0 +1,122 @@
+---
+type: Example
+title: Tekton Shared Workspace
+description: A Tekton Task where non-sandboxed steps prepare and finalize a workspace PVC, and a sandboxed step runs an AI agent against the same PVC.
+tags: [sandbox, tekton, ci-cd, pvc]
+---
+
+# Tekton shared workspace
+
+This example demonstrates the pattern from
+[Shared volumes](../guides/shared-volumes.md): a pipeline orchestrator
+manages a workspace PVC across steps, where a non-sandboxed step prepares
+the workspace, a **sandboxed** step runs an AI agent against it, and a
+final non-sandboxed step processes results — all sharing one PVC.
+
+## Key point: the sandboxed step is a separate pod
+
+Unlike a normal Tekton step (a container in the Task's own pod), the
+"sandboxed step" below doesn't run the agent directly. It runs the
+`openshell` CLI, which calls the gateway to create a **separate** Sandbox
+pod elsewhere in the sandbox namespace, waits for it to finish (via
+`--no-keep` and a trailing command), and exits. Both pods — the Tekton
+Task pod and the sandbox pod — need to mount the same PVC, which is
+exactly the scenario the
+[RWO scheduling section](../guides/shared-volumes.md#rwo-scheduling) of the
+shared-volumes guide covers. Use `ReadWriteMany` storage for this PVC if
+your cluster offers it.
+
+## Task
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: agent-shared-workspace
+spec:
+  workspaces:
+    - name: shared-workspace
+  steps:
+    - name: prepare
+      image: alpine/git
+      script: |
+        #!/bin/sh
+        set -eu
+        git clone https://github.com/example/repo.git $(workspaces.shared-workspace.path)/repo
+
+    - name: run-agent-sandbox
+      # A custom image with the openshell CLI installed and the gateway's
+      # mTLS client cert already registered (see Authentication in
+      # docs/concepts/authentication.md) - baking this in avoids repeating
+      # `openshell gateway add` setup on every pipeline run.
+      image: quay.io/myorg/openshell-cli:latest
+      script: |
+        #!/bin/sh
+        set -eu
+        openshell sandbox create \
+          --gateway my-gateway \
+          --no-keep \
+          --driver-config-json '{
+            "kubernetes": {
+              "volumes": [
+                {"name": "shared", "persistent_volume_claim": {"claim_name": "'"$(context.taskRun.name)"'-shared-workspace"}}
+              ],
+              "containers": {
+                "agent": {
+                  "volume_mounts": [
+                    {"name": "shared", "mount_path": "/workspace"}
+                  ]
+                }
+              }
+            }
+          }' \
+          -- sh -c 'cd /workspace/repo && claude "fix the failing tests"'
+
+    - name: push-results
+      image: alpine/git
+      script: |
+        #!/bin/sh
+        set -eu
+        cd $(workspaces.shared-workspace.path)/repo
+        git push origin HEAD:agent-fix-$(context.taskRun.name)
+```
+
+## PipelineRun binding
+
+```yaml
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: agent-fix-run
+spec:
+  taskRunTemplate:
+    serviceAccountName: ci-pipeline
+  workspaces:
+    - name: shared-workspace
+      persistentVolumeClaim:
+        claimName: agent-fix-run-shared-workspace
+```
+
+The PVC referenced here (`agent-fix-run-shared-workspace`) must:
+
+- Already exist (or be created by a preceding `VolumeClaimTemplate`/step) —
+  it's an **existing** PVC from the sandbox's point of view, per
+  [Shared volumes](../guides/shared-volumes.md)
+- Live in the same namespace as `spec.sandbox.namespace` on the
+  `OpenShellGateway` CR, so the sandbox pod created in `run-agent-sandbox`
+  can mount it
+- Use `ReadWriteMany` storage if available, to avoid the RWO
+  same-node-scheduling constraint between the Tekton pod and the sandbox
+  pod
+
+The `ci-pipeline` ServiceAccount is the same one granted workspace
+membership in the
+[`OpenShellWorkspaceMember` sample](https://github.com/aknochow/ogo/tree/main/config/samples) —
+see [Shared volumes](../guides/shared-volumes.md#authentication-for-non-interactive-callers)
+for the two supported non-interactive auth paths.
+
+## See also
+
+- [Shared volumes](../guides/shared-volumes.md)
+- [Sandbox](../concepts/sandbox.md)
+- [Workspace Membership](../concepts/workspace-membership.md)

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -11,3 +11,4 @@ description: Step-by-step walkthroughs for deploying and configuring OGO.
 - [Envoy Gateway](envoy-gateway.md) - gRPC ingress with Let's Encrypt TLS
 - [OpenShift SSO](openshift-sso.md) - "Log in with OpenShift" for the CLI
 - [Dev Spaces](devspaces.md) - create sandboxes from Dev Spaces workspaces
+- [Shared Volumes](shared-volumes.md) - mount existing PVCs into sandboxes for CI/CD and shared datasets

--- a/docs/guides/shared-volumes.md
+++ b/docs/guides/shared-volumes.md
@@ -1,0 +1,156 @@
+---
+type: Guide
+title: Shared Volumes
+description: Mount existing PVCs, ConfigMaps, and Secrets into OGO-managed sandboxes for CI/CD pipelines and shared datasets.
+tags: [sandbox, storage, pvc, ci-cd]
+---
+
+# Shared volumes
+
+OGO-managed sandboxes normally get one auto-provisioned PVC for the
+`/sandbox` workspace directory (see [Sandbox](../concepts/sandbox.md)). This
+guide covers mounting an **additional, pre-existing** PVC (or ConfigMap or
+Secret) into a sandbox pod — for sharing a workspace across pipeline steps,
+serving a read-only dataset to multiple sandboxes, or injecting
+configuration that shouldn't live in the sandbox image.
+
+## Is this a CRD feature or a passthrough?
+
+OGO's operator never mediates individual sandbox creation requests — it
+only provisions the `<gateway>-sandbox` ServiceAccount, RBAC, and namespace
+scaffolding that CI callers and the CLI use to talk to the gateway
+directly. OGO's own code contains no Go types or proto definitions for the
+`agents.x-k8s.io` `Sandbox` CRD's spec; a sandbox is created and owned
+entirely by the OpenShell gateway binary in response to a `CreateSandbox`
+call, independent of OGO's reconcile loop. So the existing-PVC-mount
+capability upstream added ([NVIDIA/OpenShell#2034](https://github.com/NVIDIA/OpenShell/pull/2034))
+is available to any OGO-managed gateway today, with **no OGO CRD or
+controller changes required** — it's a matter of passing the right
+request, not configuring the operator.
+
+Confirm the mechanism yourself:
+
+```bash
+openshell sandbox create --help
+```
+
+Look for `--driver-config-json`, documented as an "Experimental
+driver-keyed JSON object for driver-specific sandbox settings" whose
+"[v]alidation behavior is not yet finalized." For the Kubernetes driver,
+this accepts `kubernetes.volumes` (standard pod
+[`Volume`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#volume-v1-core)
+entries) and `kubernetes.containers.agent.volume_mounts` (standard
+[`VolumeMount`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#volumemount-v1-core)
+entries), per the upstream issue. Since the flag is marked experimental,
+verify the exact JSON shape against your installed OpenShell CLI's own
+`--help` output before relying on it in a pipeline — this guide documents
+the field paths and OGO-specific deployment constraints, not a stable
+upstream schema OGO controls.
+
+Requires the gateway's OpenShell version to be `>= v0.0.82` (the version
+`driver_config.kubernetes.volumes`/`volume_mounts` first shipped in).
+Check your gateway's pinned version:
+
+```bash
+oc get openshellgateway -o jsonpath='{.items[0].spec.imageTag}'
+```
+
+## Usage
+
+```bash
+openshell sandbox create \
+  --driver-config-json '{
+    "kubernetes": {
+      "volumes": [
+        {"name": "shared", "persistent_volume_claim": {"claim_name": "my-existing-pvc"}}
+      ],
+      "containers": {
+        "agent": {
+          "volume_mounts": [
+            {"name": "shared", "mount_path": "/data"}
+          ]
+        }
+      }
+    }
+  }' \
+  -- ls /data
+```
+
+This is additive: the sandbox's own auto-provisioned workspace PVC still
+gets mounted at `/sandbox` as usual. `/data` in this example is a second,
+independent mount pointing at a PVC that already exists before the sandbox
+was created.
+
+## Deployment constraints
+
+### Namespace alignment
+
+The sandbox pod and the PVC must be in the **same namespace** — a Sandbox
+spec references a PVC by name only, with no cross-namespace mount
+mechanism. OGO's `spec.sandbox.namespace` (default: the gateway's own
+namespace) controls where sandbox pods are created. If your workload that
+needs to share a PVC with sandboxes runs in a different namespace than
+`spec.sandbox.namespace`, either:
+
+- Move the workload into the sandbox namespace, or
+- Point `spec.sandbox.namespace` at the workload's namespace.
+
+Cross-namespace PVC access isn't supported by the underlying mechanism, so
+there's no OGO-side workaround for this — the
+[recommended approach](../reference/openshellgateway.md) is one gateway per
+team, with the sandbox namespace matching the team's workload namespace,
+rather than trying to share PVCs across namespace boundaries.
+
+### Authentication for non-interactive callers
+
+A CI pipeline step or controller creating sandboxes non-interactively needs
+a supported auth path — the same two options documented in
+[Authentication](../concepts/authentication.md):
+
+- **mTLS** — works today, no extra setup. Extract the gateway's client
+  certificate and use it with `openshell gateway add ... --local` or
+  `--remote` (see the mTLS section of the Authentication doc).
+- **ServiceAccount identity** — as of
+  [`OpenShellWorkspaceMember`](../concepts/workspace-membership.md)
+  (shipped v0.3.0), a Kubernetes ServiceAccount in the same namespace as
+  the gateway can be granted workspace membership declaratively, letting a
+  CI pipeline authenticate as its own ServiceAccount instead of
+  distributing a shared mTLS client certificate. See the
+  [sample CR](https://github.com/aknochow/ogo/tree/main/config/samples) for
+  a `ci-pipeline`-style grant.
+
+### RWO scheduling
+
+This is the constraint most likely to bite a shared-workspace CI/CD
+pattern, and it's a Kubernetes volume-binding property, not something OGO
+or OpenShell control:
+
+- A `ReadWriteOnce` (RWO) PVC can be mounted by multiple pods
+  **concurrently only if those pods land on the same node**. A
+  `ReadWriteOnce` claim restricts attachment to one node at a time — not
+  one pod — but Kubernetes doesn't guarantee co-location unless you tell it
+  to.
+- The common failure mode: a CI system (e.g. Tekton) holds a workspace PVC
+  mounted in its own pod for the full duration of a multi-step Task, and a
+  sandbox pod created mid-task also needs that PVC. If the scheduler places
+  the sandbox pod on a different node, it gets stuck `Pending` with a
+  `FailedAttachVolume`/multi-attach error — nothing about the sandbox
+  itself is broken, the volume just can't attach to two nodes
+  simultaneously.
+- **Prefer a `ReadWriteMany` (RWX) storage class** for any PVC that will be
+  concurrently mounted by a CI pod and a sandbox pod, if your cluster's
+  storage provider offers one (e.g. NFS-backed, CephFS, or a cloud
+  provider's RWX-capable class).
+- If only RWO storage is available, either avoid true concurrency (don't
+  create the sandbox until the CI pod has released the mount, and vice
+  versa — awkward with Tekton's per-Task pod-lifetime volume mounting), or
+  pin both the CI pod and the sandbox pod to the same node with matching
+  `nodeSelector`/affinity rules. Neither is as simple as just switching to
+  RWX if you have the option.
+
+## See also
+
+- [Tekton shared-workspace example](../examples/tekton-shared-workspace.md)
+- [Sandbox](../concepts/sandbox.md)
+- [Workspace Membership](../concepts/workspace-membership.md)
+- [Authentication](../concepts/authentication.md)


### PR DESCRIPTION
## Summary

- Upstream OpenShell's Kubernetes driver added support for mounting existing PVCs/ConfigMaps/Secrets into sandbox pods via `driver_config.kubernetes.volumes` and `driver_config.kubernetes.containers.agent.volume_mounts` ([NVIDIA/OpenShell#2034](https://github.com/NVIDIA/OpenShell/pull/2034)), already satisfied by OGO's current OpenShell pin.
- Assessed whether this needs OGO CRD/controller changes: it does not. OGO vendors no Go or proto types for the `agents.x-k8s.io` Sandbox CRD at all, and the vendored proto subset explicitly omits every sandbox-creation RPC by design (only workspace membership, provider credentials, and the policy lock are vendored). Sandbox creation is entirely mediated by the `openshell` CLI/gateway binary, outside OGO's reconcile loop. The mechanism is fully expressible today via the CLI's existing `--driver-config-json` flag.
- Adds a guide (`docs/guides/shared-volumes.md`) covering the docs-vs-CRD assessment, namespace alignment, both supported non-interactive auth paths (mTLS today, ServiceAccount via `OpenShellWorkspaceMember` as of v0.3.0), and an RWO/RWX scheduling gotcha for concurrent CI-pod + sandbox-pod access to the same PVC.
- Adds a Tekton Task example (`docs/examples/tekton-shared-workspace.md`) demonstrating the shared-workspace pattern, with an explicit callout that the "sandboxed step" is architecturally a separate pod, not a normal same-pod Tekton step.

Closes #61.

## Test plan

- [x] `make docs-lint`: 0 warnings, 26 docs checked
- [x] `make docs`: builds clean, 26 pages including both new ones
- [x] Verified `--driver-config-json` is a real, existing flag on the installed `openshell` CLI (`openshell sandbox create --help`)
- [ ] Live E2E validation (actual sandbox creation with a mounted existing PVC): not performed — this is a docs-only change with no OGO code changes, exempt from this project's SNO live-verify gate per its own release-verification policy