### PR TITLE
test(smoke): make fixture JWT signing key readable by container uid

### DIFF
--- a/hack/smoke-test-config/main.go
+++ b/hack/smoke-test-config/main.go
@@ -105,7 +105,14 @@ func main() {
 		content []byte
 		perm    os.FileMode
 	}{
-		{"signing.pem", keys.SigningKey, 0o600}, // private key
+		// World-readable on purpose: this is an ephemeral throwaway key generated
+		// fresh each CI run, and the smoke test bind-mounts it into a gateway
+		// container running as an unprivileged non-root uid (--user 1000:1000) that
+		// does not own this file. Newer gateway versions read the sandbox JWT signing
+		// key eagerly at startup, so an owner-only 0o600 file yields "Permission
+		// denied", which the harness would misreport as a config-schema rejection.
+		// 0o644 lets the container uid read it regardless of owner.
+		{"signing.pem", keys.SigningKey, 0o644},
 		{"public.pem", keys.PublicKey, 0o644},
 		{"kid", []byte(keys.KID), 0o644},
 	}


### PR DESCRIPTION
## Summary

Harness-only fix so the upstream gateway smoke test can read the fixture JWT signing key. Unblocks the OpenShell pin bump (#83); does **not** bump the OpenShell version itself.

The `Gateway config compatibility` check fails on the 0.0.110 pin with:

`failed to read sandbox JWT signing key from /etc/openshell-jwt/signing.pem: Permission denied (os error 13)`

That is a **false positive**: the gateway parsed the config and reached `Starting OpenShell server`, then failed reading the key file. The harness wrote `signing.pem` as `0o600` (owner-only) but bind-mounts it into a gateway container running as `--user 1000:1000`, a uid that does not own the file. Newer gateway builds read that key eagerly at startup, so the perms now matter.

Production is unaffected (the key is mounted via a Kubernetes secret volume).

## Related Issue

Unblocks #83 (OpenShell 0.0.106 → 0.0.110 pin bump). Does not close it.

## Changes

- Write the ephemeral throwaway `signing.pem` as `0o644` instead of `0o600` in `hack/smoke-test-config/main.go`
- Document why world-readable is intentional for this CI fixture

## Testing

- [x] `go run ./hack/smoke-test-config /tmp/smoke` → `signing.pem` is `-rw-r--r--` / `0o644`
- [x] `go build ./... && go vet ./hack/... && make lint` (0 issues)
- [ ] `sudo -u nobody cat` not run locally (sudo required a password); mode bits confirm world-readable

## Checklist

- [x] Follows Conventional Commits
- [x] Commit is GPG-signed / Verified (`git log -1 --pretty='%G?'` → `G`)