### PR TITLE
fix: make apt fail fast on a slow mirror during MicroShift install

### DIFF
--- a/.github/workflows/test-e2e-microshift-native.yml
+++ b/.github/workflows/test-e2e-microshift-native.yml
@@ -204,6 +204,24 @@ jobs:
           insecure = true
           EOF
 
+      - name: Configure apt to fail fast on a slow mirror
+        # azure.archive.ubuntu.com (the runner's preferred mirror) is
+        # sometimes slow to fail rather than erroring outright -- apt still
+        # falls through to archive.ubuntu.com and succeeds, but burns 2+
+        # minutes doing so every single `apt-get update` call install.sh
+        # makes internally. Across 3 consecutive real runs that alone was
+        # enough to blow every attempt's 300s budget before the actual
+        # install work got a chance to run. Force short per-request
+        # timeouts and no retries so a bad mirror gets skipped in seconds,
+        # not minutes -- applies to every apt-get call system-wide,
+        # including the ones install.sh makes internally.
+        run: |
+          cat <<'EOF' | sudo tee /etc/apt/apt.conf.d/99-ci-fast-fail
+          Acquire::Retries "0";
+          Acquire::http::Timeout "10";
+          Acquire::https::Timeout "10";
+          EOF
+
       - name: Install MicroShift (DEB, native — no nested containers)
         working-directory: microshift-io
         # install.sh's install_crio()/install_ctl_tools() call `curl -fsSL`


### PR DESCRIPTION
## Summary

PR #78's E2E job failed 3 consecutive times today, always the same way: `install.sh`'s internal `apt-get` calls stall on `azure.archive.ubuntu.com` (the runner's preferred mirror) for 2+ minutes before falling through to `archive.ubuntu.com` and succeeding — eating enough of each attempt's existing 300s budget that all 3 built-in retries still timed out. Checked GitHub's status page: no reported incident, so this isn't a tracked GitHub Actions outage — just this particular third-party mirror having a slow day, a known category of flake for Azure-hosted runners.

Checked upstream's `install.sh` directly to confirm scope: the MicroShift `.deb`s themselves are never fetched via apt — they're pre-downloaded directly from a GitHub release asset and installed via `dpkg -i`. But `install.sh` also installs its own prerequisites via real `apt-get` (`tzdata`, `curl`, `ufw`, etc. from standard mirrors, plus `cri-o`/`kubectl` from `pkgs.k8s.io`), and runs `apt-get install -f` afterward to resolve MicroShift's own dependencies — all of which legitimately need mirror access that can't be avoided without forking upstream's script.

## Fix

Forces short per-request timeouts and zero retries via `/etc/apt/apt.conf.d/99-ci-fast-fail`, applied system-wide right before `install.sh` runs, so a bad mirror gets skipped in ~10s instead of ~2 minutes — freeing the existing timeout budget for the actual install rather than mirror negotiation.

## Testing

`go build ./...` unaffected (workflow-only change). Will be validated live by PR #78's next E2E run once this merges and #78 rebases onto it.