### PR TITLE
ci(e2e): wait for dns-default pod to exist before kubectl wait

### DIFF
--- a/.github/workflows/test-e2e-microshift-native.yml
+++ b/.github/workflows/test-e2e-microshift-native.yml
@@ -352,11 +352,33 @@ jobs:
         #
         # "Wait for cluster ready" above only waits on node Ready, which
         # says nothing about whether the openshift-dns DaemonSet has
-        # actually scheduled/started its pod yet -- an earlier version of
-        # this workflow hit that race directly (dns-default sitting at
-        # ContainerCreating with zero Service endpoints), so wait on the
-        # DNS pod specifically before probing it.
+        # actually scheduled/started its pod yet. kubectl wait
+        # --for=condition=Ready fails immediately with "no matching
+        # resources found" if the selector matches nothing, so wait for
+        # the pod to be *created* before waiting for Ready. Observed
+        # 2026-09-10 on main (#88): node Ready, node-resolver Running,
+        # dns-default not created yet; wait bailed in ~100ms, then
+        # failure diagnostics showed dns-default at ContainerCreating
+        # AGE 0s.
         run: |
+          echo "Waiting for openshift-dns DaemonSet pod to be created..."
+          for i in $(seq 1 60); do
+            if kubectl get pod -n openshift-dns \
+                 -l dns.operator.openshift.io/daemonset-dns=default \
+                 --no-headers 2>/dev/null | grep -q .; then
+              break
+            fi
+            echo "dns-default pod not created yet ($i/60)"
+            sleep 2
+          done
+          if ! kubectl get pod -n openshift-dns \
+               -l dns.operator.openshift.io/daemonset-dns=default \
+               --no-headers 2>/dev/null | grep -q .; then
+            echo "ERROR: dns-default pod never appeared" >&2
+            kubectl get pods -n openshift-dns -o wide || true
+            exit 1
+          fi
+
           echo "Waiting for openshift-dns pod to be Ready..."
           kubectl wait --for=condition=Ready pod \
             -n openshift-dns -l dns.operator.openshift.io/daemonset-dns=default \


### PR DESCRIPTION
## Summary

Fix a false-fast failure in the native MicroShift E2E DNS smoke test on `main`.

[Failed run](https://github.com/aknochow/ogo/actions/runs/34430425536/job/102724602754) (push of #88):

```
Waiting for openshift-dns pod to be Ready...
error: no matching resources found
```

`kubectl wait --for=condition=Ready` does **not** wait for matching pods to appear. If the selector matches zero objects, it exits immediately. At that moment the node was Ready and `node-resolver` was Running, but `dns-default` had not been created yet. Failure diagnostics ~100ms later showed `dns-default` at `ContainerCreating` AGE 0s.

This is unrelated to the git-cliff bump that happened to land on `main`. Prior E2E runs on `main` were green.

## Changes

- Poll until a pod with `dns.operator.openshift.io/daemonset-dns=default` exists (up to 120s)
- Then `kubectl wait --for=condition=Ready` as before
- Fail with a pod dump if the DaemonSet never creates a pod

## Testing

- [x] Commit is GPG-signed / Verified
- [x] E2E will run on this PR (native MicroShift job)

## Checklist

- [x] Follows Conventional Commits
- [x] Commit is GPG-signed / Verified (`git log -1 --pretty='%G?'` → `G`)