### PR TITLE
fix(controller): reconcile database Secret changes

### DIFF
--- a/internal/controller/openshellgateway_controller.go
+++ b/internal/controller/openshellgateway_controller.go
@@ -828,7 +828,16 @@ func (r *OpenShellGatewayReconciler) reconcileDeployment(ctx context.Context, gw
 		if authBridgeEnabled(gw, isOCP) {
 			oidcIssuer = authBridgeInternalURL(gw)
 		}
-		configHash := computeConfigHash(gateway.RenderGatewayTOML(gw, sandboxNamespace(gw), oidcIssuer))
+		databaseSecretRevision, err := r.databaseSecretRevision(ctx, gw)
+		if err != nil {
+			return fmt.Errorf("get database secret revision: %w", err)
+		}
+		configHashInput := gateway.RenderGatewayTOML(gw, sandboxNamespace(gw), oidcIssuer)
+		// OPENSHELL_DB_URL is injected through a SecretKeyRef, so a Secret
+		// update or recreation would otherwise leave the running pod with a
+		// stale database URL until it is restarted manually.
+		configHashInput += "\ndatabase_secret_revision=" + databaseSecretRevision
+		configHash := computeConfigHash(configHashInput)
 
 		image := gw.Spec.Image
 		if image == "" {
@@ -1056,6 +1065,22 @@ func (r *OpenShellGatewayReconciler) reconcileDeployment(ctx context.Context, gw
 		return nil
 	})
 	return err
+}
+
+// databaseSecretRevision returns metadata only; the credential itself must
+// never be copied into the pod template or its annotations. ResourceVersion
+// changes on updates, and UID changes when a Secret is recreated.
+func (r *OpenShellGatewayReconciler) databaseSecretRevision(ctx context.Context, gw *ogov1alpha1.OpenShellGateway) (string, error) {
+	secretName := databaseSecretName(gw)
+	if secretName == "" {
+		return "", nil
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: gatewayNamespace(gw)}, secret); err != nil {
+		return "", err
+	}
+	return string(secret.UID) + "/" + secret.ResourceVersion, nil
 }
 
 // --- Service ---
@@ -1862,11 +1887,13 @@ func (r *OpenShellGatewayReconciler) dependencies() []DependencyReconciler {
 
 func (r *OpenShellGatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	labelMatcher := handler.EnqueueRequestsFromMapFunc(r.findGatewayForManagedResource)
+	databaseSecretMatcher := handler.EnqueueRequestsFromMapFunc(r.findGatewaysForDatabaseSecret)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&ogov1alpha1.OpenShellGateway{}).
 		Watches(&appsv1.Deployment{}, labelMatcher).
 		Watches(&corev1.Service{}, labelMatcher).
 		Watches(&corev1.ConfigMap{}, labelMatcher).
+		Watches(&corev1.Secret{}, databaseSecretMatcher).
 		Named("openshellgateway").
 		Complete(r)
 }
@@ -1881,6 +1908,25 @@ func (r *OpenShellGatewayReconciler) findGatewayForManagedResource(ctx context.C
 		return nil
 	}
 	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: name}}}
+}
+
+func (r *OpenShellGatewayReconciler) findGatewaysForDatabaseSecret(ctx context.Context, obj client.Object) []reconcile.Request {
+	gateways := &ogov1alpha1.OpenShellGatewayList{}
+	if err := r.List(ctx, gateways); err != nil {
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(gateways.Items))
+	for i := range gateways.Items {
+		gw := &gateways.Items[i]
+		if gatewayNamespace(gw) != obj.GetNamespace() || databaseSecretName(gw) != obj.GetName() {
+			continue
+		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: gw.Name},
+		})
+	}
+	return requests
 }
 
 // --- Helpers ---

--- a/internal/controller/openshellgateway_controller_test.go
+++ b/internal/controller/openshellgateway_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -31,7 +32,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ogov1alpha1 "github.com/aknochow/ogo/api/v1alpha1"
@@ -219,6 +223,56 @@ var _ = Describe("OpenShellGateway Controller", func() {
 		Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(1))
 		Expect(deploy.Spec.Template.Spec.Containers[0].Name).To(Equal("openshell-gateway"))
 		Expect(deploy.Spec.Template.Annotations).To(HaveKey("ogo.aknochow.io/config-hash"))
+	})
+
+	It("should roll the Deployment when the database Secret changes", func() {
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:                 scheme.Scheme,
+			Metrics:                metricsserver.Options{BindAddress: "0"},
+			HealthProbeBindAddress: "0",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		r := &OpenShellGatewayReconciler{
+			Client:          mgr.GetClient(),
+			Scheme:          mgr.GetScheme(),
+			DiscoveryClient: fake.NewSimpleClientset().Discovery(),
+		}
+		Expect(r.SetupWithManager(mgr)).To(Succeed())
+
+		managerCtx, cancelManager := context.WithCancel(ctx)
+		managerErr := make(chan error, 1)
+		go func() {
+			managerErr <- mgr.Start(managerCtx)
+		}()
+		DeferCleanup(func() {
+			cancelManager()
+			Eventually(managerErr, 10*time.Second).Should(Receive(BeNil()))
+		})
+
+		Eventually(func() bool {
+			return mgr.GetCache().WaitForCacheSync(managerCtx)
+		}, 10*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+		configHash := func() string {
+			deploy := &appsv1.Deployment{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: gwName, Namespace: "ogo-test"}, deploy); err != nil {
+				return ""
+			}
+			return deploy.Spec.Template.Annotations["ogo.aknochow.io/config-hash"]
+		}
+		Eventually(configHash, 30*time.Second, 250*time.Millisecond).ShouldNot(BeEmpty())
+		initialHash := configHash()
+
+		secret := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "test-pg-uri", Namespace: "ogo-test"}, secret)).To(Succeed())
+		secret.Data["uri"] = []byte("postgresql://rotated:rotated@localhost:5432/test")
+		Expect(k8sClient.Update(ctx, secret)).To(Succeed())
+
+		Eventually(func() bool {
+			updatedHash := configHash()
+			return updatedHash != "" && updatedHash != initialHash
+		}, 30*time.Second, 250*time.Millisecond).Should(BeTrue())
 	})
 
 	It("should not report Available while the Envoy Route isn't ready, even with pods Ready", func() {


### PR DESCRIPTION
## Summary

- Include the referenced database Secret UID/resource version in the gateway Deployment rollout hash without copying credential data.
- Watch referenced database Secrets and enqueue the owning gateway when they change.
- Add a manager-backed envtest regression covering the actual Secret event path.

## Test plan

- `make test` with Go 1.26 explicitly selected
- `make lint`
- Global pre-commit hook
- Full Ansible code review: 100/100, zero findings across functionality, security, and quality

## Notes

The change is limited to the gateway controller and its regression test.