### PR TITLE
fix: guard against digest+imageTag concatenation in gateway Deployment

### DIFF
--- a/api/v1alpha1/openshellgateway_types.go
+++ b/api/v1alpha1/openshellgateway_types.go
@@ -306,6 +306,7 @@ const (
 	ConditionEnvoyProxySCCReady = "EnvoyProxySCCReady"
 	ConditionEnvoyRouteReady    = "EnvoyRouteReady"
 	ConditionBrowserSSOReady    = "BrowserSSOReady"
+	ConditionImageConfigValid   = "ImageConfigValid"
 )
 
 // Phase values for OpenShellGateway.

--- a/internal/controller/openshellgateway_controller.go
+++ b/internal/controller/openshellgateway_controller.go
@@ -834,9 +834,30 @@ func (r *OpenShellGatewayReconciler) reconcileDeployment(ctx context.Context, gw
 		if image == "" {
 			image = "ghcr.io/nvidia/openshell/gateway"
 		}
-		if gw.Spec.ImageTag != "" {
-			image = image + ":" + gw.Spec.ImageTag
+
+		// A digest reference is already fully pinned; appending imageTag
+		// would produce an invalid "image@sha256:...:tag" reference that
+		// Kubernetes rejects as InvalidImageName. That combination stuck a
+		// Deployment silently for 9 hours on RDU (2026-08-03) with
+		// Available still True on the old ReplicaSet - surface the ignored
+		// tag via ConditionImageConfigValid instead of dropping it with no
+		// trace.
+		imageConfigCondition := metav1.Condition{
+			Type: ogov1alpha1.ConditionImageConfigValid, Status: metav1.ConditionTrue, Reason: "OK",
 		}
+		if gw.Spec.ImageTag != "" {
+			if strings.Contains(image, "@") {
+				imageConfigCondition = metav1.Condition{
+					Type: ogov1alpha1.ConditionImageConfigValid, Status: metav1.ConditionFalse,
+					Reason: "ImageTagIgnored",
+					Message: fmt.Sprintf("spec.imageTag %q is ignored because spec.image is already digest-pinned (%s)",
+						gw.Spec.ImageTag, image),
+				}
+			} else {
+				image = image + ":" + gw.Spec.ImageTag
+			}
+		}
+		meta.SetStatusCondition(&gw.Status.Conditions, imageConfigCondition)
 
 		container := corev1.Container{
 			Name:  "openshell-gateway",
@@ -1783,6 +1804,7 @@ func (r *OpenShellGatewayReconciler) updateStatus(ctx context.Context, gw *ogov1
 		ogov1alpha1.ConditionOpenShiftGroups,
 		ogov1alpha1.ConditionEnvoyRouteReady,
 		ogov1alpha1.ConditionBrowserSSOReady,
+		ogov1alpha1.ConditionImageConfigValid,
 	} {
 		if condType == ogov1alpha1.ConditionEnvoyRouteReady && !envoyRouteActive {
 			continue

--- a/internal/controller/openshellgateway_controller_test.go
+++ b/internal/controller/openshellgateway_controller_test.go
@@ -548,6 +548,57 @@ var _ = Describe("OpenShellGateway Controller", func() {
 		Expect(container.Image).To(ContainSubstring("openshell/gateway"))
 	})
 
+	It("should not append imageTag onto a digest-pinned image", func() {
+		r := reconciler()
+		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
+
+		gw := &ogov1alpha1.OpenShellGateway{}
+		Expect(k8sClient.Get(ctx, gwKey, gw)).To(Succeed())
+		const digestImage = "ghcr.io/nvidia/openshell/gateway@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+		gw.Spec.Image = digestImage
+		gw.Spec.ImageTag = "0.0.92"
+		Expect(k8sClient.Update(ctx, gw)).To(Succeed())
+		Expect(k8sClient.Get(ctx, gwKey, gw)).To(Succeed())
+
+		// Regression test for the RDU incident (2026-08-03): concatenating
+		// a non-empty imageTag onto an already digest-pinned image produced
+		// "image@sha256:...:tag", an invalid OCI reference Kubernetes
+		// rejects as InvalidImageName.
+		Expect(r.reconcileDeployment(ctx, gw)).To(Succeed())
+
+		deploy := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: gwName, Namespace: "ogo-test"}, deploy)).To(Succeed())
+		Expect(deploy.Spec.Template.Spec.Containers[0].Image).To(Equal(digestImage))
+
+		condition := meta.FindStatusCondition(gw.Status.Conditions, ogov1alpha1.ConditionImageConfigValid)
+		Expect(condition).NotTo(BeNil())
+		Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+		Expect(condition.Reason).To(Equal("ImageTagIgnored"))
+	})
+
+	It("should append imageTag onto a non-digest image", func() {
+		r := reconciler()
+		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})
+
+		gw := &ogov1alpha1.OpenShellGateway{}
+		Expect(k8sClient.Get(ctx, gwKey, gw)).To(Succeed())
+		gw.Spec.Image = "ghcr.io/nvidia/openshell/gateway"
+		gw.Spec.ImageTag = "0.0.92"
+		Expect(k8sClient.Update(ctx, gw)).To(Succeed())
+		Expect(k8sClient.Get(ctx, gwKey, gw)).To(Succeed())
+
+		Expect(r.reconcileDeployment(ctx, gw)).To(Succeed())
+
+		deploy := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: gwName, Namespace: "ogo-test"}, deploy)).To(Succeed())
+		Expect(deploy.Spec.Template.Spec.Containers[0].Image).To(Equal("ghcr.io/nvidia/openshell/gateway:0.0.92"))
+
+		condition := meta.FindStatusCondition(gw.Status.Conditions, ogov1alpha1.ConditionImageConfigValid)
+		Expect(condition).NotTo(BeNil())
+		Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+		Expect(condition.Reason).To(Equal("OK"))
+	})
+
 	It("should mount TLS volumes when TLS enabled", func() {
 		r := reconciler()
 		_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: gwKey})

--- a/internal/gateway/config_test.go
+++ b/internal/gateway/config_test.go
@@ -97,6 +97,31 @@ func TestRenderGatewayTOML_TLSDisabled(t *testing.T) {
 	}
 }
 
+func TestRenderGatewayTOML_SupervisorImageDigestPinned(t *testing.T) {
+	// Regression check for the same class of bug fixed in the controller's
+	// gateway-image handling (RDU incident, 2026-08-03): a digest-pinned
+	// image plus a non-empty ImageTag must not concatenate into an invalid
+	// "image@sha256:...:tag" reference. supervisorImage() already guards
+	// this (any ":" in the image, including the one inside "sha256:",
+	// suppresses the tag append) - this test locks that behavior in.
+	const digestImage = "ghcr.io/nvidia/openshell/supervisor@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	gw := &ogov1alpha1.OpenShellGateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "openshell"},
+		Spec: ogov1alpha1.OpenShellGatewaySpec{
+			Namespace:       "openshell",
+			Database:        ogov1alpha1.DatabaseSpec{SecretName: "pg-uri"},
+			SupervisorImage: digestImage,
+			ImageTag:        "0.0.92",
+		},
+	}
+
+	toml := RenderGatewayTOML(gw, "openshell")
+
+	if !strings.Contains(toml, `supervisor_image      = "`+digestImage+`"`) {
+		t.Errorf("expected supervisor_image to remain digest-pinned without an appended tag, got:\n%s", toml)
+	}
+}
+
 func TestRenderGatewayTOML_CustomSandbox(t *testing.T) {
 	gw := &ogov1alpha1.OpenShellGateway{
 		ObjectMeta: metav1.ObjectMeta{Name: "openshell"},


### PR DESCRIPTION
## Summary
- Guards `ensureDeployment` against concatenating a digest-pinned `spec.image` with a non-empty `spec.imageTag` into an invalid `image@sha256:...:tag` reference
- Real bug found live on RDU (2026-08-03): this combination silently stuck the Deployment in `InvalidImageName` for 9 hours with no status-condition indication
- Adds a new `ImageConfigValid` status condition so the same misconfiguration surfaces immediately instead of failing silently

## Test plan
- [x] Unit tests added covering the guard in `openshellgateway_controller_test.go` and `config_test.go`
- [x] ansible-ai review pass — clean, no Critical/Major findings
- [x] Live-verified on a staging OpenShift cluster: reproduced the exact digest+imageTag conflict against a live CR, confirmed the Deployment image stays correctly digest-pinned with no tag appended, the pod pulls successfully (no `InvalidImageName`), and `ImageConfigValid` reports the ignored tag as designed